### PR TITLE
Tests for agent loop, tool registry, smoketest, request-id context (42 tests)

### DIFF
--- a/ai-core/src/agent/test_agent.py
+++ b/ai-core/src/agent/test_agent.py
@@ -1,0 +1,354 @@
+"""
+Unit tests for the agent loop.
+
+Run: `python -m src.agent.test_agent` from ai-core/.
+
+The agent loop's job is to drive a deterministic, bounded interaction
+between the LLM and the tool registry. Every guard rail (max_iters,
+loop detection, tool-failure cap) is load-bearing -- without them, a
+buggy LLM response can run up unbounded cost or burn through API
+quota. Tests cover each rail independently.
+
+Strategy: a stub LLM that returns canned (message, tool_calls, usage)
+tuples per iteration so the loop's behavior is fully deterministic.
+
+Tests:
+  1. Clean stop: LLM emits no tool calls -> AgentOutcome(stopped_reason="clean").
+  2. One tool round-trip then clean stop.
+  3. Hits max_iterations -> stopped_reason="max_iters", terminal=None.
+  4. Same tool+args twice -> stopped_reason="loop_detected".
+  5. tool_failures >= max_tool_failures -> stopped_reason="tool_failures".
+  6. Token usage accumulates across turns.
+  7. Scope line composed correctly when scope_library set.
+  8. Scope line composed correctly when scope_library is None.
+  9. Conversation history is preserved + extended (not replaced).
+ 10. _canonical_args produces stable string for dict reorderings.
+ 11. _tool_result_message shape: role=tool, tool_call_id, name, content.
+ 12. _tool_result_message handles non-JSON-serializable data via repr.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+# Allow running from ai-core/ as `python -m src.agent.test_agent`.
+_HERE = Path(__file__).resolve().parent
+_AI_CORE = _HERE.parent.parent
+sys.path.insert(0, str(_AI_CORE))
+
+from src.agent.agent import (  # noqa: E402
+    AgentRequest,
+    _canonical_args,
+    _tool_result_message,
+    run_agent,
+)
+from src.agent.tool_registry import (  # noqa: E402
+    Tool,
+    ToolCall,
+    ToolError,
+    ToolRegistry,
+    ToolResult,
+)
+
+
+# --- Fixtures --------------------------------------------------------------
+
+
+def _registry_with(*tools: Tool) -> ToolRegistry:
+    reg = ToolRegistry()
+    for t in tools:
+        reg.register(t)
+    return reg
+
+
+def _echo_tool() -> Tool:
+    return Tool(
+        name="echo", description="Echo a string.",
+        parameters={"type": "object"},
+        handler=lambda args: {"echoed": args.get("msg", "")},
+    )
+
+
+def _failing_tool() -> Tool:
+    return Tool(
+        name="fail", description="Always fails.",
+        parameters={"type": "object"},
+        handler=lambda _: (_ for _ in ()).throw(ToolError("simulated failure")),
+    )
+
+
+class StubLLM:
+    """LLM stub that returns canned (message, tool_calls, usage) per call.
+
+    Construct with a list of return tuples; the i-th call returns
+    responses[i]. Cycles back to the last response if exhausted (the
+    test's max_iterations cap will kick in first).
+    """
+
+    def __init__(self, responses: list[tuple[dict, list[ToolCall], dict]]):
+        self.responses = responses
+        self.calls: list[dict] = []  # capture every call for inspection
+
+    def __call__(self, *, prefix_id, messages, tools, model):
+        self.calls.append({
+            "prefix_id": prefix_id, "messages": list(messages),
+            "tools": tools, "model": model,
+        })
+        idx = min(len(self.calls) - 1, len(self.responses) - 1)
+        return self.responses[idx]
+
+
+def _request(scope_library: str | None = None) -> AgentRequest:
+    return AgentRequest(
+        user_message="hello", intent="hours",
+        scope_campus="oxford", scope_library=scope_library,
+    )
+
+
+# --- Tests -----------------------------------------------------------------
+
+
+def test_clean_stop_when_no_tool_calls() -> None:
+    llm = StubLLM([
+        ({"role": "assistant", "content": "Done"}, [], {"input_tokens": 10, "output_tokens": 5}),
+    ])
+    out = run_agent(_request(), _registry_with(), llm=llm)
+    assert out.stopped_reason == "clean"
+    assert out.terminal_message == {"role": "assistant", "content": "Done"}
+    assert out.input_tokens == 10
+    assert out.output_tokens == 5
+    assert len(out.turns) == 1
+
+
+def test_one_tool_round_trip_then_clean() -> None:
+    llm = StubLLM([
+        # iter 0: request a tool call
+        (
+            {"role": "assistant", "content": None, "tool_calls": [...]},
+            [ToolCall(id="tc1", name="echo", arguments={"msg": "hi"})],
+            {"input_tokens": 100, "output_tokens": 20},
+        ),
+        # iter 1: terminal
+        (
+            {"role": "assistant", "content": "Echoed."},
+            [],
+            {"input_tokens": 110, "output_tokens": 5},
+        ),
+    ])
+    out = run_agent(_request(), _registry_with(_echo_tool()), llm=llm)
+    assert out.stopped_reason == "clean"
+    assert len(out.turns) == 2
+    assert out.turns[0].tool_calls[0].name == "echo"
+    assert out.turns[0].tool_results[0].data == {"echoed": "hi"}
+    # Token usage accumulates.
+    assert out.input_tokens == 210
+
+
+def test_hits_max_iterations() -> None:
+    """LLM keeps requesting tools forever -> loop bails at max_iters."""
+    # Different tool args each call so loop_detected doesn't fire first.
+    responses = [
+        (
+            {"role": "assistant", "content": None},
+            [ToolCall(id=f"tc{i}", name="echo", arguments={"msg": f"call-{i}"})],
+            {"input_tokens": 50, "output_tokens": 10},
+        )
+        for i in range(10)
+    ]
+    llm = StubLLM(responses)
+    out = run_agent(_request(), _registry_with(_echo_tool()), llm=llm, max_iterations=3)
+    assert out.stopped_reason == "max_iters"
+    assert out.terminal_message is None
+    assert len(out.turns) == 3
+
+
+def test_loop_detected_on_repeated_tool_call() -> None:
+    """Same tool name AND same args twice in a row -> loop_detected."""
+    same = ToolCall(id="tc-x", name="echo", arguments={"msg": "stuck"})
+    llm = StubLLM([
+        ({"role": "assistant", "content": None}, [same], {"input_tokens": 50, "output_tokens": 10}),
+        ({"role": "assistant", "content": None}, [same], {"input_tokens": 60, "output_tokens": 10}),
+    ])
+    out = run_agent(_request(), _registry_with(_echo_tool()), llm=llm)
+    assert out.stopped_reason == "loop_detected"
+    # Both turns logged.
+    assert len(out.turns) == 2
+
+
+def test_tool_failure_cap_breaks_loop() -> None:
+    """Repeated tool failures bail before max_iters -- no point asking
+    LibCal for hours 6 times when it's down."""
+    responses = [
+        (
+            {"role": "assistant", "content": None},
+            [ToolCall(id=f"tc{i}", name="fail", arguments={"i": i})],
+            {"input_tokens": 50, "output_tokens": 10},
+        )
+        for i in range(10)
+    ]
+    llm = StubLLM(responses)
+    out = run_agent(
+        _request(), _registry_with(_failing_tool()),
+        llm=llm, max_iterations=10, max_tool_failures=2,
+    )
+    assert out.stopped_reason == "tool_failures"
+    # Loop bailed after 2nd failure (before doing 3rd iteration).
+    assert len(out.turns) == 2
+
+
+def test_token_usage_accumulates_across_turns() -> None:
+    llm = StubLLM([
+        (
+            {"role": "assistant", "content": None},
+            [ToolCall(id="tc1", name="echo", arguments={"msg": "a"})],
+            {"input_tokens": 100, "cached_input_tokens": 80, "output_tokens": 10},
+        ),
+        (
+            {"role": "assistant", "content": "done"},
+            [],
+            {"input_tokens": 200, "cached_input_tokens": 180, "output_tokens": 20},
+        ),
+    ])
+    out = run_agent(_request(), _registry_with(_echo_tool()), llm=llm)
+    assert out.input_tokens == 300
+    assert out.cached_input_tokens == 260
+    assert out.output_tokens == 30
+
+
+def test_scope_line_includes_library_when_set() -> None:
+    llm = StubLLM([({"role": "assistant", "content": "x"}, [], {})])
+    run_agent(_request(scope_library="king"), _registry_with(), llm=llm)
+    user_msg_content = llm.calls[0]["messages"][-1]["content"]
+    assert "campus=oxford" in user_msg_content
+    assert "library=king" in user_msg_content
+    assert "intent=hours" in user_msg_content
+
+
+def test_scope_line_omits_library_when_none() -> None:
+    llm = StubLLM([({"role": "assistant", "content": "x"}, [], {})])
+    run_agent(_request(scope_library=None), _registry_with(), llm=llm)
+    user_msg = llm.calls[0]["messages"][-1]["content"]
+    assert "campus=oxford" in user_msg
+    assert "library=" not in user_msg
+
+
+def test_conversation_history_preserved_and_extended() -> None:
+    llm = StubLLM([
+        (
+            {"role": "assistant", "content": None},
+            [ToolCall(id="tc1", name="echo", arguments={"msg": "a"})],
+            {"input_tokens": 50, "output_tokens": 10},
+        ),
+        (
+            {"role": "assistant", "content": "ok"}, [], {"input_tokens": 60, "output_tokens": 5},
+        ),
+    ])
+    history = [
+        {"role": "user", "content": "previous question"},
+        {"role": "assistant", "content": "previous answer"},
+    ]
+    request = AgentRequest(
+        user_message="follow-up", intent="hours",
+        scope_campus="oxford", scope_library=None,
+        conversation_history=history,
+    )
+    run_agent(request, _registry_with(_echo_tool()), llm=llm)
+    # First call: history + the new user message at end.
+    first_msgs = llm.calls[0]["messages"]
+    assert first_msgs[0:2] == history
+    assert first_msgs[-1]["role"] == "user"
+    assert "follow-up" in first_msgs[-1]["content"]
+    # Second call: includes the assistant + tool result messages.
+    second_msgs = llm.calls[1]["messages"]
+    assert len(second_msgs) > len(first_msgs)
+    # Tool result message present.
+    assert any(m.get("role") == "tool" for m in second_msgs)
+
+
+# --- _canonical_args ---
+
+
+def test_canonical_args_stable_across_dict_orderings() -> None:
+    a = _canonical_args({"x": 1, "y": 2})
+    b = _canonical_args({"y": 2, "x": 1})
+    assert a == b
+
+
+def test_canonical_args_handles_non_json_safe_values() -> None:
+    """Set / object values fall back to repr; must not crash."""
+    s = _canonical_args({"items": {1, 2, 3}})  # set isn't JSON-serializable
+    assert isinstance(s, str)
+    assert s  # non-empty
+
+
+# --- _tool_result_message ---
+
+
+def test_tool_result_message_success_shape() -> None:
+    r = ToolResult(call_id="tc1", name="echo", data={"echoed": "hi"})
+    msg = _tool_result_message(r)
+    assert msg["role"] == "tool"
+    assert msg["tool_call_id"] == "tc1"
+    assert msg["name"] == "echo"
+    # Content is JSON-stringified for the LLM.
+    assert isinstance(msg["content"], str)
+    assert "echoed" in msg["content"]
+
+
+def test_tool_result_message_error_shape() -> None:
+    r = ToolResult(call_id="tc1", name="echo", error="LibCal 503")
+    msg = _tool_result_message(r)
+    assert msg["role"] == "tool"
+    assert "error" in msg["content"]
+    assert "LibCal 503" in msg["content"]
+
+
+def test_tool_result_message_handles_non_json_safe_data() -> None:
+    """If a tool returns a non-JSON-safe object (e.g. a dataclass
+    instance), the wrapper must produce SOMETHING serializable rather
+    than crash the loop. Defensive default=str path."""
+    class Weird:
+        def __repr__(self): return "<Weird>"
+
+    r = ToolResult(call_id="tc1", name="x", data=Weird())
+    msg = _tool_result_message(r)
+    assert isinstance(msg["content"], str)
+    assert msg["role"] == "tool"
+
+
+def main() -> int:
+    tests = [
+        test_clean_stop_when_no_tool_calls,
+        test_one_tool_round_trip_then_clean,
+        test_hits_max_iterations,
+        test_loop_detected_on_repeated_tool_call,
+        test_tool_failure_cap_breaks_loop,
+        test_token_usage_accumulates_across_turns,
+        test_scope_line_includes_library_when_set,
+        test_scope_line_omits_library_when_none,
+        test_conversation_history_preserved_and_extended,
+        test_canonical_args_stable_across_dict_orderings,
+        test_canonical_args_handles_non_json_safe_values,
+        test_tool_result_message_success_shape,
+        test_tool_result_message_error_shape,
+        test_tool_result_message_handles_non_json_safe_data,
+    ]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:
+            failed += 1
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ai-core/src/agent/test_tool_registry.py
+++ b/ai-core/src/agent/test_tool_registry.py
@@ -1,0 +1,208 @@
+"""
+Unit tests for the tool registry + dispatcher.
+
+Run: `python -m src.agent.test_tool_registry` from ai-core/.
+
+ToolRegistry sits between the LLM and every external system the bot
+touches. A bug in dispatch silently swallows errors or surfaces stack
+traces to the model -- the latter regularly causes the model to
+hallucinate "I'll try a different approach" responses that turn into
+junk answers.
+
+Tests:
+  1. register accepts a tool; get returns it; duplicate name raises.
+  2. as_openai_tools returns the [{type, function:{name,description,parameters}}] shape.
+  3. dispatch with unknown name returns error result (not raise).
+  4. dispatch with successful handler returns data + non-zero latency.
+  5. ToolError -> structured error result, latency recorded, no stack trace leak.
+  6. Other exceptions PROPAGATE (agent loop captures at outer level).
+  7. is_read_only defaults to True; can be overridden False.
+  8. Tool dataclass fields all set correctly.
+  9. Empty registry's as_openai_tools returns [].
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Allow running from ai-core/ as `python -m src.agent.test_tool_registry`.
+_HERE = Path(__file__).resolve().parent
+_AI_CORE = _HERE.parent.parent
+sys.path.insert(0, str(_AI_CORE))
+
+from src.agent.tool_registry import (  # noqa: E402
+    Tool,
+    ToolCall,
+    ToolError,
+    ToolRegistry,
+    ToolResult,
+)
+
+
+def _basic_tool(name: str = "echo") -> Tool:
+    return Tool(
+        name=name,
+        description=f"Echo {name}.",
+        parameters={"type": "object", "properties": {"msg": {"type": "string"}}},
+        handler=lambda args: {"echoed": args.get("msg", "")},
+    )
+
+
+# --- register / get / duplicate ---
+
+
+def test_register_and_get() -> None:
+    reg = ToolRegistry()
+    t = _basic_tool()
+    reg.register(t)
+    assert reg.get("echo") is t
+    assert reg.get("nonexistent") is None
+
+
+def test_register_duplicate_raises() -> None:
+    reg = ToolRegistry()
+    reg.register(_basic_tool("echo"))
+    try:
+        reg.register(_basic_tool("echo"))
+    except ValueError as e:
+        assert "already registered" in str(e)
+        return
+    raise AssertionError("expected ValueError on duplicate")
+
+
+# --- as_openai_tools ---
+
+
+def test_as_openai_tools_shape() -> None:
+    reg = ToolRegistry()
+    reg.register(_basic_tool("a"))
+    reg.register(_basic_tool("b"))
+    schema = reg.as_openai_tools()
+    assert len(schema) == 2
+    for entry in schema:
+        assert entry["type"] == "function"
+        assert "name" in entry["function"]
+        assert "description" in entry["function"]
+        assert "parameters" in entry["function"]
+
+
+def test_as_openai_tools_empty_registry() -> None:
+    assert ToolRegistry().as_openai_tools() == []
+
+
+# --- dispatch: success / errors ---
+
+
+def test_dispatch_unknown_tool_returns_error_result() -> None:
+    reg = ToolRegistry()
+    result = reg.dispatch(ToolCall(id="t1", name="missing", arguments={}))
+    assert result.is_error
+    assert "Unknown tool" in result.error
+    assert result.call_id == "t1"
+
+
+def test_dispatch_success_returns_data_and_latency() -> None:
+    reg = ToolRegistry()
+    reg.register(_basic_tool())
+    result = reg.dispatch(ToolCall(id="t1", name="echo", arguments={"msg": "hi"}))
+    assert not result.is_error
+    assert result.data == {"echoed": "hi"}
+    assert result.latency_ms >= 0  # may be 0 for very fast handlers
+
+
+def test_dispatch_tool_error_returns_structured_error() -> None:
+    """ToolError -> error result with the message, NO stack trace
+    leaked. The LLM reads this back; a stack trace would derail it."""
+    reg = ToolRegistry()
+    reg.register(Tool(
+        name="boom",
+        description="Always fails.",
+        parameters={"type": "object"},
+        handler=lambda _: (_ for _ in ()).throw(ToolError("LibCal returned 503")),
+    ))
+    result = reg.dispatch(ToolCall(id="t1", name="boom", arguments={}))
+    assert result.is_error
+    assert result.error == "LibCal returned 503"
+    assert "Traceback" not in result.error
+    # Latency still recorded so we can chart slow-failure tools.
+    assert result.latency_ms >= 0
+
+
+def test_dispatch_unexpected_exception_propagates() -> None:
+    """Non-ToolError exceptions PROPAGATE so the agent loop's outer
+    try/except captures them as turn-level failures (vs tool-level).
+    Distinction matters for telemetry: a KeyError in a tool handler is
+    a code bug, not a 'LibCal is down'."""
+    def crashing(_):
+        raise ValueError("wrong arg shape")
+
+    reg = ToolRegistry()
+    reg.register(Tool(
+        name="crash", description="Crashes.",
+        parameters={"type": "object"}, handler=crashing,
+    ))
+    try:
+        reg.dispatch(ToolCall(id="t1", name="crash", arguments={}))
+    except ValueError as e:
+        assert "wrong arg shape" in str(e)
+        return
+    raise AssertionError("expected ValueError to propagate")
+
+
+# --- Tool dataclass fields ---
+
+
+def test_tool_is_read_only_defaults_true() -> None:
+    t = _basic_tool()
+    assert t.is_read_only is True
+
+
+def test_tool_is_read_only_overridable() -> None:
+    t = Tool(
+        name="book", description="Action tool.",
+        parameters={"type": "object"},
+        handler=lambda _: {},
+        is_read_only=False,
+    )
+    assert t.is_read_only is False
+
+
+def test_tool_result_is_error_property() -> None:
+    ok = ToolResult(call_id="t1", name="x", data={"a": 1})
+    err = ToolResult(call_id="t1", name="x", error="boom")
+    assert not ok.is_error
+    assert err.is_error
+
+
+def main() -> int:
+    tests = [
+        test_register_and_get,
+        test_register_duplicate_raises,
+        test_as_openai_tools_shape,
+        test_as_openai_tools_empty_registry,
+        test_dispatch_unknown_tool_returns_error_result,
+        test_dispatch_success_returns_data_and_latency,
+        test_dispatch_tool_error_returns_structured_error,
+        test_dispatch_unexpected_exception_propagates,
+        test_tool_is_read_only_defaults_true,
+        test_tool_is_read_only_overridable,
+        test_tool_result_is_error_property,
+    ]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:
+            failed += 1
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ai-core/src/observability/test_logging.py
+++ b/ai-core/src/observability/test_logging.py
@@ -1,0 +1,145 @@
+"""
+Unit tests for the request-id ContextVar plumbing.
+
+Run: `python -m src.observability.test_logging` from ai-core/.
+
+The full structlog setup is integration-tested (it actually has to
+write to stdout); these tests cover the request-context ContextVar
+glue, which is what makes "every log line in this request carries the
+same id" actually work.
+
+Tests:
+  1. new_request_id returns a hex string of stable shape (32 chars).
+  2. new_request_id calls produce different ids.
+  3. bind_request_context with explicit id sets it.
+  4. bind_request_context without id auto-generates one.
+  5. bind_request_context preserves the existing id on subsequent calls.
+  6. bind_request_context merges fields from multiple calls.
+  7. ContextVar isolates per-task (asyncio).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+# Allow running from ai-core/ as `python -m src.observability.test_logging`.
+_HERE = Path(__file__).resolve().parent
+_AI_CORE = _HERE.parent.parent
+sys.path.insert(0, str(_AI_CORE))
+
+from src.observability.logging import (  # noqa: E402
+    _request_context_var,
+    bind_request_context,
+    new_request_id,
+    request_id_var,
+)
+
+
+def _reset() -> None:
+    request_id_var.set(None)
+    _request_context_var.set({})
+
+
+def test_new_request_id_shape() -> None:
+    rid = new_request_id()
+    assert isinstance(rid, str)
+    assert len(rid) == 32
+    # UUID hex is all lowercase hex digits.
+    assert all(c in "0123456789abcdef" for c in rid)
+
+
+def test_new_request_id_uniqueness() -> None:
+    ids = {new_request_id() for _ in range(100)}
+    assert len(ids) == 100  # vanishingly low collision probability
+
+
+def test_bind_request_context_with_explicit_id() -> None:
+    _reset()
+    bind_request_context(request_id="abc123")
+    assert request_id_var.get() == "abc123"
+    assert _request_context_var.get()["request_id"] == "abc123"
+
+
+def test_bind_request_context_auto_generates_id() -> None:
+    _reset()
+    bind_request_context()
+    rid = request_id_var.get()
+    assert rid is not None
+    assert len(rid) == 32
+
+
+def test_bind_request_context_preserves_existing_id() -> None:
+    """Second call without an id reuses the one set by the first call.
+    Without this, every nested middleware/handler would mint a new id
+    and the forensic spine breaks."""
+    _reset()
+    bind_request_context(request_id="abc")
+    bind_request_context(intent="hours")
+    assert request_id_var.get() == "abc"
+    ctx = _request_context_var.get()
+    assert ctx["request_id"] == "abc"
+    assert ctx["intent"] == "hours"
+
+
+def test_bind_request_context_merges_fields() -> None:
+    _reset()
+    bind_request_context(request_id="r1", intent="hours")
+    bind_request_context(scope_campus="oxford")
+    bind_request_context(model_used="gpt-5.4-mini")
+    ctx = _request_context_var.get()
+    assert ctx["request_id"] == "r1"
+    assert ctx["intent"] == "hours"
+    assert ctx["scope_campus"] == "oxford"
+    assert ctx["model_used"] == "gpt-5.4-mini"
+
+
+def test_context_isolated_across_asyncio_tasks() -> None:
+    """ContextVar is per-task by default in asyncio. Two concurrent
+    requests must NOT see each other's ids -- without this, log lines
+    from request A could carry request B's id."""
+    _reset()
+
+    async def worker(rid: str) -> str | None:
+        bind_request_context(request_id=rid)
+        # Yield to scheduler so other task interleaves.
+        await asyncio.sleep(0)
+        # After the yield, our id must still be ours, not the other task's.
+        return request_id_var.get()
+
+    async def main() -> tuple[str | None, str | None]:
+        return await asyncio.gather(worker("alpha"), worker("beta"))
+
+    a, b = asyncio.run(main())
+    assert a == "alpha"
+    assert b == "beta"
+
+
+def main() -> int:
+    tests = [
+        test_new_request_id_shape,
+        test_new_request_id_uniqueness,
+        test_bind_request_context_with_explicit_id,
+        test_bind_request_context_auto_generates_id,
+        test_bind_request_context_preserves_existing_id,
+        test_bind_request_context_merges_fields,
+        test_context_isolated_across_asyncio_tasks,
+    ]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:
+            failed += 1
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ai-core/src/observability/test_smoketest.py
+++ b/ai-core/src/observability/test_smoketest.py
@@ -1,0 +1,189 @@
+"""
+Unit tests for the synthetic-monitoring smoketest.
+
+Run: `python -m src.observability.test_smoketest` from ai-core/.
+
+The /smoketest endpoint is the canary that catches outages where every
+component reports healthy but the chain is broken. A bug here means
+real outages slip past the external pinger -- worse than no monitoring
+at all (false sense of security).
+
+Tests use stub `ask_bot` callables that return canned shapes, so the
+test runs in milliseconds and covers every check independently.
+
+Tests:
+  1. Happy path: answer + citations + under budget -> passed=True.
+  2. ask_bot raises -> passed=False, reachable=False, reason includes exception type.
+  3. is_refusal=True -> passed=False, "response was a refusal".
+  4. citations=[] -> passed=False, "no citations".
+  5. Slow ask_bot -> passed=False, latency exceeds budget.
+  6. Multiple failures composed in reason string.
+  7. answer_preview truncated to 200 chars.
+  8. checks dict has all three keys on success path.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+# Allow running from ai-core/ as `python -m src.observability.test_smoketest`.
+_HERE = Path(__file__).resolve().parent
+_AI_CORE = _HERE.parent.parent
+sys.path.insert(0, str(_AI_CORE))
+
+from src.observability.smoketest import (  # noqa: E402
+    DEFAULT_LATENCY_BUDGET_MS,
+    DEFAULT_QUESTION,
+    SmoketestResult,
+    run_smoketest,
+)
+
+
+def _good_response() -> dict:
+    return {
+        "answer": "King opens at 7am [1].",
+        "citations": [{"n": 1, "url": "https://lib.miamioh.edu/king/"}],
+        "is_refusal": False,
+    }
+
+
+def test_happy_path_passes() -> None:
+    result = run_smoketest(ask_bot=lambda q: _good_response())
+    assert result.passed
+    assert result.reason == ""
+    assert result.checks["is_answer"] is True
+    assert result.checks["has_citation"] is True
+    assert result.checks["under_latency"] is True
+    assert "King opens" in result.answer_preview
+
+
+def test_ask_bot_raises_returns_unreachable() -> None:
+    def crash(_):
+        raise ConnectionError("backend down")
+
+    result = run_smoketest(ask_bot=crash)
+    assert not result.passed
+    assert result.checks == {"reachable": False}
+    assert "ConnectionError" in result.reason
+    assert "backend down" in result.reason
+
+
+def test_refusal_fails_check() -> None:
+    result = run_smoketest(ask_bot=lambda q: {
+        "answer": "I can't help with that.",
+        "citations": [{"n": 1, "url": "https://x"}],
+        "is_refusal": True,
+    })
+    assert not result.passed
+    assert result.checks["is_answer"] is False
+    assert "refusal" in result.reason
+
+
+def test_no_citations_fails_check() -> None:
+    result = run_smoketest(ask_bot=lambda q: {
+        "answer": "King opens at 7am.",
+        "citations": [],
+        "is_refusal": False,
+    })
+    assert not result.passed
+    assert result.checks["has_citation"] is False
+    assert "no citations" in result.reason
+
+
+def test_slow_response_fails_under_latency() -> None:
+    def slow(_):
+        time.sleep(0.05)
+        return _good_response()
+
+    # Tiny budget so even the 50ms sleep blows it.
+    result = run_smoketest(ask_bot=slow, latency_budget_ms=10)
+    assert not result.passed
+    assert result.checks["under_latency"] is False
+    assert "latency" in result.reason
+    assert "budget 10" in result.reason
+
+
+def test_multiple_failures_composed_in_reason() -> None:
+    """Refusal + no citations: reason should mention both so the
+    pager-tier alert tells operators the full story."""
+    result = run_smoketest(ask_bot=lambda q: {
+        "answer": "no",
+        "citations": [],
+        "is_refusal": True,
+    })
+    assert not result.passed
+    assert "refusal" in result.reason
+    assert "no citations" in result.reason
+    assert ";" in result.reason  # bits joined by "; "
+
+
+def test_answer_preview_truncated_to_200_chars() -> None:
+    long_answer = "a" * 1000
+    result = run_smoketest(ask_bot=lambda q: {
+        "answer": long_answer,
+        "citations": [{"n": 1, "url": "https://x"}],
+        "is_refusal": False,
+    })
+    assert len(result.answer_preview) == 200
+
+
+def test_default_question_is_exposed() -> None:
+    """The canned question is a public constant so external pingers
+    and integration tests reference the same string."""
+    assert isinstance(DEFAULT_QUESTION, str)
+    assert "King" in DEFAULT_QUESTION  # default targets King hours
+    assert DEFAULT_LATENCY_BUDGET_MS > 0
+
+
+def test_latency_recorded_even_on_failure() -> None:
+    """Failed runs must still report latency (helps debug 'is it
+    slow because the call hung?')."""
+    result = run_smoketest(ask_bot=lambda q: {
+        "answer": "x", "citations": [], "is_refusal": False,
+    })
+    assert result.latency_ms >= 0
+
+
+def test_smoketest_question_passed_through() -> None:
+    seen: list[str] = []
+
+    def capture(q):
+        seen.append(q)
+        return _good_response()
+
+    run_smoketest(ask_bot=capture, question="What time does Wertz close?")
+    assert seen == ["What time does Wertz close?"]
+
+
+def main() -> int:
+    tests = [
+        test_happy_path_passes,
+        test_ask_bot_raises_returns_unreachable,
+        test_refusal_fails_check,
+        test_no_citations_fails_check,
+        test_slow_response_fails_under_latency,
+        test_multiple_failures_composed_in_reason,
+        test_answer_preview_truncated_to_200_chars,
+        test_default_question_is_exposed,
+        test_latency_recorded_even_on_failure,
+        test_smoketest_question_passed_through,
+    ]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:
+            failed += 1
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Four more "implementation shipped, tests missing" gaps closed. **42 new tests, all pass locally.**

| File | Tests | What it locks |
|---|---|---|
| `test_tool_registry.py` | 11 | dispatch contract; ToolError vs unexpected exception distinction; no stack-trace leak to LLM |
| `test_agent.py` | 14 | every loop guard rail (max_iters, loop_detected, tool_failures); token accumulation; scope composition; conversation history extension; canonical-args stability |
| `test_smoketest.py` | 10 | every check independently; multi-failure reason composition; latency recorded even on failure |
| `test_logging.py` | 7 | request-id ContextVar isolation across concurrent asyncio tasks (the forensic spine) |

## Highlights
**Agent loop guard rails — each tested independently using a stub LLM:**
- ✅ Clean stop when no tool calls
- ✅ `max_iterations` cap (LLM keeps requesting tools forever → bail)
- ✅ Loop-detected on repeated tool name+args (model is stuck → bail)
- ✅ Tool-failure cap (don't keep asking LibCal when it's down → bail)
- ✅ Token usage accumulates across turns (input + cached + output)

**Tool registry contract:**
- ✅ `ToolError` → structured error string the LLM reads back to decide its next move
- ✅ Non-`ToolError` exceptions PROPAGATE (turn-level vs tool-level distinction matters for telemetry)
- ✅ Latency recorded on both success and failure

**Smoketest reason composition:**
- ✅ Multiple failures combined: `"response was a refusal; no citations"` — pager-tier alert tells operators the full story

**ContextVar isolation:**
- ✅ Two concurrent asyncio tasks each see only their own `request_id` (without this, log lines from request A could carry request B's id — silently broken forensics)

## Independence
Pure Python. No DB, no LLM, no I/O. Safe to merge.

## Test plan
- [x] `python -m src.agent.test_tool_registry` — 11/11 pass
- [x] `python -m src.agent.test_agent` — 14/14 pass
- [x] `python -m src.observability.test_smoketest` — 10/10 pass
- [x] `python -m src.observability.test_logging` — 7/7 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)