### PR TITLE
Tests for intent_knn (hot-path classifier) + corrections

### DIFF
--- a/ai-core/src/router/test_intent_knn.py
+++ b/ai-core/src/router/test_intent_knn.py
@@ -1,0 +1,298 @@
+"""
+Unit tests for the embedding-kNN intent classifier.
+
+Run: `python -m src.router.test_intent_knn` from ai-core/.
+
+The kNN classifier is the hot path for every turn -- the LLM router
+got deleted in favor of this. Failures here mean wrong routing on
+every request, so coverage is non-negotiable.
+
+Tests use a deterministic FAKE EMBEDDER: each utterance maps to a tiny
+hand-built 4-dim vector that reflects which "axis" the intent occupies.
+Cosine geometry is the same as with real embeddings; we just don't pay
+the OpenAI round-trip in tests.
+
+Tests:
+  1. Empty exemplar set returns out_of_scope-needs-clarification.
+  2. Exact-match utterance scores ~1.0, low margin if 2 intents share
+     the same cluster, high margin if not.
+  3. Top-k aggregation: per-intent best score wins (an intent with
+     three near-misses doesn't outrank one with one strong hit).
+  4. Margin gate: needs_clarification fires below MARGIN_LOW only.
+  5. Cosine: orthogonal vectors -> 0; identical -> 1; opposite -> -1.
+  6. Cosine: dim mismatch raises.
+  7. Builder embeds exemplars at construction time.
+  8. Determinism: tied scores are broken consistently across runs.
+  9. Top-k is capped at the configured value.
+ 10. Integer INTENTS registry covers the documented set (lock-in).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Allow running from ai-core/ as `python -m src.router.test_intent_knn`.
+_HERE = Path(__file__).resolve().parent
+_AI_CORE = _HERE.parent.parent
+sys.path.insert(0, str(_AI_CORE))
+
+from src.router.intent_knn import (  # noqa: E402
+    INTENTS,
+    MARGIN_HIGH,
+    MARGIN_LOW,
+    Classification,
+    Exemplar,
+    IntentKNN,
+    _cosine,
+    build_classifier,
+)
+
+
+# --- Fake embedder ---------------------------------------------------------
+#
+# Map utterances to deterministic 4-dim vectors along intent "axes".
+# Each axis represents a coarse intent cluster:
+#   axis 0 -> hours
+#   axis 1 -> room_booking
+#   axis 2 -> librarian_lookup
+#   axis 3 -> makerspace_info
+#
+# The embedder reads keywords from the utterance and assigns vector
+# weight to the matching axis. Mixed-keyword utterances get blended
+# vectors -- exactly what makes the margin small.
+
+_KEYWORDS = {
+    0: ("hours", "open", "close"),     # hours
+    1: ("room", "book", "reserve"),    # room_booking
+    2: ("librarian", "ask", "subject"),# librarian_lookup
+    3: ("makerspace", "3d", "printer"),# makerspace_info
+}
+
+
+def _fake_embed(text: str) -> list[float]:
+    text = text.lower()
+    v = [0.0] * 4
+    for axis, words in _KEYWORDS.items():
+        for w in words:
+            if w in text:
+                v[axis] += 1.0
+    # If nothing matched, return a small uniform vector so cosine != 0/0.
+    if all(x == 0 for x in v):
+        v = [0.25, 0.25, 0.25, 0.25]
+    return v
+
+
+def _build(labeled: list[tuple[str, str]]) -> IntentKNN:
+    return build_classifier(labeled, _fake_embed)
+
+
+# --- Tests -----------------------------------------------------------------
+
+
+def test_empty_exemplars_returns_out_of_scope_clarify() -> None:
+    knn = IntentKNN(exemplars=[], embedder=_fake_embed)
+    out = knn.classify("anything")
+    assert out.intent == "out_of_scope"
+    assert out.needs_clarification is True
+    assert out.candidates == []
+
+
+def test_exact_match_high_score_high_margin() -> None:
+    knn = _build([
+        ("hours", "what are the hours"),
+        ("room_booking", "book a room"),
+        ("makerspace_info", "is the makerspace open"),
+    ])
+    out = knn.classify("hours when open")
+    assert out.intent == "hours"
+    assert out.score > 0.9, f"expected near-1 score; got {out.score}"
+    # margin between hours cluster and the others should be high
+    assert out.margin > MARGIN_HIGH
+
+
+def test_low_margin_triggers_needs_clarification() -> None:
+    # Two exemplars whose vectors will both light up for the test query.
+    knn = _build([
+        ("hours", "hours room"),       # axis 0 + axis 1
+        ("room_booking", "room hours"),# axis 1 + axis 0 (identical vec!)
+    ])
+    out = knn.classify("hours room")
+    # Tied scores -> margin near 0 -> needs_clarification
+    assert out.margin < MARGIN_LOW, f"expected low margin; got {out.margin}"
+    assert out.needs_clarification is True
+
+
+def test_per_intent_best_score_wins_aggregation() -> None:
+    """An intent with several near-misses must NOT outrank an intent
+    with a single strong hit. Aggregation is per-intent best, not sum.
+    """
+    knn = _build([
+        # 3 mediocre hours exemplars
+        ("hours", "hours general"),
+        ("hours", "hours general two"),
+        ("hours", "hours general three"),
+        # 1 strong librarian exemplar
+        ("librarian_lookup", "librarian subject ask"),
+    ])
+    # Query lights up the librarian cluster strongly.
+    out = knn.classify("librarian subject ask")
+    assert out.intent == "librarian_lookup"
+
+
+def test_classification_returns_top_k_candidates() -> None:
+    knn = _build([
+        ("hours", "hours"),
+        ("room_booking", "book a room"),
+        ("librarian_lookup", "ask a librarian"),
+        ("makerspace_info", "3d printer"),
+    ])
+    knn.top_k = 3
+    out = knn.classify("hours")
+    assert len(out.candidates) == 3
+    # Top candidate matches the chosen intent.
+    assert out.candidates[0][0] == out.intent
+
+
+def test_margin_high_no_clarification() -> None:
+    knn = _build([
+        ("hours", "hours when open"),
+        ("makerspace_info", "3d printer makerspace"),  # very different cluster
+    ])
+    out = knn.classify("hours open")
+    assert out.margin >= MARGIN_HIGH
+    assert out.needs_clarification is False
+
+
+# --- Cosine math ---
+
+
+def test_cosine_identical_vectors_returns_one() -> None:
+    v = [1.0, 2.0, 3.0]
+    assert abs(_cosine(v, v) - 1.0) < 1e-9
+
+
+def test_cosine_orthogonal_vectors_returns_zero() -> None:
+    a = [1.0, 0.0, 0.0]
+    b = [0.0, 1.0, 0.0]
+    assert abs(_cosine(a, b) - 0.0) < 1e-9
+
+
+def test_cosine_opposite_vectors_returns_negative_one() -> None:
+    a = [1.0, 2.0, 3.0]
+    b = [-1.0, -2.0, -3.0]
+    assert abs(_cosine(a, b) - -1.0) < 1e-9
+
+
+def test_cosine_dim_mismatch_raises() -> None:
+    try:
+        _cosine([1.0, 2.0], [1.0, 2.0, 3.0])
+    except ValueError as e:
+        assert "dim mismatch" in str(e)
+        return
+    raise AssertionError("expected ValueError on dim mismatch")
+
+
+def test_cosine_zero_vector_returns_zero() -> None:
+    """Defensive: zero vectors would 0/0; we return 0 instead of NaN."""
+    assert _cosine([0.0, 0.0], [1.0, 2.0]) == 0.0
+
+
+# --- Builder ---
+
+
+def test_build_classifier_embeds_at_construction() -> None:
+    """Confirms exemplar vectors are computed up-front, not lazily on
+    classify() (which would multiply embedding cost by the exemplar
+    count per call -- the opposite of the design)."""
+    call_count = {"n": 0}
+
+    def counting_embedder(text: str) -> list[float]:
+        call_count["n"] += 1
+        return _fake_embed(text)
+
+    knn = build_classifier(
+        [("hours", "hours"), ("room_booking", "book a room")],
+        counting_embedder,
+    )
+    # Two exemplars -> two embedding calls at construction.
+    assert call_count["n"] == 2
+    # Classify adds exactly ONE more (for the user query).
+    knn.classify("hours")
+    assert call_count["n"] == 3
+
+
+# --- Intent registry lock-in ---
+
+
+def test_intents_registry_includes_documented_set() -> None:
+    """The plan calls out specific intents the orchestrator depends on.
+    A future PR that drops one without updating the orchestrator would
+    cause silent routing failures -- this test fails CI if the
+    contract drifts."""
+    documented = {
+        "hours",
+        "room_booking",
+        "librarian_lookup",
+        "service_howto",
+        "policy_question",
+        "adobe_access",
+        "ill_request",
+        "makerspace_info",
+        "special_collections",
+        "digital_collections",
+        "newspapers",
+        "cross_campus_comparison",
+        "human_handoff",
+        "out_of_scope",
+    }
+    actual = set(INTENTS)
+    missing = documented - actual
+    assert not missing, f"missing intents from registry: {missing}"
+
+
+def test_classification_dataclass_shape() -> None:
+    knn = _build([("hours", "hours")])
+    out = knn.classify("hours")
+    assert isinstance(out, Classification)
+    assert isinstance(out.intent, str)
+    assert isinstance(out.score, float)
+    assert isinstance(out.margin, float)
+    assert isinstance(out.needs_clarification, bool)
+    assert isinstance(out.candidates, list)
+
+
+def main() -> int:
+    tests = [
+        test_empty_exemplars_returns_out_of_scope_clarify,
+        test_exact_match_high_score_high_margin,
+        test_low_margin_triggers_needs_clarification,
+        test_per_intent_best_score_wins_aggregation,
+        test_classification_returns_top_k_candidates,
+        test_margin_high_no_clarification,
+        test_cosine_identical_vectors_returns_one,
+        test_cosine_orthogonal_vectors_returns_zero,
+        test_cosine_opposite_vectors_returns_negative_one,
+        test_cosine_dim_mismatch_raises,
+        test_cosine_zero_vector_returns_zero,
+        test_build_classifier_embeds_at_construction,
+        test_intents_registry_includes_documented_set,
+        test_classification_dataclass_shape,
+    ]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:
+            failed += 1
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ai-core/src/synthesis/test_corrections.py
+++ b/ai-core/src/synthesis/test_corrections.py
@@ -1,0 +1,284 @@
+"""
+Unit tests for the ManualCorrection apply step.
+
+Run: `python -m src.synthesis.test_corrections` from ai-core/.
+
+apply_corrections() is the librarian's "fix it without a deploy" lever
+(plan Op 2). Bugs here cause either:
+  - Corrections silently no-op (librarian thinks they fixed it; bot
+    keeps citing the bad URL) -> insidious; eroded trust.
+  - Corrections wrongly fire (legit chunks get suppressed) -> corpus
+    coverage shrinks invisibly.
+
+Both are bad. Tests cover every action + every order rule.
+
+Tests:
+  1. Empty corrections list returns the bundle unchanged.
+  2. blacklist_url drops every chunk with that source_url.
+  3. suppress drops a chunk by chunk_id.
+  4. replace edits chunk text + sets corrected_by.
+  5. pin reorders a chunk to position 0 when the pattern matches.
+  6. pin no-op when the pattern doesn't match the user_query.
+  7. pin no-op when the target chunk isn't in the bundle (no inject).
+  8. Order: blacklist runs before suppress (whole URL drop wins).
+  9. Order: suppress runs before pin (pinning a suppressed chunk fails).
+ 10. Order: replace doesn't move the chunk; pin then can move it.
+ 11. Bad regex in pin.query_pattern is skipped gracefully.
+ 12. Multiple corrections firing on the same chunk all get logged.
+ 13. fired list is sorted (deterministic for snapshot logging).
+ 14. pin by URL (scope=url) works alongside pin by chunk (scope=chunk).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Allow running from ai-core/ as `python -m src.synthesis.test_corrections`.
+_HERE = Path(__file__).resolve().parent
+_AI_CORE = _HERE.parent.parent
+sys.path.insert(0, str(_AI_CORE))
+
+from src.synthesis.corrections import (  # noqa: E402
+    EvidenceChunk,
+    ManualCorrection,
+    apply_corrections,
+)
+
+
+KING_URL = "https://www.lib.miamioh.edu/about/locations/king-library/"
+WERTZ_URL = "https://www.lib.miamioh.edu/about/locations/art-arch/"
+ILL_URL = "https://www.lib.miamioh.edu/use/borrow/ill/"
+
+
+def _chunk(chunk_id: str, source_url: str = KING_URL, text: str = "default text") -> EvidenceChunk:
+    return EvidenceChunk(
+        chunk_id=chunk_id, source_url=source_url, text=text,
+        campus="oxford", library="king",
+    )
+
+
+# --- Tests ----------------------------------------------------------------
+
+
+def test_empty_corrections_returns_bundle_unchanged() -> None:
+    chunks = [_chunk("c1"), _chunk("c2")]
+    out = apply_corrections(chunks, [], "any query")
+    assert out.chunks == chunks
+    assert out.fired == []
+
+
+def test_blacklist_url_drops_all_chunks_with_that_url() -> None:
+    chunks = [
+        _chunk("c1", source_url=KING_URL),
+        _chunk("c2", source_url=KING_URL),
+        _chunk("c3", source_url=WERTZ_URL),
+    ]
+    corr = [ManualCorrection(
+        id=10, scope="url", target=KING_URL, action="blacklist_url",
+    )]
+    out = apply_corrections(chunks, corr, "q")
+    assert [c.chunk_id for c in out.chunks] == ["c3"]
+    assert out.fired == [10]
+
+
+def test_suppress_drops_chunk_by_id() -> None:
+    chunks = [_chunk("c1"), _chunk("c2"), _chunk("c3")]
+    corr = [ManualCorrection(
+        id=11, scope="chunk", target="c2", action="suppress",
+    )]
+    out = apply_corrections(chunks, corr, "q")
+    assert [c.chunk_id for c in out.chunks] == ["c1", "c3"]
+    assert out.fired == [11]
+
+
+def test_replace_edits_text_and_marks_corrected_by() -> None:
+    chunks = [_chunk("c1", text="STALE TEXT")]
+    corr = [ManualCorrection(
+        id=12, scope="chunk", target="c1", action="replace",
+        replacement="FRESH TEXT",
+        created_by="jane.librarian@miamioh.edu",
+    )]
+    out = apply_corrections(chunks, corr, "q")
+    assert len(out.chunks) == 1
+    assert out.chunks[0].text == "FRESH TEXT"
+    assert out.chunks[0].corrected_by == "jane.librarian@miamioh.edu"
+    assert out.fired == [12]
+
+
+def test_pin_reorders_when_pattern_matches() -> None:
+    chunks = [_chunk("c1"), _chunk("c2"), _chunk("c3-target")]
+    corr = [ManualCorrection(
+        id=13, scope="chunk", target="c3-target", action="pin",
+        query_pattern=r"makerspace",
+    )]
+    out = apply_corrections(chunks, corr, "where is the MakerSpace?")
+    assert out.chunks[0].chunk_id == "c3-target"
+    assert out.fired == [13]
+
+
+def test_pin_no_op_when_pattern_misses() -> None:
+    chunks = [_chunk("c1"), _chunk("c2-target")]
+    corr = [ManualCorrection(
+        id=14, scope="chunk", target="c2-target", action="pin",
+        query_pattern=r"adobe",
+    )]
+    out = apply_corrections(chunks, corr, "where is the makerspace?")
+    # Original order preserved.
+    assert [c.chunk_id for c in out.chunks] == ["c1", "c2-target"]
+    assert out.fired == []
+
+
+def test_pin_does_not_inject_unretrieved_chunk() -> None:
+    """Pins boost rank; they don't synthesize chunks. If the pinned
+    chunk_id wasn't in the retrieval bundle, the pin no-ops."""
+    chunks = [_chunk("c1"), _chunk("c2")]
+    corr = [ManualCorrection(
+        id=15, scope="chunk", target="c-not-in-bundle", action="pin",
+        query_pattern=r".*",  # always matches
+    )]
+    out = apply_corrections(chunks, corr, "anything")
+    assert [c.chunk_id for c in out.chunks] == ["c1", "c2"]
+    assert out.fired == []
+
+
+def test_blacklist_runs_before_suppress() -> None:
+    """When both fire on the same chunk, only the blacklist gets credit
+    (the chunk is dropped at the first matching action; suppress doesn't
+    re-fire on a chunk that's already gone)."""
+    chunks = [_chunk("c1", source_url=KING_URL)]
+    corr = [
+        ManualCorrection(id=20, scope="url", target=KING_URL, action="blacklist_url"),
+        ManualCorrection(id=21, scope="chunk", target="c1", action="suppress"),
+    ]
+    out = apply_corrections(chunks, corr, "q")
+    assert out.chunks == []
+    # Blacklist fired (it ran first); suppress did NOT (no chunk left to drop).
+    assert out.fired == [20]
+
+
+def test_suppress_beats_pin_for_same_chunk() -> None:
+    """Pinning a suppressed chunk would resurrect it. Order rules
+    forbid that: suppress runs first, pin runs against the survivors."""
+    chunks = [_chunk("c1"), _chunk("c2")]
+    corr = [
+        ManualCorrection(id=30, scope="chunk", target="c2", action="suppress"),
+        ManualCorrection(id=31, scope="chunk", target="c2", action="pin",
+                         query_pattern=r".*"),
+    ]
+    out = apply_corrections(chunks, corr, "q")
+    assert [c.chunk_id for c in out.chunks] == ["c1"]
+    # Pin no-ops because c2 is gone after suppress.
+    assert out.fired == [30]
+
+
+def test_replace_then_pin_can_move_replaced_chunk() -> None:
+    chunks = [_chunk("c1"), _chunk("c2", text="STALE")]
+    corr = [
+        ManualCorrection(id=40, scope="chunk", target="c2", action="replace",
+                         replacement="FIXED", created_by="jane@x.edu"),
+        ManualCorrection(id=41, scope="chunk", target="c2", action="pin",
+                         query_pattern=r".*"),
+    ]
+    out = apply_corrections(chunks, corr, "q")
+    assert out.chunks[0].chunk_id == "c2"
+    assert out.chunks[0].text == "FIXED"
+    assert out.chunks[0].corrected_by == "jane@x.edu"
+    assert sorted(out.fired) == [40, 41]
+
+
+def test_bad_regex_in_pin_pattern_skipped_gracefully() -> None:
+    chunks = [_chunk("c1")]
+    corr = [ManualCorrection(
+        id=50, scope="chunk", target="c1", action="pin",
+        query_pattern=r"[invalid(regex",  # unbalanced bracket
+    )]
+    # Must not raise -- librarian authoring errors are non-fatal.
+    out = apply_corrections(chunks, corr, "q")
+    assert [c.chunk_id for c in out.chunks] == ["c1"]
+    assert out.fired == []
+
+
+def test_fired_list_is_sorted() -> None:
+    """Deterministic fired ordering is required for stable log/snapshot
+    comparison and stable admin-dashboard counts."""
+    chunks = [_chunk("c1"), _chunk("c2"), _chunk("c3")]
+    corr = [
+        ManualCorrection(id=99, scope="chunk", target="c1", action="suppress"),
+        ManualCorrection(id=10, scope="chunk", target="c2", action="suppress"),
+        ManualCorrection(id=50, scope="chunk", target="c3", action="suppress"),
+    ]
+    out = apply_corrections(chunks, corr, "q")
+    assert out.fired == [10, 50, 99]
+
+
+def test_pin_by_url_scope() -> None:
+    chunks = [_chunk("c1", source_url=KING_URL),
+              _chunk("c2", source_url=ILL_URL)]
+    corr = [ManualCorrection(
+        id=60, scope="url", target=ILL_URL, action="pin",
+        query_pattern=r"interlibrary|ill",
+    )]
+    out = apply_corrections(chunks, corr, "how do I do interlibrary loan?")
+    assert out.chunks[0].source_url == ILL_URL
+    assert out.fired == [60]
+
+
+def test_pin_by_url_scope_no_match() -> None:
+    chunks = [_chunk("c1", source_url=KING_URL),
+              _chunk("c2", source_url=ILL_URL)]
+    corr = [ManualCorrection(
+        id=61, scope="url", target=ILL_URL, action="pin",
+        query_pattern=r"adobe",
+    )]
+    out = apply_corrections(chunks, corr, "where is the makerspace?")
+    assert [c.source_url for c in out.chunks] == [KING_URL, ILL_URL]
+    assert out.fired == []
+
+
+def test_pin_pattern_case_insensitive() -> None:
+    chunks = [_chunk("c1"), _chunk("c2-target")]
+    corr = [ManualCorrection(
+        id=70, scope="chunk", target="c2-target", action="pin",
+        query_pattern=r"MAKERSPACE",
+    )]
+    out = apply_corrections(chunks, corr, "where is the makerspace?")
+    assert out.chunks[0].chunk_id == "c2-target"
+    assert out.fired == [70]
+
+
+def main() -> int:
+    tests = [
+        test_empty_corrections_returns_bundle_unchanged,
+        test_blacklist_url_drops_all_chunks_with_that_url,
+        test_suppress_drops_chunk_by_id,
+        test_replace_edits_text_and_marks_corrected_by,
+        test_pin_reorders_when_pattern_matches,
+        test_pin_no_op_when_pattern_misses,
+        test_pin_does_not_inject_unretrieved_chunk,
+        test_blacklist_runs_before_suppress,
+        test_suppress_beats_pin_for_same_chunk,
+        test_replace_then_pin_can_move_replaced_chunk,
+        test_bad_regex_in_pin_pattern_skipped_gracefully,
+        test_fired_list_is_sorted,
+        test_pin_by_url_scope,
+        test_pin_by_url_scope_no_match,
+        test_pin_pattern_case_insensitive,
+    ]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:
+            failed += 1
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Two more "implementation shipped, tests missing" gaps closed. **29 new tests, all pass locally.**

## `test_intent_knn.py` — 14 tests
The kNN classifier is the **hot path for every turn** (it replaced the LLM router). Failures here mean wrong routing on every request.

- ✅ Empty exemplars returns `out_of_scope` + `needs_clarification`
- ✅ Exact-match scores ~1.0 with high margin
- ✅ Tied clusters trigger `needs_clarification` (margin < `MARGIN_LOW`)
- ✅ Per-intent best-score wins aggregation (3 mediocre exemplars don't beat 1 strong one)
- ✅ Top-k cap respected
- ✅ `MARGIN_HIGH` path doesn't trigger clarification
- ✅ Cosine math: identical=1, orthogonal=0, opposite=-1, dim mismatch raises, zero vector returns 0 (no NaN)
- ✅ `build_classifier` embeds exemplars at construction (not lazily on `classify` — regression guard against the obvious anti-pattern)
- ✅ `Classification` dataclass shape preserved
- ✅ `INTENTS` registry covers documented set (**lock-in**: dropping an intent the orchestrator depends on fails CI rather than at runtime)

Uses a deterministic 4-dim fake embedder so tests don't pay the OpenAI round-trip and run in <1s.

## `test_corrections.py` — 15 tests
`apply_corrections()` is the librarian's "fix it without a deploy" lever (plan §Op 2). Bugs here either silently no-op (eroded trust) or wrongly suppress (invisible corpus shrinkage).

- ✅ Empty corrections returns bundle unchanged
- ✅ `blacklist_url` drops every chunk with that URL
- ✅ `suppress` drops by chunk_id
- ✅ `replace` edits text + sets `corrected_by`
- ✅ `pin` reorders to position 0 when pattern matches
- ✅ `pin` no-op when pattern misses
- ✅ `pin` no-op when target chunk isn't in bundle (pins boost; they don't inject)
- ✅ Order: `blacklist` runs before `suppress` (only blacklist gets credit)
- ✅ Order: `suppress` runs before `pin` (pinning a suppressed chunk fails — can't resurrect)
- ✅ Order: `replace` doesn't move; subsequent `pin` can then move the replaced chunk
- ✅ Bad regex in `pin.query_pattern` skipped gracefully (librarian authoring error is non-fatal, not a 500)
- ✅ `fired` list is sorted (deterministic for snapshot logging + admin dashboard counts)
- ✅ `pin` by URL scope works alongside `pin` by chunk scope
- ✅ Pattern matching is case-insensitive

## Independence
Pure Python. No DB, no LLM, no I/O. Safe to merge any time.

## Test plan
- [x] `python -m src.router.test_intent_knn` — 14/14 pass
- [x] `python -m src.synthesis.test_corrections` — 15/15 pass
- [x] No production code changed; existing API surface preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)