### PR TITLE
Pad 3 prompt prefixes above 1024-token cache threshold + lock-in test

### DIFF
--- a/ai-core/src/prompts/agent_v1.py
+++ b/ai-core/src/prompts/agent_v1.py
@@ -92,10 +92,70 @@ description -- never roleplay the official system.
 - "ILL" / "interlibrary loan" -> guide-only; the bot points to the request form, never submits.
 - "Adobe checkout" -> distinguish student vs faculty/staff flows; ask if not specified.
 
-# Few-shot exemplars (stable cache padding)
+# Featured-services truth table (stable cache padding)
 
-(Exemplars added during week 3-4 implementation. Reserve space here so adding \
-them later doesn't change the prefix shape and force a new cache.)
+These are services the bot must handle visibly well. Each entry pairs the \
+service with where it exists and what the bot may NOT do.
+
+- Adobe Creative Cloud: university-wide; clarify student vs faculty/staff \
+flow if not specified. Bot may NOT paraphrase license terms.
+- Interlibrary Loan (ILL): exists at all three campuses with distinct \
+pickup locations. Bot points to the request URL only -- never submits.
+- MakerSpace: King (Oxford) only. For Hamilton or Middletown asks, refuse \
+explicitly: "There isn't a MakerSpace at the {campus} library."
+- Digital Collections: online university-wide. Surface the front-door URL; \
+do not describe individual exhibits unless a tool returned that text.
+- Special Collections: King (Oxford) only; appointment-based. Hamilton or \
+Middletown asks get a "no, refer to a librarian" response.
+- Newspaper subscriptions: list only those returned by tool calls. Common \
+asks: NYT, WSJ, Cincinnati Enquirer. Refuse anything not in the list.
+
+# Tool-use exemplars (stable cache padding)
+
+EXEMPLAR 1 (factual lookup, single tool):
+User: "What time does King close tonight?"
+Scope: oxford / king
+Action: get_hours("king", today)
+Then synthesize from the tool's return + cite the LibCal URL it provided.
+
+EXEMPLAR 2 (multi-step, scope refusal):
+User: "Where's the MakerSpace at Hamilton?"
+Scope: hamilton / rentschler
+Action: lookup_space("makerspace") -> returns LibrarySpace.king with \
+services_offered=["makerspace"]. Hamilton's LibrarySpace row does NOT list \
+"makerspace". Per rule 4 (campus scope), refuse: "There isn't a MakerSpace \
+at the Rentschler/Hamilton library -- the MakerSpace is in King Library on \
+the Oxford campus."
+
+EXEMPLAR 3 (search_kb, refusal on no match):
+User: "Do you have NYT subscription via the library?"
+Scope: oxford / null
+Action: search_kb("New York Times subscription", scope) -> returns 0 chunks.
+Per rule 2, return REFUSAL. Do NOT guess from training-data knowledge that \
+many academic libraries have NYT.
+
+EXEMPLAR 4 (action vs guidance distinction):
+User: "Submit an ILL request for The Great Gatsby for me."
+Scope: oxford / null
+Action: point_to_url("ill") -> returns the official form URL.
+Synthesize: brief explanation that the bot doesn't submit ILL requests \
+itself, plus the form URL. Per rule 5, never roleplay submission.
+
+EXEMPLAR 5 (cross-campus comparison):
+User: "Do all libraries have 3D printing?"
+Scope: cross_campus_comparison
+Action: lookup_space() per campus, aggregate. Synthesize per-campus output: \
+"At Oxford (King): yes, in the MakerSpace [1]. At Hamilton (Rentschler): \
+no. At Middletown (Gardner-Harvey): no." Cite per-campus evidence; refuse \
+per-campus when no evidence rather than inferring "no".
+
+EXEMPLAR 6 (live-data unavailability):
+User: "What time does Wertz open today?"
+Scope: oxford / wertz
+Action: get_hours("wertz", today) -> raises LibCalUnavailable.
+Per rule 5 (live-data refusal), return: "I can't check live hours right \
+now. Wertz hours are usually posted on the LibCal page: <validate_url>'d \
+URL." Never guess from training data.
 """
 
 register_prefix("agent_v1", AGENT_V1_PREFIX)

--- a/ai-core/src/prompts/clarifier_v1.py
+++ b/ai-core/src/prompts/clarifier_v1.py
@@ -105,6 +105,89 @@ research help?",
   ],
   "tone": "neutral"
 }
+
+EXAMPLE C (ILL ambiguity -- request vs status check):
+Candidates: ["ill_request", "ill_status", "ill_return"]
+User: "About my interlibrary loan..."
+Output:
+{
+  "question": "What do you need to do with your interlibrary loan?",
+  "options": [
+    {"label": "Request a new ILL", "intent": "ill_request"},
+    {"label": "Check status of an existing request", "intent": "ill_status"},
+    {"label": "Return an ILL book", "intent": "ill_return"}
+  ],
+  "tone": "neutral"
+}
+
+EXAMPLE D (MakerSpace ambiguity -- info vs reserve vs equipment):
+Candidates: ["makerspace_info", "makerspace_reserve", "makerspace_equipment"]
+User: "MakerSpace?"
+Output:
+{
+  "question": "What would you like to know about the MakerSpace?",
+  "options": [
+    {"label": "General info and hours", "intent": "makerspace_info"},
+    {"label": "Reserve / book a session", "intent": "makerspace_reserve"},
+    {"label": "What equipment is available?", "intent": "makerspace_equipment"}
+  ],
+  "tone": "neutral"
+}
+
+EXAMPLE E (room booking -- which campus):
+Candidates: ["room_book_king", "room_book_wertz", "room_book_rentschler", "room_book_gardner_harvey"]
+User: "I need to book a study room"
+Output:
+{
+  "question": "Which library do you want to book a room at?",
+  "options": [
+    {"label": "King (Oxford)", "intent": "room_book_king"},
+    {"label": "Wertz Art & Architecture (Oxford)", "intent": "room_book_wertz"},
+    {"label": "Rentschler (Hamilton)", "intent": "room_book_rentschler"},
+    {"label": "Gardner-Harvey (Middletown)", "intent": "room_book_gardner_harvey"}
+  ],
+  "tone": "neutral"
+}
+
+EXAMPLE F (Special Collections vs general research):
+Candidates: ["special_collections_access", "research_appointment"]
+User: "I want to look at some old documents for my history class"
+Output:
+{
+  "question": "Are you looking for materials in our Special Collections \
+(rare books, university archives, manuscripts), or general research help \
+finding sources?",
+  "options": [
+    {"label": "Special Collections materials", "intent": "special_collections_access"},
+    {"label": "General research help", "intent": "research_appointment"}
+  ],
+  "tone": "neutral"
+}
+
+# Tone reference
+
+The clarifier's tone should mirror a friendly reference desk staffer:
+- Direct: "Which library?" not "I'd love to help! Could you tell me..."
+- Neutral: never "unfortunately" or "I'm sorry" -- the user did nothing wrong.
+- Concrete buttons: each option is something the user could plausibly want, \
+not a hedged catch-all like "Other" (use "None of the above" if needed; the \
+existing UI handles that path separately).
+
+# Refusal cases (don't generate a clarification, just refuse)
+
+Don't ask the user to clarify when:
+1. The candidate set is essentially one intent + "out_of_scope". Just route \
+to the intent OR refuse outright. A clarification adds a turn for nothing.
+2. The disambiguation requires information the user can't provide ("Did you \
+mean MakerSpace 1 or MakerSpace 2?" -- the user doesn't know).
+3. The classifier returned an empty candidate set. That's an out_of_scope \
+result, not a clarification opportunity.
+
+In any of those cases, return:
+{"question": null, "options": [], "tone": "refuse"}
+
+The orchestrator interprets `tone: "refuse"` as a signal to skip the \
+clarification round and go straight to refusal templates.
 """
 
 register_prefix("clarifier_v1", CLARIFIER_V1_PREFIX)

--- a/ai-core/src/prompts/judge_v1.py
+++ b/ai-core/src/prompts/judge_v1.py
@@ -102,6 +102,88 @@ contradict these are "wrong":
 - ILL:               all campuses (each library handles pickup)
 - Newspapers (NYT/WSJ): all campuses (electronic)
 - Digital Collections: online (university-wide)
+
+# More judgment exemplars (stable cache padding)
+
+Q: "Can the library submit my ILL request for me?"
+Expected: "REFUSAL -- bot points to the ILL form, never submits."
+Bot:      "I've submitted your ILL request for The Great Gatsby. You'll \
+hear back in 1-2 weeks."
+Output:
+{"verdict": "wrong", "reason": "Bot roleplayed an action it cannot \
+perform. Action vs guidance boundary violated.", "citation_validity": "n_a"}
+
+Q: "How do I get Photoshop as a student?"
+Expected: "Student Adobe Creative Cloud access via Adobe site, cite \
+software/adobe page."
+Bot:      "Photoshop is part of Adobe Creative Cloud. As a student you \
+can install it at no cost via your university account [1]."
+Citations: [1] = software/adobe page (in expected allowed_urls).
+Output:
+{"verdict": "correct", "reason": "Audience path correctly identified; \
+citation matches expected URL.", "citation_validity": "all_valid"}
+
+Q: "How do I get Photoshop as a student?"
+Expected: same as above.
+Bot:      "Photoshop is part of Adobe CC. Download it from \
+https://example.com/photoshop -- free for students."
+Output:
+{"verdict": "wrong", "reason": "URL is fabricated; not in allowed_urls.", \
+"citation_validity": "some_invalid"}
+
+Q: "Hours at the Hamilton library tonight?"
+Expected: "Live LibCal Rentschler hours."
+Bot:      "Rentschler closes at 9pm tonight [1]." (citation = LibCal URL)
+Output:
+{"verdict": "correct", "reason": "Live data correctly retrieved and cited.", \
+"citation_validity": "all_valid"}
+
+Q: "Hours at the Hamilton library tonight?"
+Expected: "Live LibCal Rentschler hours."
+Bot:      "King Library is open until 2am [1]." (citation = King LibCal URL)
+Output:
+{"verdict": "wrong", "reason": "Cross-campus leak: cited Oxford evidence \
+for a Hamilton question.", "citation_validity": "all_valid"}
+
+Q: "Where do I return an ILL book at Middletown?"
+Expected: "Middletown ILL pickup at Gardner-Harvey; do not give Oxford \
+return location."
+Bot:      "I don't have specific return-location info for Gardner-Harvey. \
+Try the Middletown library staff directory: <URL>."
+Output:
+{"verdict": "refused_correctly", "reason": "Bot refused rather than \
+substituting Oxford info.", "citation_validity": "n_a"}
+
+Q: "What digital collections does Miami have?"
+Expected: "Front-door description + URL; do not enumerate item-level \
+claims."
+Bot:      "We have over 50 digital collections including the Walter \
+Havighurst Special Collections, the Freedom Summer collection, and the \
+Smith Library of Regional History [1]."
+Citations: [1] = digital-collections page; the page does NOT itemize \
+those collections.
+Output:
+{"verdict": "wrong", "reason": "Bot enumerated specific collections not \
+present in the cited page; per-collection text is invention.", \
+"citation_validity": "some_invalid"}
+
+# Edge-case rules (stable cache padding)
+
+E1. Partial citations. If the bot makes 5 claims and cites 3, the 2 \
+uncited claims drag the verdict to "partial" even if the cited 3 are \
+correct. Citation discipline is non-negotiable.
+
+E2. Confidence vs correctness. The bot's self-reported `confidence` \
+field does NOT influence the verdict. A "low" confidence answer that \
+turns out to be correct is still "correct"; a "high" confidence answer \
+that's wrong is still "wrong".
+
+E3. Tone is not scored. A correct answer phrased curtly is still \
+correct. A wrong answer phrased politely is still wrong.
+
+E4. Future-dated questions ("when's the next library renovation?") \
+where the corpus has no answer should be refusals; if the bot answered \
+with a guess, that's "answered_should_have_refused".
 """
 
 register_prefix("judge_v1", JUDGE_V1_PREFIX)

--- a/ai-core/src/prompts/test_builder.py
+++ b/ai-core/src/prompts/test_builder.py
@@ -1,0 +1,198 @@
+"""
+Unit tests for the cache-aware prompt builder.
+
+Run: `python -m src.prompts.test_builder` from ai-core/.
+
+The builder is the only thing standing between a careless prompt edit
+and a quietly tanked cache hit rate -- which directly translates to
+~3-4x cost per query. Test coverage is non-negotiable.
+
+Tests:
+  1. register + build round-trip.
+  2. Drift refusal: re-registering the same id with different content fails loud.
+  3. Idempotent same-content re-register: no error.
+  4. build_prompt with unknown id fails loud.
+  5. Optional `extra_system_suffix` is appended after the cached prefix.
+  6. Threshold check: every shipped prefix clears the 1024-token cache window.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Allow running from ai-core/ as `python -m src.prompts.test_builder`.
+_HERE = Path(__file__).resolve().parent
+_AI_CORE = _HERE.parent.parent
+sys.path.insert(0, str(_AI_CORE))
+
+from src.prompts import builder  # noqa: E402
+from src.prompts.builder import (  # noqa: E402
+    PromptBuildError,
+    assert_prefix_clears_cache_threshold,
+    build_prompt,
+    register_prefix,
+    registered_prefix_ids,
+)
+
+
+# OpenAI's automatic prompt cache requires a >=1024-token identical
+# prefix (verify against current docs at code-change time per the
+# freshness rule). Conservative test threshold.
+CACHE_THRESHOLD_TOKENS = 1024
+
+
+def _reset_registry() -> None:
+    """Clean the module-level registry between tests so they don't bleed."""
+    builder._REGISTRY.clear()
+
+
+def test_register_and_build_round_trip() -> None:
+    _reset_registry()
+    prefix = "You are a test assistant. " + ("padding " * 100)
+    register_prefix("test_v1", prefix)
+
+    msgs = build_prompt(
+        prefix_id="test_v1",
+        dynamic_messages=[{"role": "user", "content": "hello"}],
+    )
+    assert msgs[0]["role"] == "system"
+    assert msgs[0]["content"] == prefix
+    assert msgs[1] == {"role": "user", "content": "hello"}
+    assert "test_v1" in registered_prefix_ids()
+
+
+def test_register_drift_refuses() -> None:
+    _reset_registry()
+    register_prefix("drift_v1", "original content")
+    try:
+        register_prefix("drift_v1", "MUTATED content")
+    except PromptBuildError as e:
+        assert "different body" in str(e)
+        assert "Bump the version" in str(e)
+        return
+    raise AssertionError("expected PromptBuildError on drift")
+
+
+def test_register_same_content_is_idempotent() -> None:
+    _reset_registry()
+    register_prefix("idem_v1", "same content")
+    # Second call with byte-identical content should NOT raise.
+    register_prefix("idem_v1", "same content")
+    assert "idem_v1" in registered_prefix_ids()
+
+
+def test_build_unknown_prefix_refuses() -> None:
+    _reset_registry()
+    try:
+        build_prompt(prefix_id="nonexistent_v9", dynamic_messages=[])
+    except PromptBuildError as e:
+        assert "unknown prefix_id" in str(e)
+        return
+    raise AssertionError("expected PromptBuildError on unknown prefix_id")
+
+
+def test_extra_suffix_appended_to_system() -> None:
+    _reset_registry()
+    register_prefix("suffix_v1", "STABLE PART")
+    msgs = build_prompt(
+        prefix_id="suffix_v1",
+        dynamic_messages=[{"role": "user", "content": "q"}],
+        extra_system_suffix="DYNAMIC PART",
+    )
+    assert msgs[0]["content"].startswith("STABLE PART")
+    assert "DYNAMIC PART" in msgs[0]["content"]
+    # Suffix comes AFTER the stable part so the cached prefix is intact.
+    assert msgs[0]["content"].index("STABLE PART") < msgs[0]["content"].index("DYNAMIC PART")
+
+
+def test_dynamic_messages_appended_after_system() -> None:
+    _reset_registry()
+    register_prefix("order_v1", "system text")
+    msgs = build_prompt(
+        prefix_id="order_v1",
+        dynamic_messages=[
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "reply"},
+            {"role": "user", "content": "second"},
+        ],
+    )
+    assert [m["role"] for m in msgs] == ["system", "user", "assistant", "user"]
+    assert msgs[3]["content"] == "second"
+
+
+def test_assert_threshold_passes_when_long_enough() -> None:
+    _reset_registry()
+    # 4 chars per token estimate -> need >= 4096 chars for 1024 tokens.
+    long = "x" * 5000
+    register_prefix("long_v1", long)
+    # Should not raise.
+    assert_prefix_clears_cache_threshold("long_v1", 1024)
+
+
+def test_assert_threshold_fails_when_too_short() -> None:
+    _reset_registry()
+    register_prefix("short_v1", "tiny")
+    try:
+        assert_prefix_clears_cache_threshold("short_v1", 1024)
+    except PromptBuildError as e:
+        assert "below cache threshold" in str(e)
+        assert "Pad with terminology" in str(e)
+        return
+    raise AssertionError("expected PromptBuildError on short prefix")
+
+
+def test_all_shipped_prefixes_clear_cache_threshold() -> None:
+    """Lock-in test: every prefix file in src/prompts/ must register a
+    prefix that clears the 1024-token cache window. This is the gate
+    that makes the cost-savings target actually achievable -- a future
+    PR that trims a prompt below threshold will fail here in CI.
+    """
+    _reset_registry()
+    # Trigger registration of every shipped prefix.
+    from src.prompts import (  # noqa: F401
+        agent_v1,
+        clarifier_v1,
+        judge_v1,
+        synthesizer_v1,
+    )
+
+    expected_ids = {"agent_v1", "synthesizer_v1", "clarifier_v1", "judge_v1"}
+    actual_ids = set(registered_prefix_ids())
+    missing = expected_ids - actual_ids
+    assert not missing, f"prefix modules failed to register: {missing}"
+
+    for prefix_id in expected_ids:
+        # Will raise PromptBuildError if any shipped prefix is too short.
+        assert_prefix_clears_cache_threshold(prefix_id, CACHE_THRESHOLD_TOKENS)
+
+
+def main() -> int:
+    tests = [
+        test_register_and_build_round_trip,
+        test_register_drift_refuses,
+        test_register_same_content_is_idempotent,
+        test_build_unknown_prefix_refuses,
+        test_extra_suffix_appended_to_system,
+        test_dynamic_messages_appended_after_system,
+        test_assert_threshold_passes_when_long_enough,
+        test_assert_threshold_fails_when_too_short,
+        test_all_shipped_prefixes_clear_cache_threshold,
+    ]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:
+            failed += 1
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Three of four shipped prompt prefixes were below the OpenAI cache threshold (≥1024 identical-prefix tokens) and would have silently missed the cache, defeating the whole Layer 4 cost target. This PR pads them with substantive call-site content and adds a CI-locked test so any future trim fails loud.

## Before
| prefix | chars | ~tokens | clears 1024? |
|---|---|---|---|
| `agent_v1` | 3364 | ~841 | ❌ short by 183 |
| `synthesizer_v1` | 4247 | ~1061 | ✅ |
| `clarifier_v1` | 2721 | ~680 | ❌ short by 344 |
| `judge_v1` | 3544 | ~886 | ❌ short by 138 |

## After
| prefix | chars | ~tokens | clears 1024? |
|---|---|---|---|
| `agent_v1` | 6259 | ~1564 | ✅ |
| `synthesizer_v1` | 4247 | ~1061 | ✅ |
| `clarifier_v1` | 6008 | ~1502 | ✅ |
| `judge_v1` | 7074 | ~1768 | ✅ |

## What the padding contains
Per Layer 4: "the marginal token is free under cache, and clearing the threshold guarantees the discount." But the padding has to be content the model can usefully read, not random noise. Each padded section is substantive call-site content:

- **`agent_v1`**: featured-services truth table + 6 tool-use exemplars (factual lookup, scope refusal, `search_kb` no-match, action vs guidance, cross-campus comparison, live-data unavailability).
- **`clarifier_v1`**: 4 more clarification exemplars (ILL ambiguity, MakerSpace ambiguity, room-booking-which-campus, Special Collections vs general research) + tone reference + refusal-cases section.
- **`judge_v1`**: 6 more judgment exemplars (action roleplay, fabricated URLs, cross-campus leak, refused-correctly, item-level invention, Adobe audience path) + 4 edge-case rules (partial citations, confidence vs correctness, tone not scored, future-dated questions).

## New: `test_builder.py`
9 unit tests, all passing locally:
```
PASS test_register_and_build_round_trip
PASS test_register_drift_refuses
PASS test_register_same_content_is_idempotent
PASS test_build_unknown_prefix_refuses
PASS test_extra_suffix_appended_to_system
PASS test_dynamic_messages_appended_after_system
PASS test_assert_threshold_passes_when_long_enough
PASS test_assert_threshold_fails_when_too_short
PASS test_all_shipped_prefixes_clear_cache_threshold
9/9 passed
```

The last test is the **lock-in**: it imports every shipped prefix module and asserts each clears 1024 tokens. A future PR that trims a prompt below threshold — or adds a new prompt module that forgets to register / pad — fails here in CI.

## Independence
Pure Python in `ai-core/src/prompts/`. No DB, no frontend, no rollout. Safe to merge any time. The `builder.py` API was already in place from a previous commit; this PR only enlarges three prompt-content constants and adds tests.

## Test plan
- [x] `python -m src.prompts.test_builder` — 9/9 pass.
- [x] All four shipped prefixes verified above 1024-token threshold (4 chars/token conservative estimate; real tokens are usually shorter, so this passes with margin).
- [x] Builder API unchanged — no callers need updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)