### PR TITLE
Add inline citation chips for grounded answers

### DIFF
--- a/client/src/components/ChatBotComponent.jsx
+++ b/client/src/components/ChatBotComponent.jsx
@@ -238,9 +238,12 @@ const ChatBotComponent = ({ askUsStatus = { isOpen: false, hoursToday: null } })
               .filter((l) => l.length > 0)
               .slice(0, 5);
 
-            const lowConfidenceHint = /No strong matches found|Institutional knowledge service is temporarily unavailable|ask a clarifying question/i.test(
-              adjustedMessage,
-            );
+            // Structured confidence (v2) wins over text heuristic (legacy).
+            const lowConfidenceHint =
+              message.confidence === 'low' ||
+              /No strong matches found|Institutional knowledge service is temporarily unavailable|ask a clarifying question/i.test(
+                adjustedMessage,
+              );
             return (
               <div
                 key={index}
@@ -267,43 +270,66 @@ const ChatBotComponent = ({ askUsStatus = { isOpen: false, hoursToday: null } })
                   >
                     {typeof message.text === 'object' ? (
                       <div className="half-line-height">
-                        <MessageComponents msg={bodyText} />
+                        <MessageComponents msg={bodyText} citations={message.citations} />
                       </div>
                     ) : (
-                      <MessageComponents msg={bodyText} />
+                      <MessageComponents msg={bodyText} citations={message.citations} />
                     )}
                   </div>
                 </div>
-                {/* Render nicely formatted citations when available */}
-                {message.sender !== 'user' && references.length > 0 && (
-                  <div className="max-w-md mt-2 px-4 py-3 border border-gray-300 rounded-md bg-gray-50">
-                    <h4 className="text-xs font-semibold mb-2 text-gray-700">
-                      Sources
-                    </h4>
-                    <ul className="list-disc pl-4 space-y-1">
-                      {references.map((line, i) => {
-                        const urlMatch = line.match(/https?:\/\/\S+/);
-                        const url = urlMatch ? urlMatch[0] : undefined;
-                        return (
-                          <li key={i} className="text-gray-700">
-                            {url ? (
-                              <a
-                                href={url}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="text-blue-600 hover:underline"
-                              >
-                                {url}
-                              </a>
-                            ) : (
-                              <span>{line}</span>
-                            )}
-                          </li>
-                        );
-                      })}
-                    </ul>
-                  </div>
-                )}
+                {/* Sources footer.
+                    v2 path: render from message.citations (structured),
+                    matching the inline [n] chips above.
+                    Legacy path: parse the "References:" tail from message text. */}
+                {message.sender !== 'user' &&
+                  ((message.citations && message.citations.length > 0) ||
+                    references.length > 0) && (
+                    <div className="max-w-md mt-2 px-4 py-3 border border-gray-300 rounded-md bg-gray-50">
+                      <h4 className="text-xs font-semibold mb-2 text-gray-700">
+                        Sources
+                      </h4>
+                      <ul className="list-disc pl-4 space-y-1">
+                        {message.citations && message.citations.length > 0
+                          ? message.citations.map((c, i) => (
+                              <li key={i} className="text-gray-700 text-xs">
+                                <span className="font-semibold mr-1">[{c.n}]</span>
+                                {c.url ? (
+                                  <a
+                                    href={c.url}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-blue-600 hover:underline break-all"
+                                  >
+                                    {c.url}
+                                  </a>
+                                ) : (
+                                  <span>{c.snippet || ''}</span>
+                                )}
+                              </li>
+                            ))
+                          : references.map((line, i) => {
+                              const urlMatch = line.match(/https?:\/\/\S+/);
+                              const url = urlMatch ? urlMatch[0] : undefined;
+                              return (
+                                <li key={i} className="text-gray-700">
+                                  {url ? (
+                                    <a
+                                      href={url}
+                                      target="_blank"
+                                      rel="noopener noreferrer"
+                                      className="text-blue-600 hover:underline"
+                                    >
+                                      {url}
+                                    </a>
+                                  ) : (
+                                    <span>{line}</span>
+                                  )}
+                                </li>
+                              );
+                            })}
+                      </ul>
+                    </div>
+                  )}
                 {/* Render clarification choices if present */}
                 {message.sender !== 'user' && message.clarificationChoices && (
                   <ClarificationChoices

--- a/client/src/components/CitationChip.jsx
+++ b/client/src/components/CitationChip.jsx
@@ -1,0 +1,92 @@
+import { useState, useRef, useEffect } from 'react';
+import { ExternalLink } from 'lucide-react';
+
+/**
+ * Inline citation pill: renders `[n]` in answer text as a clickable chip
+ * that expands to show {snippet, source_url}. Click outside to dismiss.
+ *
+ * The synthesizer emits answers like "King opens at 7am [1] and closes at
+ * 2am [2]." with a parallel `citations: [{n, url, snippet}]` array. This
+ * component is what makes those numbers verifiable -- one click and the
+ * user sees the exact passage the bot was reading from. That's the
+ * trust-loop the rebuild plan is built around.
+ *
+ * Degrades cleanly: if `citation` is missing (number with no matching
+ * entry, e.g. backend bug or stale message), renders as plain text so
+ * we don't drop information silently.
+ */
+const CitationChip = ({ n, citation }) => {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef(null);
+
+  // Dismiss on outside click. Listening at document scope rather than
+  // a portal because the popover is positioned inline -- click within
+  // the chip's wrapper shouldn't close.
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e) => {
+      if (containerRef.current && !containerRef.current.contains(e.target)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  // Missing citation -- render the original `[n]` so info is preserved.
+  if (!citation) {
+    return <span className="text-gray-500">[{n}]</span>;
+  }
+
+  const { url, snippet } = citation;
+  // Snippet can be long; cap for display, full text shown via title attr.
+  const SNIPPET_DISPLAY_MAX = 280;
+  const displaySnippet =
+    snippet && snippet.length > SNIPPET_DISPLAY_MAX
+      ? snippet.slice(0, SNIPPET_DISPLAY_MAX).trimEnd() + '…'
+      : snippet || '';
+
+  return (
+    <span ref={containerRef} className="relative inline-block align-baseline">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        title={snippet ? `Source ${n}: ${snippet.slice(0, 200)}` : `Source ${n}`}
+        className={`inline-flex items-center justify-center align-baseline mx-0.5 px-1.5 h-5 min-w-[1.25rem] text-[11px] font-semibold leading-none rounded ${
+          open
+            ? 'bg-red-600 text-white'
+            : 'bg-red-100 text-red-700 hover:bg-red-200'
+        } cursor-pointer transition-colors`}
+        aria-expanded={open}
+        aria-label={`Source ${n}`}
+      >
+        {n}
+      </button>
+      {open && (
+        <span
+          role="tooltip"
+          className="absolute z-10 left-0 top-full mt-1 w-80 max-w-[90vw] block px-3 py-2 text-xs text-left text-gray-800 bg-white border border-gray-300 rounded-md shadow-lg"
+        >
+          {displaySnippet && (
+            <span className="block mb-2 whitespace-pre-wrap">
+              “{displaySnippet}”
+            </span>
+          )}
+          {url && (
+            <a
+              href={url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-blue-600 hover:underline break-all"
+            >
+              <ExternalLink size={12} className="shrink-0" />
+              <span>{url}</span>
+            </a>
+          )}
+        </span>
+      )}
+    </span>
+  );
+};
+
+export default CitationChip;

--- a/client/src/components/ParseLinks.jsx
+++ b/client/src/components/ParseLinks.jsx
@@ -1,32 +1,107 @@
+import { Children, Fragment } from 'react';
 import ReactMarkdown from 'react-markdown';
 import gfm from 'remark-gfm';
+import CitationChip from './CitationChip';
 import './ChatBotComponent.css';
 
 /**
- * This component is used to parse links in the chat messages
+ * This component is used to parse links in the chat messages.
+ *
+ * If `citations` is provided (an array of {n, url, snippet}), any `[n]`
+ * markers in the text are replaced with clickable CitationChip pills that
+ * expand to show the source snippet + URL. If no citations are provided,
+ * `[n]` markers render as plain text -- existing messages keep working
+ * unchanged.
  */
-const MessageComponents = ({ msg }) => {
+
+// Splits a string on [n] markers and returns an array of strings + chips.
+// Used inside markdown-rendered text nodes so the chips inherit the right
+// flow (paragraph, list item, etc.) instead of breaking layout.
+function injectChips(text, citationsByN, keyPrefix) {
+  if (typeof text !== 'string' || !citationsByN || citationsByN.size === 0) {
+    return text;
+  }
+  const re = /\[(\d+)\]/g;
+  const parts = [];
+  let last = 0;
+  let match;
+  let i = 0;
+  while ((match = re.exec(text)) !== null) {
+    if (match.index > last) {
+      parts.push(text.slice(last, match.index));
+    }
+    const n = Number(match[1]);
+    const citation = citationsByN.get(n);
+    parts.push(
+      <CitationChip key={`${keyPrefix}-c-${i++}-${n}`} n={n} citation={citation} />,
+    );
+    last = re.lastIndex;
+  }
+  if (last < text.length) {
+    parts.push(text.slice(last));
+  }
+  return parts.length > 0 ? parts : text;
+}
+
+// Recursively walks markdown-rendered children, injecting chips into any
+// string leaf. Wrapping element components (p, li, em, strong, code...) all
+// hand their children to this so chips work everywhere -- not just bare
+// paragraphs.
+function transformChildren(children, citationsByN, keyPrefix) {
+  return Children.map(children, (child, idx) => {
+    if (typeof child === 'string') {
+      const replaced = injectChips(child, citationsByN, `${keyPrefix}-${idx}`);
+      if (Array.isArray(replaced)) {
+        return <Fragment key={`${keyPrefix}-${idx}-frag`}>{replaced}</Fragment>;
+      }
+      return replaced;
+    }
+    return child;
+  });
+}
+
+const MessageComponents = ({ msg, citations }) => {
   // Clean up excessive whitespace for more compact display
   let message = msg
-    .replace(/\n\n\n+/g, '\n\n')  // Max 2 newlines
-    .replace(/^\s+|\s+$/g, '')     // Trim start/end whitespace
+    .replace(/\n\n\n+/g, '\n\n') // Max 2 newlines
+    .replace(/^\s+|\s+$/g, '') // Trim start/end whitespace
     .replace(/\n\s*\n\s*\n/g, '\n\n'); // Remove triple+ line breaks
-  
+
+  // Build a Map<n, citation> once per render so injectChips is O(1).
+  const citationsByN =
+    citations && citations.length > 0
+      ? new Map(citations.map((c) => [Number(c.n), c]))
+      : null;
+
+  // Wrap a markdown text-container component so its string children get
+  // chip-replacement. Used for every element that can contain prose.
+  const wrapText = (Tag) => {
+    return ({ node, children, ...props }) => (
+      <Tag {...props}>{transformChildren(children, citationsByN, Tag)}</Tag>
+    );
+  };
+
   return (
-    <span className='chat-message-container'>
+    <span className="chat-message-container">
       <ReactMarkdown
         remarkPlugins={[gfm]}
-        // Used to customize the rendering of links
-        // [noopener noreferrer] improves security when opening links in a new tab
         components={{
           a: ({ ...props }) => (
             <a
               {...props}
-              className='styled-link'
-              target='_blank'
-              rel='noopener noreferrer'
+              className="styled-link"
+              target="_blank"
+              rel="noopener noreferrer"
             />
           ),
+          p: wrapText('p'),
+          li: wrapText('li'),
+          strong: wrapText('strong'),
+          em: wrapText('em'),
+          h1: wrapText('h1'),
+          h2: wrapText('h2'),
+          h3: wrapText('h3'),
+          h4: wrapText('h4'),
         }}
       >
         {message}

--- a/client/src/context/MessageContextProvider.jsx
+++ b/client/src/context/MessageContextProvider.jsx
@@ -41,16 +41,34 @@ const MessageContextProvider = ({ children }) => {
     const messageText =
       typeof message === 'object' && message.response
         ? message.response.join('\n')
+        : typeof message === 'object' && typeof message.answer === 'string'
+        ? message.answer
         : message;
+
+    // Pull through the structured-output fields the synthesizer emits when
+    // the v2 stack is live: { answer, citations: [{n, url, snippet}], confidence }.
+    // Old/legacy responses won't have these -- they stay undefined and the
+    // renderer falls back to the existing flat behavior.
+    const citations =
+      message && typeof message === 'object' && Array.isArray(message.citations)
+        ? message.citations
+        : undefined;
+    const confidence =
+      message && typeof message === 'object' && typeof message.confidence === 'string'
+        ? message.confidence
+        : undefined;
+
     setMessage((prevMessages) => {
       const updatedMessages = [
         ...prevMessages,
-        { 
-          text: messageText, 
-          sender, 
+        {
+          text: messageText,
+          sender,
           messageId: id,
           responseTime: responseTime, // Time in seconds for bot responses
-          timestamp: Date.now()
+          timestamp: Date.now(),
+          citations,
+          confidence,
         },
       ];
       sessionStorage.setItem('chat_messages', JSON.stringify(updatedMessages));


### PR DESCRIPTION
## Summary
- Renders `[1]`, `[2]` markers in bot answers as small red **CitationChip** pills. Click expands an inline popover showing the source snippet + clickable URL; outside-click dismisses.
- Reads from the v2 synthesizer's structured output: `{ answer, citations: [{n, url, snippet}], confidence }`. Legacy responses without those fields render exactly as before — zero behavior change until the v2 backend ships.
- Sources footer now prefers structured `citations` when present (matching the inline chips), falling back to the existing "References:" tail-parsing for legacy responses.
- Low-confidence hint now respects `confidence: "low"` from structured output in addition to the existing text heuristics.

This is the trust loop the rebuild plan is built around: every claim has a chip, every chip opens to the exact passage that backs it.

## Files
- **`client/src/components/CitationChip.jsx`** (new) — pill + popover. Outside-click dismiss, missing-citation fallback (`[n]` as plain text — never drops info).
- **`client/src/components/ParseLinks.jsx`** — walks markdown-rendered text leaves (`p`, `li`, `em`, `strong`, `h1`–`h4`) and swaps `[n]` regex matches for chips. Injection happens inside the markdown component overrides so layout flow is preserved.
- **`client/src/context/MessageContextProvider.jsx`** — `addMessage` accepts `citations` + `confidence` from structured backend payloads; both default to `undefined` for legacy.
- **`client/src/components/ChatBotComponent.jsx`** — threads `message.citations` into `MessageComponents`; updates Sources footer to prefer structured citations; low-confidence check honors `message.confidence`.

## Backend contract (already in plan, not in this PR)
The synthesizer (Layer 4 of the rebuild plan) will emit:
```json
{
  "answer": "King opens at 7am [1] and closes at 2am [2].",
  "citations": [
    { "n": 1, "url": "https://lib.miamioh.edu/about/locations/king-library/", "snippet": "Hours: Mon-Fri 7am-2am..." },
    { "n": 2, "url": "https://lib.miamioh.edu/.../hours/", "snippet": "..." }
  ],
  "confidence": "high"
}
```
Backend wiring is out of scope for this PR — but the frontend is now ready to consume it the moment it lands.

## Test plan
- [x] `vite build` succeeds (verified locally — clean build, no new warnings).
- [ ] Legacy chat (no `citations` field): renders identically to today; `[n]` markers stay as plain text; "References:" footer still parses; low-confidence text heuristic still fires.
- [ ] Structured payload with citations: `[1]` `[2]` show as red pills; clicking opens popover with snippet + URL; outside-click dismisses; URL opens in new tab.
- [ ] Mixed: a `[3]` in text without a matching citation entry renders as gray `[3]` plain text (no broken chip).
- [ ] `confidence: "low"` triggers the low-confidence librarian-handoff alert.
- [ ] Sources footer with structured citations renders `[n]` prefix + URL list.
- [ ] Mobile: popover doesn't overflow viewport (capped at 90vw).

## Independent of #13 / #14
This PR doesn't touch the schema or the rollout flag — safe to merge any time. Frontend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)