### PR TITLE
Admin v0: Metabase queries + librarian spreadsheet templates

### DIFF
--- a/ai-core/admin/README.md
+++ b/ai-core/admin/README.md
@@ -1,0 +1,123 @@
+# Admin v0 — Metabase queries + shared spreadsheet
+
+The custom React admin surface (Op 1 in the rebuild plan) is post-launch
+work. This directory is the **interim** review surface librarians use
+until then: nine saved Metabase queries + two CSV templates.
+
+It's not pretty. It works. It ships in a day.
+
+## What's here
+
+```
+admin/
+├── README.md                         (this file)
+├── queries/                          paste these into Metabase as "saved questions"
+│   ├── 01_my_subject_queue.sql       a librarian's recent dialogs in their subject area
+│   ├── 02_my_campus_queue.sql        all recent dialogs scoped to a campus (regional default)
+│   ├── 03_low_confidence.sql         answers the bot self-flagged as uncertain
+│   ├── 04_thumbs_down.sql            user marked the answer down
+│   ├── 05_refusals_by_trigger.sql    why the bot refused (aggregate)
+│   ├── 06_cross_campus_leaks.sql     hard correctness gate -- expected to be empty
+│   ├── 07_per_source_correctness.sql which URLs are getting bad verdicts
+│   ├── 08_cost_and_cache.sql         daily cost + cache-hit per call site
+│   └── 09_active_corrections.sql     active ManualCorrection rows + fire counts
+└── templates/
+    ├── review_log_template.csv       librarians fill in verdicts here (until v1 UI)
+    └── correction_log_template.csv   librarians log requested corrections here
+```
+
+## One-time setup (web dev, ~30 min)
+
+1. **Stand up Metabase** (free tier covers small teams):
+   ```bash
+   docker run -d -p 3000:3000 --name metabase metabase/metabase
+   ```
+   Or use a hosted instance Miami IT already runs.
+2. **Connect Metabase to the chatbot Postgres**:
+   - Admin Settings → Databases → Add Database → PostgreSQL
+   - Host: `<chatbot DB host>`
+   - DB name: `smartchatbot_db`
+   - **Use a read-only DB user** (don't reuse the app's RW credentials).
+     Create one with:
+     ```sql
+     CREATE USER metabase_ro WITH PASSWORD '...';
+     GRANT CONNECT ON DATABASE smartchatbot_db TO metabase_ro;
+     GRANT USAGE ON SCHEMA public TO metabase_ro;
+     GRANT SELECT ON ALL TABLES IN SCHEMA public TO metabase_ro;
+     ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO metabase_ro;
+     ```
+3. **Import each `.sql` file as a saved question**:
+   - Metabase → New → SQL query → paste contents → save with the
+     filename as the title.
+   - For queries with `{{parameter}}` placeholders, Metabase prompts to
+     declare them as variables. The comment header on each query lists
+     what type to pick (text / dropdown / number / boolean).
+4. **Build a dashboard per role**:
+   - **Subject librarian**: 01 + 03 + 04 (their queue + uncertainty + thumbs-down).
+   - **Regional librarian**: 02 (filtered to their campus) + 04 + 05.
+   - **Program lead / web dev**: 05 + 06 + 07 + 08 + 09 (system health, pollution, cost, corrections).
+5. **Create the shared spreadsheet** (Google Sheets, OneDrive, whatever
+   the team already uses):
+   - One tab from `review_log_template.csv` — librarians paste verdicts.
+   - One tab from `correction_log_template.csv` — librarians request
+     ManualCorrection inserts that the web dev applies (until the v1 UI
+     wires this to a real form).
+   - Link to it from the Metabase dashboard description.
+
+## Daily / weekly use
+
+**Subject librarian (10 min, weekly):**
+1. Open the "My subject queue" dashboard. Skim the answers in your area.
+2. For each answer, click the citation URLs in `cited_urls` and
+   eyeball: does the answer match what's actually on that page?
+3. For wrong answers: paste the `message_id` into the review-log sheet,
+   pick a verdict, write a one-line note. If a fix is needed, also add
+   a row to the correction-log sheet.
+4. Forget it for the week.
+
+**Regional librarian (Hamilton, Middletown):**
+1. Open the "My campus queue" dashboard with campus filter set.
+2. Same flow. Pay extra attention to anything cited from `lib.miamioh.edu`
+   (Oxford content) — that's a cross-campus leak per query 06.
+
+**Program lead (15 min, weekly):**
+1. "Refusals by trigger" — is `low_confidence` or `no_results` climbing?
+   That's a corpus gap. File an ETL backlog item.
+2. "Cross-campus leaks" — must be **zero**. Anything here is a
+   post-processor escape; open a GitHub issue immediately.
+3. "Per-source correctness" — top of the list is your pollution
+   shortlist. Coordinate with the librarian who owns that subject area
+   to either correct or escalate to the web team.
+4. "Cost + cache" — every call site individually >= 0.5 cache-hit,
+   average >= 0.6. Sustained drop on one site = prefix drift; debug via
+   the byte-stability log in `prompts/builder.py`.
+
+## Migration to v1 React admin (post-launch)
+
+When the React admin ships:
+- The `LibrarianReview` table replaces the review-log spreadsheet. Same
+  column shape — migrate the spreadsheet rows in via:
+  ```sql
+  INSERT INTO "LibrarianReview" ("messageId", "librarianId", verdict, note, "reviewedAt")
+  SELECT message_id,
+         (SELECT id FROM "Librarian" WHERE lower(email) = lower(librarian_email)),
+         verdict, note, reviewed_at::timestamp
+  FROM <staging table loaded from the CSV export>;
+  ```
+- The `ManualCorrection` table replaces the correction-log spreadsheet.
+- The Metabase dashboards stay — they're useful complements to the
+  custom UI for ad-hoc investigation, especially the cost/cache and
+  cross-campus-leak gates.
+
+## Why this and not something fancier
+
+The plan explicitly calls for v0 to be Metabase + spreadsheet, not a
+custom UI. Reasons:
+- A librarian has to be in the loop from week 7. We don't have time to
+  build (and then UAT) a real admin app before that.
+- The data model needs to settle first. Building a UI against a
+  schema that's still moving creates throwaway code.
+- If Metabase can't answer a question, that's a signal the schema is
+  missing a field. Fix the schema before fixing the UI.
+- All review and correction *content* lives in Postgres tables already
+  — the admin UI is just chrome. The chrome can be deferred.

--- a/ai-core/admin/queries/01_my_subject_queue.sql
+++ b/ai-core/admin/queries/01_my_subject_queue.sql
@@ -1,0 +1,99 @@
+-- =============================================================================
+-- 01 — "My subject queue"
+--
+-- Recent bot conversations whose cited chunks came from a source URL that
+-- belongs to a subject this librarian liaises. Filtered to the last
+-- 7 days by default. Use this as the daily/weekly review entry point.
+--
+-- Parameter:
+--   {{librarian_email}}  Metabase text variable. The librarian enters
+--                        their @miamioh.edu address; we resolve to their
+--                        Librarian row + subject set in-query.
+--
+-- Output columns:
+--   message_id, timestamp, question, answer (truncated), confidence,
+--   was_refusal, refusal_trigger, scope_campus, scope_library,
+--   intent, model_used, cited_urls (array), thumbs_rating,
+--   subject_match (which of the librarian's subjects matched).
+--
+-- Sort: newest first.
+--
+-- See plan: Operations §Op 1 -- librarian-facing review surface.
+-- =============================================================================
+
+WITH liaison AS (
+    SELECT id, name, email, campus
+    FROM "Librarian"
+    WHERE lower(email) = lower({{librarian_email}})
+      AND "isActive" = true
+),
+liaison_subjects AS (
+    SELECT s.id AS subject_id, s.name AS subject_name
+    FROM "LibrarianSubject" ls
+    JOIN "Subject" s ON s.id = ls."subjectId"
+    WHERE ls."librarianId" IN (SELECT id FROM liaison)
+),
+-- Cited chunks per recent message, expanded to URLs + featured-service tags.
+recent_cited AS (
+    SELECT
+        m.id          AS message_id,
+        m.timestamp   AS msg_ts,
+        m."conversationId" AS conv_id,
+        m.content     AS answer,
+        m.intent,
+        m."scopeCampus"  AS scope_campus,
+        m."scopeLibrary" AS scope_library,
+        m.confidence,
+        m."wasRefusal"   AS was_refusal,
+        m."refusalTrigger" AS refusal_trigger,
+        m."modelUsed"    AS model_used,
+        m."isPositiveRated" AS thumbs_rating,
+        cp."sourceUrl"   AS source_url,
+        cp."featuredService" AS featured_service
+    FROM "Message" m
+    LEFT JOIN LATERAL unnest(m."citedChunkIds") AS chunk_id ON TRUE
+    LEFT JOIN "ChunkProvenance" cp ON cp."chunkId" = chunk_id
+    WHERE m.timestamp >= NOW() - INTERVAL '7 days'
+      AND m.type = 'chatbot'
+)
+SELECT
+    rc.message_id,
+    rc.msg_ts                  AS timestamp,
+    -- The user's question is the prior message in the conversation.
+    (SELECT content FROM "Message"
+        WHERE "conversationId" = rc.conv_id
+          AND timestamp < rc.msg_ts
+          AND type = 'user'
+        ORDER BY timestamp DESC
+        LIMIT 1)                AS question,
+    LEFT(rc.answer, 280)        AS answer_preview,
+    rc.confidence,
+    rc.was_refusal,
+    rc.refusal_trigger,
+    rc.scope_campus,
+    rc.scope_library,
+    rc.intent,
+    rc.model_used,
+    array_agg(DISTINCT rc.source_url) FILTER (WHERE rc.source_url IS NOT NULL) AS cited_urls,
+    rc.thumbs_rating,
+    -- Which of the librarian's subjects this message touched. Heuristic v0:
+    -- match the cited URL prefix to the LibGuide URLs owned by the subject.
+    -- Tighten to a real classifier output once the v2 stack ships.
+    array_agg(DISTINCT ls.subject_name) FILTER (WHERE ls.subject_name IS NOT NULL)
+                                AS matched_subjects
+FROM recent_cited rc
+LEFT JOIN "LibGuide" lg ON rc.source_url ILIKE lg.url || '%'
+LEFT JOIN "LibGuideSubject" lgs ON lgs."libGuideId" = lg.id
+LEFT JOIN liaison_subjects ls ON ls.subject_id = lgs."subjectId"
+GROUP BY
+    rc.message_id, rc.msg_ts, rc.conv_id, rc.answer,
+    rc.confidence, rc.was_refusal, rc.refusal_trigger,
+    rc.scope_campus, rc.scope_library, rc.intent,
+    rc.model_used, rc.thumbs_rating
+HAVING
+    -- Keep only rows that touched at least one of the librarian's subjects.
+    -- Comment this HAVING out to see ALL recent conversations (campus-wide
+    -- queue rather than subject-specific).
+    COUNT(DISTINCT ls.subject_id) > 0
+ORDER BY rc.msg_ts DESC
+LIMIT 200;

--- a/ai-core/admin/queries/02_my_campus_queue.sql
+++ b/ai-core/admin/queries/02_my_campus_queue.sql
@@ -1,0 +1,39 @@
+-- =============================================================================
+-- 02 — "My campus queue"
+--
+-- All recent conversations resolved to a particular campus, regardless of
+-- which librarian's subject they touched. Regional librarians (Hamilton,
+-- Middletown) live here -- they own everything from their campus.
+--
+-- Parameter:
+--   {{campus}}  Metabase dropdown: "oxford" | "hamilton" | "middletown"
+--   {{days}}    Metabase number, default 7
+--
+-- See plan: Operations §Op 1 -- regional-librarian default queue.
+-- =============================================================================
+
+SELECT
+    m.id                                AS message_id,
+    m.timestamp,
+    (SELECT content FROM "Message"
+        WHERE "conversationId" = m."conversationId"
+          AND timestamp < m.timestamp
+          AND type = 'user'
+        ORDER BY timestamp DESC LIMIT 1) AS question,
+    LEFT(m.content, 280)                AS answer_preview,
+    m.intent,
+    m."scopeCampus"                     AS scope_campus,
+    m."scopeLibrary"                    AS scope_library,
+    m."scopeSource"                     AS scope_source,
+    m.confidence,
+    m."wasRefusal"                      AS was_refusal,
+    m."refusalTrigger"                  AS refusal_trigger,
+    m."modelUsed"                       AS model_used,
+    m."isPositiveRated"                 AS thumbs_rating,
+    array_length(m."citedChunkIds", 1)  AS citation_count
+FROM "Message" m
+WHERE m.type = 'chatbot'
+  AND m."scopeCampus" = {{campus}}
+  AND m.timestamp >= NOW() - ({{days}} || ' days')::INTERVAL
+ORDER BY m.timestamp DESC
+LIMIT 500;

--- a/ai-core/admin/queries/03_low_confidence.sql
+++ b/ai-core/admin/queries/03_low_confidence.sql
@@ -1,0 +1,37 @@
+-- =============================================================================
+-- 03 — Low-confidence answers
+--
+-- Synthesizer self-reported `confidence = "low"`. These are the cases the
+-- bot was honest about being unsure -- ideal review fodder because either
+-- (a) the corpus is missing content -> add to ETL; (b) the retrieval
+-- ranking is wrong -> tune; (c) the question was genuinely answerable but
+-- the bot panicked -> reduce false-low rate.
+--
+-- Parameter:
+--   {{days}}  Metabase number, default 7
+--
+-- See plan: Citation contract §refusal triggers / measurement.
+-- =============================================================================
+
+SELECT
+    m.id                                AS message_id,
+    m.timestamp,
+    (SELECT content FROM "Message"
+        WHERE "conversationId" = m."conversationId"
+          AND timestamp < m.timestamp
+          AND type = 'user'
+        ORDER BY timestamp DESC LIMIT 1) AS question,
+    LEFT(m.content, 400)                AS answer_preview,
+    m.intent,
+    m."scopeCampus"                     AS scope_campus,
+    m."scopeLibrary"                    AS scope_library,
+    m."modelUsed"                       AS model_used,
+    array_length(m."citedChunkIds", 1)  AS citation_count,
+    m."isPositiveRated"                 AS thumbs_rating
+FROM "Message" m
+WHERE m.type = 'chatbot'
+  AND m.confidence = 'low'
+  AND m."wasRefusal" = false
+  AND m.timestamp >= NOW() - ({{days}} || ' days')::INTERVAL
+ORDER BY m.timestamp DESC
+LIMIT 200;

--- a/ai-core/admin/queries/04_thumbs_down.sql
+++ b/ai-core/admin/queries/04_thumbs_down.sql
@@ -1,0 +1,37 @@
+-- =============================================================================
+-- 04 — Thumbs-down answers
+--
+-- Real users telling us we got it wrong. Highest-signal review queue.
+-- Joined to ChunkProvenance so the librarian can see (and click) the
+-- exact sources the bot cited when the user marked the answer down.
+--
+-- Parameter:
+--   {{days}}  Metabase number, default 14
+--
+-- See plan: Operations §Op 1 -- "saved filter for user_rating=down".
+-- =============================================================================
+
+SELECT
+    m.id                                AS message_id,
+    m.timestamp,
+    (SELECT content FROM "Message"
+        WHERE "conversationId" = m."conversationId"
+          AND timestamp < m.timestamp
+          AND type = 'user'
+        ORDER BY timestamp DESC LIMIT 1) AS question,
+    LEFT(m.content, 400)                AS answer_preview,
+    m.intent,
+    m."scopeCampus"                     AS scope_campus,
+    m."scopeLibrary"                    AS scope_library,
+    m.confidence,
+    m."modelUsed"                       AS model_used,
+    -- Pull the source URLs the bot cited so the librarian can audit.
+    (SELECT array_agg(DISTINCT cp."sourceUrl")
+        FROM "ChunkProvenance" cp
+        WHERE cp."chunkId" = ANY (m."citedChunkIds"))  AS cited_urls
+FROM "Message" m
+WHERE m.type = 'chatbot'
+  AND m."isPositiveRated" = false
+  AND m.timestamp >= NOW() - ({{days}} || ' days')::INTERVAL
+ORDER BY m.timestamp DESC
+LIMIT 200;

--- a/ai-core/admin/queries/05_refusals_by_trigger.sql
+++ b/ai-core/admin/queries/05_refusals_by_trigger.sql
@@ -1,0 +1,28 @@
+-- =============================================================================
+-- 05 — Refusals broken down by trigger
+--
+-- Aggregate view of why the bot is refusing, by category. Healthy
+-- distribution: most refusals should be `out_of_scope` (catalog searches,
+-- general-knowledge questions) and `capability_limit` (account ops). High
+-- counts of `low_confidence` or `no_results` mean the corpus is missing
+-- something -- candidate ETL backlog.
+--
+-- Parameter:
+--   {{days}}  Metabase number, default 7
+--
+-- See plan: Citation contract §refusal triggers.
+-- =============================================================================
+
+SELECT
+    COALESCE(m."refusalTrigger", '(unknown)') AS refusal_trigger,
+    COUNT(*)                                  AS refusal_count,
+    COUNT(*) FILTER (WHERE m."isPositiveRated" = true)  AS thumbs_up_count,
+    COUNT(*) FILTER (WHERE m."isPositiveRated" = false) AS thumbs_down_count,
+    array_agg(DISTINCT m."scopeCampus")       AS campuses_seen,
+    array_agg(DISTINCT m.intent)              AS intents_seen
+FROM "Message" m
+WHERE m.type = 'chatbot'
+  AND m."wasRefusal" = true
+  AND m.timestamp >= NOW() - ({{days}} || ' days')::INTERVAL
+GROUP BY m."refusalTrigger"
+ORDER BY refusal_count DESC;

--- a/ai-core/admin/queries/06_cross_campus_leaks.sql
+++ b/ai-core/admin/queries/06_cross_campus_leaks.sql
@@ -1,0 +1,38 @@
+-- =============================================================================
+-- 06 — Cross-campus citation leaks (must be ZERO)
+--
+-- Hard correctness check: every cited chunk's campus must match the
+-- message's resolved scope.campus (or the chunk's campus is "all").
+-- Anything in this query result is a post-processor escape -- the
+-- synthesizer cited a chunk from the wrong campus and the cross-campus
+-- guard didn't catch it. This is the load-bearing failure mode that
+-- prevents King's hours being served as Hamilton's hours.
+--
+-- Expected output: zero rows. If non-empty, file an issue immediately
+-- and inspect ai-core/src/synthesis/post_processor.py.
+--
+-- See plan: Verification §6 -- "zero answers cite a chunk from the wrong
+-- campus" gate.
+-- =============================================================================
+
+SELECT
+    m.id                                   AS message_id,
+    m.timestamp,
+    m."scopeCampus"                        AS message_campus,
+    cp.campus                              AS chunk_campus,
+    cp."sourceUrl"                         AS chunk_source_url,
+    cp."chunkId"                           AS chunk_id,
+    LEFT(m.content, 200)                   AS answer_preview,
+    m."refusalTrigger"                     AS refusal_trigger,
+    m."isPositiveRated"                    AS thumbs_rating
+FROM "Message" m
+JOIN LATERAL unnest(m."citedChunkIds") AS chunk_id ON TRUE
+JOIN "ChunkProvenance" cp ON cp."chunkId" = chunk_id
+WHERE m.type = 'chatbot'
+  AND m."scopeCampus" IS NOT NULL
+  AND cp.campus IS NOT NULL
+  AND cp.campus <> 'all'
+  AND cp.campus <> m."scopeCampus"
+  AND m.timestamp >= NOW() - INTERVAL '30 days'
+ORDER BY m.timestamp DESC
+LIMIT 100;

--- a/ai-core/admin/queries/07_per_source_correctness.sql
+++ b/ai-core/admin/queries/07_per_source_correctness.sql
@@ -1,0 +1,48 @@
+-- =============================================================================
+-- 07 — Per-source URL correctness rate
+--
+-- For each source URL the bot cited recently, what fraction of those
+-- citations got a "wrong" or "should_refuse" librarian verdict? URLs at
+-- the top of this list are pollution suspects -- the page itself is
+-- wrong, stale, or being cited in the wrong context. Candidates for
+-- ManualCorrection (suppress / replace / blacklist).
+--
+-- Parameter:
+--   {{days}}  Metabase number, default 30
+--   {{min_uses}}  Metabase number, default 3 -- only score URLs cited
+--                 enough times for the rate to be meaningful.
+--
+-- See plan: Operations §Op 1 -- "per-source-URL %-correct sorted
+-- descending (the polluted sources rise to the top)".
+-- =============================================================================
+
+WITH cited AS (
+    SELECT
+        cp."sourceUrl" AS source_url,
+        m.id           AS message_id,
+        m.timestamp    AS msg_ts
+    FROM "Message" m
+    JOIN LATERAL unnest(m."citedChunkIds") AS chunk_id ON TRUE
+    JOIN "ChunkProvenance" cp ON cp."chunkId" = chunk_id
+    WHERE m.type = 'chatbot'
+      AND m.timestamp >= NOW() - ({{days}} || ' days')::INTERVAL
+)
+SELECT
+    c.source_url,
+    COUNT(DISTINCT c.message_id)                                          AS cite_count,
+    COUNT(DISTINCT lr.id)                                                 AS reviews,
+    COUNT(*) FILTER (WHERE lr.verdict = 'correct')                        AS verdict_correct,
+    COUNT(*) FILTER (WHERE lr.verdict = 'partial')                        AS verdict_partial,
+    COUNT(*) FILTER (WHERE lr.verdict = 'wrong')                          AS verdict_wrong,
+    COUNT(*) FILTER (WHERE lr.verdict = 'should_refuse')                  AS verdict_should_refuse,
+    ROUND(
+        100.0 * COUNT(*) FILTER (WHERE lr.verdict IN ('wrong','should_refuse'))
+              / NULLIF(COUNT(DISTINCT lr.id), 0),
+        1
+    ) AS pct_bad
+FROM cited c
+LEFT JOIN "LibrarianReview" lr ON lr."messageId" = c.message_id
+GROUP BY c.source_url
+HAVING COUNT(DISTINCT c.message_id) >= {{min_uses}}
+ORDER BY pct_bad DESC NULLS LAST, cite_count DESC
+LIMIT 100;

--- a/ai-core/admin/queries/08_cost_and_cache.sql
+++ b/ai-core/admin/queries/08_cost_and_cache.sql
@@ -1,0 +1,33 @@
+-- =============================================================================
+-- 08 — Daily cost + cache-hit ratio per call site
+--
+-- Reads from DailyCost (populated by ai-core/scripts/cost_rollup.py).
+-- Per-call-site breakdown so a cache regression on one site (e.g.
+-- synthesizer prefix drifted, dropping cache from 0.7 to 0.3) is
+-- visible immediately rather than buried in a global average.
+--
+-- Week-4 gate: every call site individually >= 0.5 cache-hit, average
+-- across all >= 0.6.
+--
+-- Parameter:
+--   {{days}}  Metabase number, default 30
+--
+-- See plan: Layer 4 -- prompt shrinkage and caching strategy / measurement.
+-- =============================================================================
+
+SELECT
+    date,
+    "callSite"            AS call_site,
+    model,
+    "callCount"           AS call_count,
+    "inputTokens"         AS input_tokens,
+    "cachedTokens"        AS cached_tokens,
+    "outputTokens"        AS output_tokens,
+    ROUND(
+        100.0 * "cachedTokens" / NULLIF("inputTokens", 0),
+        1
+    )                     AS cache_hit_pct,
+    ROUND(usd::numeric, 4) AS cost_usd
+FROM "DailyCost"
+WHERE date >= (NOW() - ({{days}} || ' days')::INTERVAL)::date
+ORDER BY date DESC, "callSite", model;

--- a/ai-core/admin/queries/09_active_corrections.sql
+++ b/ai-core/admin/queries/09_active_corrections.sql
@@ -1,0 +1,41 @@
+-- =============================================================================
+-- 09 — Active manual corrections + fire counts
+--
+-- Lists every active ManualCorrection (suppress / replace / pin /
+-- blacklist_url) with how often it has fired in retrieval. Many
+-- corrections concentrated on one source URL is the signal that the
+-- underlying page needs editorial work from the web team -- escalate,
+-- don't just keep correcting.
+--
+-- Sorted by fire_count desc -- most-impactful corrections at the top.
+--
+-- Parameter:
+--   {{include_expired}}  Metabase boolean, default false. Set true to
+--                        also see corrections that auto-expired (the
+--                        librarian was emailed at expiresAt and didn't
+--                        renew).
+--
+-- See plan: Operations §Op 2 -- correction workflow.
+-- =============================================================================
+
+SELECT
+    mc.id,
+    mc.scope,
+    mc.target,
+    mc.action,
+    LEFT(mc.replacement, 200) AS replacement_preview,
+    mc."queryPattern"          AS query_pattern,
+    LEFT(mc.reason, 200)       AS reason,
+    mc."createdBy"             AS created_by,
+    mc."createdAt"             AS created_at,
+    mc."expiresAt"             AS expires_at,
+    mc.active,
+    mc."fireCount"             AS fire_count,
+    -- How many days until auto-expiry (negative = already expired but
+    -- still active=true; chase the librarian).
+    EXTRACT(EPOCH FROM (mc."expiresAt" - NOW())) / 86400 AS days_to_expiry
+FROM "ManualCorrection" mc
+WHERE ({{include_expired}} = true)
+   OR (mc.active = true AND mc."expiresAt" > NOW())
+ORDER BY mc."fireCount" DESC, mc."createdAt" DESC
+LIMIT 200;

--- a/ai-core/admin/templates/correction_log_template.csv
+++ b/ai-core/admin/templates/correction_log_template.csv
@@ -1,0 +1,20 @@
+date,librarian_email,scope,target,action,replacement_or_pattern,reason,expires_at,applied_to_db
+,,,,,,,,
+# scope values:   url | chunk | intent | global
+# action values:  suppress | replace | pin | blacklist_url
+#
+# scope x action combinations (per plan §Op 2):
+#   - chunk + suppress       : retrieval excludes the chunk_id
+#   - url   + blacklist_url  : ETL stops re-adding; URL validator rejects
+#   - chunk + replace        : keep chunk position, swap text
+#   - url   + pin            : promote to rank 1 for matching query_pattern
+#
+# expires_at: default 6 months from `date`. Auto-renewal email goes out;
+# stale corrections that no one renews fall off automatically.
+#
+# applied_to_db column:
+#   - blank  -- still pending
+#   - INSERT -- pasted into ManualCorrection table
+#
+# When the v1 React admin lands, librarians submit corrections via UI and
+# this CSV becomes a backup/audit trail rather than the system of record.

--- a/ai-core/admin/templates/review_log_template.csv
+++ b/ai-core/admin/templates/review_log_template.csv
@@ -1,0 +1,16 @@
+message_id,reviewed_at,librarian_email,verdict,note,follow_up_action,followed_up
+,,,,,,
+# Verdict values: correct | partial | wrong | should_refuse
+# Follow-up actions:
+#   - none                       (verdict was correct/partial-acceptable)
+#   - corrected_url              (filed a ManualCorrection, see correction_log_template.csv)
+#   - escalated_to_web_team      (page itself is wrong; needs site edit)
+#   - flagged_to_program_lead    (pattern issue; needs discussion)
+#   - opened_github_issue        (bot bug; link the issue # in `note`)
+#
+# Workflow:
+#   1. Run query 01_my_subject_queue.sql (or 02/03/04) in Metabase.
+#   2. For each row that needs review, paste its message_id here and fill in.
+#   3. When the v1 admin React UI ships, this file is replaced by the
+#      LibrarianReview table -- but the column shape is the same, so the
+#      sheet's history can be migrated by an INSERT...SELECT script.


### PR DESCRIPTION
## Summary
Per plan §Op 1, the minimum viable review surface for week 7 UAT is **Metabase saved queries + a shared spreadsheet** — not a custom React admin (that ships post-launch). This PR delivers exactly that.

## What ships
**Nine saved SQL queries** in `ai-core/admin/queries/`:
| # | Query | Audience |
|---|---|---|
| 01 | `my_subject_queue.sql` | Subject librarian's daily queue |
| 02 | `my_campus_queue.sql` | Regional librarian's default queue |
| 03 | `low_confidence.sql` | Bot self-flagged uncertain answers |
| 04 | `thumbs_down.sql` | User-rejected answers (highest signal) |
| 05 | `refusals_by_trigger.sql` | Why the bot refused (aggregate) |
| 06 | `cross_campus_leaks.sql` | Hard correctness gate — must be **zero** |
| 07 | `per_source_correctness.sql` | Pollution shortlist by source URL |
| 08 | `cost_and_cache.sql` | Daily cost + cache-hit per call site |
| 09 | `active_corrections.sql` | Active `ManualCorrection` rows + fire counts |

**Two CSV templates** in `ai-core/admin/templates/`:
- `review_log_template.csv` — librarians paste `message_id` + verdict + note
- `correction_log_template.csv` — librarians log requested ManualCorrections

**README** covers: Metabase docker setup, read-only DB user creation, query import, role-specific dashboards, daily/weekly librarian flow, and the migration path to the v1 React admin.

## Why Metabase + spreadsheet, not a custom UI
Quoted from the README:
- A librarian has to be in the loop from week 7 — no time to build (and UAT) a custom admin first.
- The data model is still moving — UI built against a moving schema is throwaway.
- All review/correction *content* lives in Postgres tables already; the admin UI is just chrome, and chrome can be deferred.

## Verification
All 9 queries syntax-validated against the migrated `chatbot_dev` schema:
```
=== 01_my_subject_queue.sql ===   ✓ (0 rows, no real traffic yet)
=== 02_my_campus_queue.sql ===     ✓
=== 03_low_confidence.sql ===      ✓
=== 04_thumbs_down.sql ===         ✓
=== 05_refusals_by_trigger.sql === ✓
=== 06_cross_campus_leaks.sql ===  ✓
=== 07_per_source_correctness ===  ✓
=== 08_cost_and_cache.sql ===      ✓
=== 09_active_corrections.sql ===  ✓
```

## Dependencies
The queries reference tables introduced by **PR #13** (`Message.intent`, `Message.scopeCampus`, `Message.citedChunkIds`, `LibrarianReview`, `ManualCorrection`, `ChunkProvenance`, `DailyCost`, etc.). They will return zero rows until #13 lands and traffic starts flowing through the v2 stack — that's expected and not a blocker for merging this PR. The query files are configuration-as-code; they don't run against prod until a librarian opens Metabase.

## Test plan
- [x] All 9 SQL files parse and execute cleanly against migrated schema.
- [ ] Metabase instance stood up and queries imported as saved questions.
- [ ] Read-only DB user created per README instructions.
- [ ] Three role-specific dashboards built (subject / regional / program-lead).
- [ ] Shared spreadsheet created from CSV templates and linked from dashboard.
- [ ] One librarian walks through their daily flow end-to-end and reports back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)