### PR TITLE
Wire OpenAI Responses API in src/llm/client.py + agent + synthesizer

### DIFF
--- a/ai-core/src/agent/agent.py
+++ b/ai-core/src/agent/agent.py
@@ -136,15 +136,28 @@ def _default_llm_call(
     tools: list[dict],
     model: str,
 ) -> tuple[dict, list[ToolCall], dict]:
-    """Placeholder. Raises NotImplementedError until src/llm/client.py
-    is wired per the freshness rule."""
-    raise NotImplementedError(
-        "Agent LLM client not yet wired. Wire src/llm/client.py "
-        "(see plan: Model & API freshness rule -- check OpenAI docs "
-        "before writing the call shape) and pass it as the `llm` "
-        "argument to run_agent(), or monkeypatch _default_llm_call "
-        "for tests."
+    """Real LLM call via the Responses API (src/llm/client.py).
+
+    The `messages` argument is the agent loop's running list of input
+    items (user message, prior assistant messages, tool outputs).
+    Per the Responses API contract, this list IS the `input=` payload
+    -- it accepts message-shaped dicts plus `function_call_output`
+    items keyed by `call_id`.
+
+    `tools` must already be in the Responses-API internally-tagged
+    shape (see ToolRegistry.as_responses_tools()).
+    """
+    # Lazy import: src.llm.client imports openai which requires a key;
+    # tests pass their own `llm=` and never trigger this path.
+    from src.llm.client import completion_with_tools
+
+    assistant_message, tool_calls, usage = completion_with_tools(
+        prefix_id=prefix_id,
+        input_items=messages,
+        tools=tools,
+        model=model,
     )
+    return assistant_message, tool_calls, usage.as_dict()
 
 
 # --- Loop -----------------------------------------------------------------
@@ -190,7 +203,10 @@ def run_agent(
     total_in = 0
     total_cached = 0
     total_out = 0
-    tools_schema = registry.as_openai_tools()
+    # Responses API uses internally-tagged tool shape (no `function`
+    # wrapper). `as_responses_tools()` also flips strict=true per the
+    # Responses migration guide.
+    tools_schema = registry.as_responses_tools()
 
     for i in range(max_iterations):
         llm_message, tool_calls, usage = call(
@@ -276,8 +292,22 @@ def run_agent(
                 output_tokens=total_out,
             )
 
-        # Feed results back into the messages array for the next iteration.
-        messages.append(llm_message)
+        # Feed results back into the input items for the next iteration.
+        # Per the Responses API contract, append the FULL list of
+        # output items the model returned (not just an "assistant
+        # message" wrapper) so function_call items round-trip
+        # correlated with their function_call_output siblings by
+        # call_id. The wrapper dict our llm helper returns carries
+        # the original output items in `_response_output_items`.
+        prior_outputs = llm_message.get("_response_output_items")
+        if isinstance(prior_outputs, list):
+            messages.extend(prior_outputs)
+        else:
+            # Test stubs / non-Responses-shaped LLMs may return only
+            # the consolidated message dict. Append it as-is so the
+            # loop still progresses; tests that use stubs won't have
+            # a real Responses replay either.
+            messages.append(llm_message)
         for result in results:
             messages.append(_tool_result_message(result))
 
@@ -308,18 +338,26 @@ def _canonical_args(args: dict) -> str:
 
 
 def _tool_result_message(result: ToolResult) -> dict:
-    """Shape a ToolResult as an OpenAI-format `tool` role message so
-    the LLM sees it on the next turn."""
+    """Shape a ToolResult as a Responses-API `function_call_output`
+    input item so the LLM sees it on the next turn.
+
+    Per the Responses migration guide: "tool calls and their outputs
+    are two distinct types of Items that are correlated using a
+    `call_id`." The shape is:
+        {"type": "function_call_output", "call_id": "...", "output": "..."}
+
+    `output` is a string per the API contract (the LLM treats it as
+    the tool's textual output). We JSON-stringify dict/list outputs;
+    errors get a structured `{"error": "..."}` JSON string. Non-JSON-
+    safe data falls back to repr to keep the loop running instead of
+    crashing the request.
+    """
     import json
 
     content: Any
     if result.is_error:
         content = {"error": result.error}
     else:
-        # Serializing arbitrary tool output; fall back to repr if the
-        # data isn't JSON-serializable. In prod, tool authors should
-        # return dict / list / primitives only, but a defensive repr
-        # keeps the loop running instead of crashing on bad output.
         try:
             content = result.data
             json.dumps(content, default=str)
@@ -327,10 +365,9 @@ def _tool_result_message(result: ToolResult) -> dict:
             content = {"repr": repr(result.data)}
 
     return {
-        "role": "tool",
-        "tool_call_id": result.call_id,
-        "name": result.name,
-        "content": json.dumps(content, default=str),
+        "type": "function_call_output",
+        "call_id": result.call_id,
+        "output": json.dumps(content, default=str),
     }
 
 

--- a/ai-core/src/agent/test_agent.py
+++ b/ai-core/src/agent/test_agent.py
@@ -263,8 +263,8 @@ def test_conversation_history_preserved_and_extended() -> None:
     # Second call: includes the assistant + tool result messages.
     second_msgs = llm.calls[1]["messages"]
     assert len(second_msgs) > len(first_msgs)
-    # Tool result message present.
-    assert any(m.get("role") == "tool" for m in second_msgs)
+    # Tool result message present (Responses-API function_call_output shape).
+    assert any(m.get("type") == "function_call_output" for m in second_msgs)
 
 
 # --- _canonical_args ---
@@ -287,22 +287,24 @@ def test_canonical_args_handles_non_json_safe_values() -> None:
 
 
 def test_tool_result_message_success_shape() -> None:
+    """Per Responses API: tool outputs are `function_call_output` items
+    correlated with their function_call sibling by `call_id`."""
     r = ToolResult(call_id="tc1", name="echo", data={"echoed": "hi"})
     msg = _tool_result_message(r)
-    assert msg["role"] == "tool"
-    assert msg["tool_call_id"] == "tc1"
-    assert msg["name"] == "echo"
-    # Content is JSON-stringified for the LLM.
-    assert isinstance(msg["content"], str)
-    assert "echoed" in msg["content"]
+    assert msg["type"] == "function_call_output"
+    assert msg["call_id"] == "tc1"
+    # Output is JSON-stringified for the LLM.
+    assert isinstance(msg["output"], str)
+    assert "echoed" in msg["output"]
 
 
 def test_tool_result_message_error_shape() -> None:
     r = ToolResult(call_id="tc1", name="echo", error="LibCal 503")
     msg = _tool_result_message(r)
-    assert msg["role"] == "tool"
-    assert "error" in msg["content"]
-    assert "LibCal 503" in msg["content"]
+    assert msg["type"] == "function_call_output"
+    assert msg["call_id"] == "tc1"
+    assert "error" in msg["output"]
+    assert "LibCal 503" in msg["output"]
 
 
 def test_tool_result_message_handles_non_json_safe_data() -> None:
@@ -314,8 +316,8 @@ def test_tool_result_message_handles_non_json_safe_data() -> None:
 
     r = ToolResult(call_id="tc1", name="x", data=Weird())
     msg = _tool_result_message(r)
-    assert isinstance(msg["content"], str)
-    assert msg["role"] == "tool"
+    assert msg["type"] == "function_call_output"
+    assert isinstance(msg["output"], str)
 
 
 def main() -> int:

--- a/ai-core/src/agent/test_tool_registry.py
+++ b/ai-core/src/agent/test_tool_registry.py
@@ -91,6 +91,31 @@ def test_as_openai_tools_empty_registry() -> None:
     assert ToolRegistry().as_openai_tools() == []
 
 
+def test_as_responses_tools_shape() -> None:
+    """Responses-API tools are internally-tagged: name/description/
+    parameters at the top level, no `function` wrapper, strict=True
+    by default per the migration guide."""
+    reg = ToolRegistry()
+    reg.register(_basic_tool("a"))
+    reg.register(_basic_tool("b"))
+    schema = reg.as_responses_tools()
+    assert len(schema) == 2
+    for entry in schema:
+        assert entry["type"] == "function"
+        # No nested wrapper.
+        assert "function" not in entry
+        # Top-level keys (the Responses-API contract).
+        assert entry["name"] in {"a", "b"}
+        assert "description" in entry
+        assert "parameters" in entry
+        # Strict by default per the Responses migration guide.
+        assert entry["strict"] is True
+
+
+def test_as_responses_tools_empty_registry() -> None:
+    assert ToolRegistry().as_responses_tools() == []
+
+
 # --- dispatch: success / errors ---
 
 
@@ -181,6 +206,8 @@ def main() -> int:
         test_register_duplicate_raises,
         test_as_openai_tools_shape,
         test_as_openai_tools_empty_registry,
+        test_as_responses_tools_shape,
+        test_as_responses_tools_empty_registry,
         test_dispatch_unknown_tool_returns_error_result,
         test_dispatch_success_returns_data_and_latency,
         test_dispatch_tool_error_returns_structured_error,

--- a/ai-core/src/agent/tool_registry.py
+++ b/ai-core/src/agent/tool_registry.py
@@ -126,12 +126,12 @@ class ToolRegistry:
         return self.tools.get(name)
 
     def as_openai_tools(self) -> list[dict]:
-        """Serialize the registry as the shape OpenAI's tools= param
-        expects: `[{"type": "function", "function": {...}}, ...]`.
+        """Serialize the registry in the legacy Chat-Completions tools shape:
+        `[{"type": "function", "function": {name, description, parameters}}, ...]`.
 
-        Kept here rather than inline in the agent loop so a future
-        schema bump (e.g. OpenAI renames `function` to something
-        else) is one change in one place.
+        Kept for the legacy code path. New code should use
+        `as_responses_tools()` -- the Responses API uses an
+        internally-tagged shape with no `function` wrapper.
         """
         return [
             {
@@ -141,6 +141,33 @@ class ToolRegistry:
                     "description": t.description,
                     "parameters": t.parameters,
                 },
+            }
+            for t in self.tools.values()
+        ]
+
+    def as_responses_tools(self) -> list[dict]:
+        """Serialize the registry in the Responses-API internally-tagged
+        shape: `[{"type": "function", "name", "description", "parameters",
+        "strict": True}, ...]`.
+
+        Two differences from `as_openai_tools()`:
+          - No nested `function` wrapper -- name/description/parameters
+            sit at the top level of each tool item.
+          - `strict: True` by default. Per the Responses migration
+            guide: "In the Responses API, functions ARE strict by
+            default" (vs Chat Completions where they're non-strict by
+            default). Strict mode forces argument JSON to exactly
+            match the schema -- the same enforcement as Structured
+            Outputs and the only sane default for tools we'll
+            actually dispatch.
+        """
+        return [
+            {
+                "type": "function",
+                "name": t.name,
+                "description": t.description,
+                "parameters": t.parameters,
+                "strict": True,
             }
             for t in self.tools.values()
         ]

--- a/ai-core/src/llm/client.py
+++ b/ai-core/src/llm/client.py
@@ -19,27 +19,34 @@ Why centralize:
      stubs; prod calls these helpers.
 
 ================================================================================
-FRESHNESS RULE -- READ BEFORE EDITING
-================================================================================
-Per plan ("Model & API freshness rule"):
-  - Before adding / changing ANY of: model identifier strings,
-    structured-output schema syntax, prompt-caching headers,
-    tool/function calling shape, streaming, or the openai SDK call
-    signature -- FETCH the live OpenAI docs at
-    https://platform.openai.com/docs and confirm:
-      (1) the exact model identifier string
-      (2) supported parameters (some models drop temperature, change
-          max_tokens semantics, etc.)
-      (3) current structured-output / response-format syntax
-      (4) prompt-cache prefix length and headers
+FRESHNESS RULE -- VERIFIED 2026-04-25 against the OpenAI Responses API
+migration guide. This module is wired against the **Responses API**
+(not legacy Chat Completions), per OpenAI's recommendation that
+"Responses is recommended for all new projects".
 
-  - Do NOT rely on training-data memory of older OpenAI APIs -- model
-    families change call shapes frequently.
-  - If the docs cannot be reached, STOP and ask before writing code.
+Key differences from Chat Completions that this module embodies:
+  - `client.responses.create(...)` not `client.chat.completions.create(...)`.
+  - Stable system prefix goes in `instructions=` (top-level), dynamic
+    portion in `input=`. This pairs cleanly with prompts/builder.py's
+    [stable prefix] + [dynamic suffix] discipline -- the same prefix
+    string is used as `instructions` on every call, maximizing the
+    cache prefix.
+  - Structured outputs use `text={"format": {...}}` not `response_format`.
+  - Tools are internally-tagged: `{type: "function", name, description,
+    parameters, strict}` -- NOT the Chat Completions outer wrapper
+    `{type: "function", function: {...}}`.
+  - Function calls come back as items in `response.output` with
+    `type: "function_call"`, `call_id`, `name`, `arguments` (JSON-string).
+  - Function-call results are passed back as input items of type
+    `function_call_output` with the matching `call_id`.
+  - Usage shape: `response.usage.input_tokens`,
+    `response.usage.input_tokens_details.cached_tokens` (when present),
+    `response.usage.output_tokens`.
+  - We pass `store=False` everywhere -- the bot's persistence happens in
+    Postgres (Conversation/Message), not in OpenAI's stateful storage.
+    This keeps us ZDR-compatible by default.
 
-The functions below intentionally raise NotImplementedError until that
-verification is performed. Replace the bodies after consulting the
-docs.
+If OpenAI changes any of the above, re-verify here before editing.
 ================================================================================
 
 See plan:
@@ -50,8 +57,14 @@ See plan:
 
 from __future__ import annotations
 
+import json
+import logging
 from dataclasses import dataclass
 from typing import Any, Optional
+
+from src.agent.tool_registry import ToolCall
+
+logger = logging.getLogger(__name__)
 
 
 # --- Shared shapes --------------------------------------------------------
@@ -84,36 +97,87 @@ class LLMUsage:
         }
 
 
-# --- Guard ---------------------------------------------------------------
+# --- SDK client (lazy) ----------------------------------------------------
 
-_NOT_WIRED_MESSAGE = (
-    "OpenAI client call not wired. Per the plan's freshness rule, fetch "
-    "live OpenAI docs (https://platform.openai.com/docs) for the target "
-    "model identifier ('gpt-5.4-mini' / 'gpt-5.2' / 'text-embedding-3-large') "
-    "and confirm: (1) exact id string, (2) supported parameters, (3) "
-    "structured-output / response-format syntax, (4) prompt-cache prefix "
-    "length and headers. Then replace this function body. Do NOT rely on "
-    "training-data memory of older OpenAI APIs."
-)
+_client: Any = None
 
 
-def _ensure_wired() -> None:
-    raise NotImplementedError(_NOT_WIRED_MESSAGE)
+def _get_client() -> Any:
+    """Return a memoized OpenAI client. Imported lazily so test envs
+    without OPENAI_API_KEY can still import this module."""
+    global _client
+    if _client is None:
+        from openai import OpenAI  # type: ignore[import-not-found]
+
+        _client = OpenAI()
+    return _client
 
 
-# --- Public helpers (each gated until verified) ---------------------------
+# --- Usage parsing --------------------------------------------------------
+
+
+def _usage_from_response(response: Any) -> LLMUsage:
+    """Pull token counts off the Responses-API response.
+
+    Defensive about field presence: not every SDK version exposes
+    `input_tokens_details` on every model. Missing cached count is
+    treated as zero (worst-case overcount of billable tokens, which
+    is the safe direction).
+    """
+    usage = getattr(response, "usage", None)
+    if usage is None:
+        return LLMUsage()
+
+    input_tokens = int(getattr(usage, "input_tokens", 0) or 0)
+    output_tokens = int(getattr(usage, "output_tokens", 0) or 0)
+
+    cached = 0
+    details = getattr(usage, "input_tokens_details", None)
+    if details is not None:
+        cached = int(getattr(details, "cached_tokens", 0) or 0)
+
+    return LLMUsage(
+        input_tokens=input_tokens,
+        cached_input_tokens=cached,
+        output_tokens=output_tokens,
+    )
+
+
+# --- Prefix lookup --------------------------------------------------------
+
+
+def _resolve_prefix(prefix_id: str) -> str:
+    """Look up a registered prompt prefix by id.
+
+    The prompts/builder registry is the source of truth -- this module
+    pulls the stable text from there so the byte-stability assertions
+    apply to every Responses API call too. The prefix is passed as the
+    Responses API's top-level `instructions=` field, where it serves
+    as the cached system prefix.
+    """
+    from src.prompts.builder import _REGISTRY, PromptBuildError
+
+    entry = _REGISTRY.get(prefix_id)
+    if entry is None:
+        raise PromptBuildError(
+            f"unknown prefix_id {prefix_id!r}. Did you forget to import "
+            f"the prompt module so its register_prefix() call runs?"
+        )
+    return entry["content"]
+
+
+# --- Public helpers -------------------------------------------------------
 
 
 def embed(text: str, *, model: str = "text-embedding-3-large") -> list[float]:
     """Embed one piece of text. Used by intent_knn and (future) by
     retrieval-time query embedding.
 
-    Wiring TODO (after freshness check):
-        client.embeddings.create(model=model, input=text)
-        return resp.data[0].embedding
+    Embeddings API call shape is stable across openai SDK versions and
+    independent of the Responses-vs-Chat-Completions split.
     """
-    _ensure_wired()
-    return []  # unreachable; satisfies static type checkers
+    resp = _get_client().embeddings.create(model=model, input=text)
+    return list(resp.data[0].embedding)
 
 
 def completion(
@@ -123,22 +187,24 @@ def completion(
     model: str = "gpt-5.4-mini",
     max_output_tokens: int = 800,
 ) -> tuple[str, LLMUsage]:
-    """Plain text completion. Goes through prompts/builder so the cache
-    prefix is byte-stable.
+    """Plain text completion via the Responses API.
 
-    Wiring TODO (after freshness check):
-        from src.prompts.builder import build_prompt
-        messages = build_prompt(prefix_id, [{'role': 'user', 'content': dynamic_suffix}])
-        resp = client.chat.completions.create(model=model, messages=messages, ...)
-        usage = LLMUsage(
-            input_tokens=resp.usage.prompt_tokens,
-            cached_input_tokens=resp.usage.prompt_tokens_details.cached_tokens,
-            output_tokens=resp.usage.completion_tokens,
-        )
-        return resp.choices[0].message.content, usage
+    The cached prefix lives in `instructions=`; the dynamic portion
+    becomes `input=`. This split is what makes prompt caching work --
+    `instructions` is byte-stable across calls (registered at module
+    import via prompts/builder.register_prefix), `input` is what
+    changes per turn.
     """
-    _ensure_wired()
-    return "", LLMUsage()
+    instructions = _resolve_prefix(prefix_id)
+    response = _get_client().responses.create(
+        model=model,
+        instructions=instructions,
+        input=dynamic_suffix,
+        max_output_tokens=max_output_tokens,
+        store=False,
+    )
+    text = getattr(response, "output_text", "") or ""
+    return text, _usage_from_response(response)
 
 
 def structured_completion(
@@ -146,40 +212,123 @@ def structured_completion(
     prefix_id: str,
     dynamic_suffix: str,
     response_schema: dict,
+    schema_name: str = "structured_output",
     model: str = "gpt-5.4-mini",
 ) -> tuple[dict, LLMUsage]:
     """Completion that returns JSON matching `response_schema`. This is
     the call the synthesizer makes -- the schema is
     `{answer, citations, confidence}`.
 
-    Wiring TODO (after freshness check): use the structured-output /
-    json-schema response_format param per the docs. The exact param
-    name and schema-version key changes across model generations --
-    confirm at code-change time."""
-    _ensure_wired()
-    return {}, LLMUsage()
+    Per the Responses API, structured outputs go in
+    `text={"format": {"type": "json_schema", "name": ..., "strict": True,
+    "schema": ...}}`. `output_text` returns the JSON string, which we
+    parse here so the caller gets a dict.
+    """
+    instructions = _resolve_prefix(prefix_id)
+    response = _get_client().responses.create(
+        model=model,
+        instructions=instructions,
+        input=dynamic_suffix,
+        text={
+            "format": {
+                "type": "json_schema",
+                "name": schema_name,
+                "strict": True,
+                "schema": response_schema,
+            }
+        },
+        store=False,
+    )
+    raw_text = getattr(response, "output_text", "") or ""
+    try:
+        parsed = json.loads(raw_text) if raw_text else {}
+    except json.JSONDecodeError as e:
+        # With strict json_schema this should be impossible. If it
+        # happens, the synthesizer's downstream post-processor will
+        # see an empty answer and refuse with model_self_flagged --
+        # log loudly so it's debuggable.
+        logger.error(
+            "structured_completion: json decode failed",
+            extra={"error": str(e), "raw_text_preview": raw_text[:200]},
+        )
+        parsed = {}
+    return parsed, _usage_from_response(response)
 
 
 def completion_with_tools(
     *,
     prefix_id: str,
-    messages: list[dict],
+    input_items: list[dict],
     tools: list[dict],
     model: str = "gpt-5.4-mini",
-) -> tuple[dict, list[Any], LLMUsage]:
-    """Tool-calling completion. This is the call the agent loop makes.
+) -> tuple[dict, list[ToolCall], LLMUsage]:
+    """Tool-calling completion via the Responses API.
 
-    Returns `(assistant_message, tool_calls, usage)`. `tool_calls` is
-    a list of `ToolCall` objects (defined in src/agent/tool_registry).
-    The mapping from raw OpenAI tool_calls to ToolCall happens here so
-    the agent module doesn't have to know the SDK shape.
+    `input_items` is a list of Items in the Responses-API shape:
+    user/assistant message dicts and prior `function_call_output`
+    items from earlier turns of the agent loop. The agent loop
+    appends to this list across iterations.
 
-    Wiring TODO (after freshness check): tool-call response shape has
-    changed across the gpt-4 / gpt-5 transition; confirm whether
-    `tool_calls` lives on `message.tool_calls` or in a `function_call`
-    field, and whether arguments are str-encoded JSON or pre-parsed."""
-    _ensure_wired()
-    return {}, [], LLMUsage()
+    `tools` must be in the Responses-API internally-tagged shape:
+        {"type": "function", "name": ..., "description": ...,
+         "parameters": ..., "strict": True}
+    Use `ToolRegistry.as_responses_tools()` to get them in this shape.
+
+    Returns `(assistant_message, tool_calls, usage)`. `assistant_message`
+    is a single dict suitable to append to `input_items` for the next
+    turn (we re-shape Responses output items into one consolidated
+    "assistant message" record for the agent loop's bookkeeping).
+    `tool_calls` is the parsed list of ToolCall objects -- the agent
+    module doesn't have to know the Responses-API SDK shape.
+    """
+    instructions = _resolve_prefix(prefix_id)
+    response = _get_client().responses.create(
+        model=model,
+        instructions=instructions,
+        input=input_items,
+        tools=tools,
+        store=False,
+    )
+
+    output_items: list[Any] = list(getattr(response, "output", []) or [])
+
+    # Parse function_call items into ToolCall objects. Arguments come
+    # back as a JSON-encoded string per the Responses API contract; we
+    # decode them here so the agent module receives a plain dict.
+    tool_calls: list[ToolCall] = []
+    for item in output_items:
+        item_type = _item_attr(item, "type")
+        if item_type != "function_call":
+            continue
+        call_id = _item_attr(item, "call_id") or _item_attr(item, "id") or ""
+        name = _item_attr(item, "name") or ""
+        raw_args = _item_attr(item, "arguments") or "{}"
+        try:
+            args = json.loads(raw_args) if isinstance(raw_args, str) else dict(raw_args)
+        except json.JSONDecodeError:
+            args = {"_raw": raw_args}
+        tool_calls.append(ToolCall(id=call_id, name=name, arguments=args))
+
+    # Build a single dict to represent "what the LLM said" for the
+    # agent loop's `last_tool_call_key` bookkeeping and conversation
+    # extension. We preserve the raw output items list so callers can
+    # round-trip them back into the next request's input.
+    text_output = getattr(response, "output_text", "") or ""
+    assistant_message = {
+        "role": "assistant",
+        "content": text_output,
+        "_response_output_items": output_items,
+    }
+
+    return assistant_message, tool_calls, _usage_from_response(response)
+
+
+def _item_attr(item: Any, name: str) -> Any:
+    """Read an attribute from a Responses-API output item that may be
+    an SDK pydantic object OR a plain dict (test stubs)."""
+    if isinstance(item, dict):
+        return item.get(name)
+    return getattr(item, name, None)
 
 
 __all__ = [

--- a/ai-core/src/llm/test_client.py
+++ b/ai-core/src/llm/test_client.py
@@ -1,0 +1,356 @@
+"""
+Unit tests for src/llm/client.py — the OpenAI Responses-API wrapper.
+
+Run: `python -m src.llm.test_client` from ai-core/.
+
+Strategy: monkeypatch `_get_client()` to return a stub that records
+the kwargs the wrapper sent to `responses.create` and returns canned
+output items. We verify both directions:
+  - Inbound (request shape): instructions=registered prefix, input
+    matches what the caller passed, store=False, structured-output
+    schema in text.format, tools in internally-tagged shape.
+  - Outbound (response parsing): output_text is returned for plain
+    completions, JSON is parsed for structured_completion, function_call
+    items are decoded into ToolCall(id, name, arguments=dict), usage
+    is pulled off response.usage including cached_tokens.
+
+Tests:
+  1. embed: shape passes through SDK correctly.
+  2. completion: instructions=prefix, input=suffix, store=False, no
+     text.format, returns output_text + usage.
+  3. structured_completion: text.format set with json_schema strict,
+     output_text JSON parsed into dict.
+  4. structured_completion: invalid JSON returns empty dict (caller's
+     post-processor fires model_self_flagged refusal).
+  5. completion_with_tools: tools passed through, function_call items
+     parsed into ToolCall objects with decoded arguments dict.
+  6. completion_with_tools: assistant_message wrapper preserves the
+     raw output items list under _response_output_items.
+  7. _resolve_prefix: unknown id raises PromptBuildError.
+  8. Usage parsing: cached_tokens read from input_tokens_details.
+  9. Usage parsing: missing usage block returns zeros (defensive).
+ 10. _item_attr handles both dict items and pydantic-ish objects.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+# Allow running from ai-core/ as `python -m src.llm.test_client`.
+_HERE = Path(__file__).resolve().parent
+_AI_CORE = _HERE.parent.parent
+sys.path.insert(0, str(_AI_CORE))
+
+from src.agent.tool_registry import ToolCall  # noqa: E402
+from src.llm import client as client_module  # noqa: E402
+from src.llm.client import (  # noqa: E402
+    LLMUsage,
+    _item_attr,
+    _resolve_prefix,
+    _usage_from_response,
+    completion,
+    completion_with_tools,
+    embed,
+    structured_completion,
+)
+from src.prompts.builder import PromptBuildError, register_prefix  # noqa: E402
+
+
+# --- Stubs ---------------------------------------------------------------
+
+
+class StubResponses:
+    """Stub for client.responses.create."""
+
+    def __init__(self, return_value: Any):
+        self.return_value = return_value
+        self.calls: list[dict] = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.return_value
+
+
+class StubEmbeddings:
+    def __init__(self, vec: list[float]):
+        self.vec = vec
+        self.calls: list[dict] = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return SimpleNamespace(data=[SimpleNamespace(embedding=self.vec)])
+
+
+class StubClient:
+    def __init__(self, responses_return: Any = None, embeddings_vec: list[float] = None):
+        self.responses = StubResponses(responses_return)
+        self.embeddings = StubEmbeddings(embeddings_vec or [])
+
+
+def _install_stub(stub: StubClient) -> None:
+    """Replace the cached _client with our stub."""
+    client_module._client = stub
+
+
+def _make_response(
+    *,
+    output_text: str = "",
+    output_items: list = None,
+    usage: dict = None,
+) -> Any:
+    """Build a SimpleNamespace that mimics a Responses-API response."""
+    usage_ns = None
+    if usage:
+        details = None
+        if "cached_tokens" in usage:
+            details = SimpleNamespace(cached_tokens=usage["cached_tokens"])
+        usage_ns = SimpleNamespace(
+            input_tokens=usage.get("input_tokens", 0),
+            output_tokens=usage.get("output_tokens", 0),
+            input_tokens_details=details,
+        )
+    return SimpleNamespace(
+        output_text=output_text,
+        output=output_items or [],
+        usage=usage_ns,
+    )
+
+
+def _ensure_test_prefix() -> None:
+    """Register a test prefix so _resolve_prefix has something to find."""
+    try:
+        register_prefix("test_client_prefix_v1", "STABLE TEST PREFIX " * 50)
+    except PromptBuildError:
+        pass  # already registered
+
+
+# --- Tests --------------------------------------------------------------
+
+
+def test_embed_passes_text_and_returns_vector() -> None:
+    stub = StubClient(embeddings_vec=[0.1, 0.2, 0.3])
+    _install_stub(stub)
+    result = embed("hello", model="text-embedding-3-large")
+    assert result == [0.1, 0.2, 0.3]
+    assert stub.embeddings.calls[0] == {
+        "model": "text-embedding-3-large",
+        "input": "hello",
+    }
+
+
+def test_completion_request_shape() -> None:
+    _ensure_test_prefix()
+    stub = StubClient(responses_return=_make_response(
+        output_text="hi back",
+        usage={"input_tokens": 100, "cached_tokens": 80, "output_tokens": 20},
+    ))
+    _install_stub(stub)
+    text, usage = completion(
+        prefix_id="test_client_prefix_v1",
+        dynamic_suffix="hello",
+        model="gpt-5.4-mini",
+    )
+    assert text == "hi back"
+    assert usage.input_tokens == 100
+    assert usage.cached_input_tokens == 80
+    assert usage.output_tokens == 20
+
+    call = stub.responses.calls[0]
+    # Instructions = the registered stable prefix; not empty.
+    assert call["instructions"].startswith("STABLE TEST PREFIX")
+    # Dynamic suffix passes through verbatim.
+    assert call["input"] == "hello"
+    # store=False (ZDR-friendly default).
+    assert call["store"] is False
+    # No text.format on plain completion.
+    assert "text" not in call
+
+
+def test_structured_completion_sets_text_format_and_parses_json() -> None:
+    _ensure_test_prefix()
+    schema = {"type": "object", "required": ["x"], "properties": {"x": {"type": "integer"}}}
+    canned = json.dumps({"x": 42})
+    stub = StubClient(responses_return=_make_response(
+        output_text=canned,
+        usage={"input_tokens": 200, "cached_tokens": 150, "output_tokens": 5},
+    ))
+    _install_stub(stub)
+    parsed, usage = structured_completion(
+        prefix_id="test_client_prefix_v1",
+        dynamic_suffix="extract this",
+        response_schema=schema,
+        schema_name="my_schema",
+    )
+    assert parsed == {"x": 42}
+    assert usage.cached_input_tokens == 150
+
+    call = stub.responses.calls[0]
+    assert call["text"]["format"]["type"] == "json_schema"
+    assert call["text"]["format"]["name"] == "my_schema"
+    assert call["text"]["format"]["strict"] is True
+    assert call["text"]["format"]["schema"] == schema
+
+
+def test_structured_completion_handles_invalid_json() -> None:
+    """If the model somehow returns non-JSON despite strict mode, we
+    return {} so the synthesizer's post_processor fires a refusal
+    rather than crashing the request."""
+    _ensure_test_prefix()
+    stub = StubClient(responses_return=_make_response(output_text="not json {"))
+    _install_stub(stub)
+    parsed, _ = structured_completion(
+        prefix_id="test_client_prefix_v1",
+        dynamic_suffix="x",
+        response_schema={},
+    )
+    assert parsed == {}
+
+
+def test_completion_with_tools_parses_function_calls() -> None:
+    _ensure_test_prefix()
+    output_items = [
+        {
+            "type": "function_call",
+            "call_id": "call_123",
+            "name": "search_kb",
+            "arguments": json.dumps({"query": "King hours", "scope": "oxford"}),
+        },
+    ]
+    stub = StubClient(responses_return=_make_response(
+        output_text="",  # no text portion when only function_call returned
+        output_items=output_items,
+        usage={"input_tokens": 500, "cached_tokens": 400, "output_tokens": 30},
+    ))
+    _install_stub(stub)
+    tools = [{"type": "function", "name": "search_kb", "description": "...",
+              "parameters": {"type": "object"}, "strict": True}]
+    msg, calls, usage = completion_with_tools(
+        prefix_id="test_client_prefix_v1",
+        input_items=[{"role": "user", "content": "King hours?"}],
+        tools=tools,
+        model="gpt-5.4-mini",
+    )
+    assert len(calls) == 1
+    assert calls[0].id == "call_123"
+    assert calls[0].name == "search_kb"
+    # Arguments decoded from JSON string into dict.
+    assert calls[0].arguments == {"query": "King hours", "scope": "oxford"}
+    # Token usage parsed.
+    assert usage.input_tokens == 500
+    assert usage.cached_input_tokens == 400
+    # Assistant message wrapper preserves raw output items for
+    # round-tripping into the next agent-loop input.
+    assert msg["_response_output_items"] == output_items
+
+
+def test_completion_with_tools_no_tool_calls_terminal() -> None:
+    _ensure_test_prefix()
+    stub = StubClient(responses_return=_make_response(
+        output_text="Final answer: 7am to 2am.",
+        output_items=[],
+        usage={"input_tokens": 300, "output_tokens": 15},
+    ))
+    _install_stub(stub)
+    msg, calls, usage = completion_with_tools(
+        prefix_id="test_client_prefix_v1",
+        input_items=[{"role": "user", "content": "King hours?"}],
+        tools=[],
+        model="gpt-5.4-mini",
+    )
+    assert calls == []
+    assert msg["content"] == "Final answer: 7am to 2am."
+    assert usage.output_tokens == 15
+
+
+def test_resolve_prefix_unknown_id_raises() -> None:
+    try:
+        _resolve_prefix("nonexistent_prefix_v999")
+    except PromptBuildError as e:
+        assert "nonexistent_prefix_v999" in str(e)
+        return
+    raise AssertionError("expected PromptBuildError for unknown prefix")
+
+
+def test_usage_parsing_with_cached_tokens() -> None:
+    response = _make_response(
+        usage={"input_tokens": 1000, "cached_tokens": 800, "output_tokens": 50},
+    )
+    usage = _usage_from_response(response)
+    assert usage.input_tokens == 1000
+    assert usage.cached_input_tokens == 800
+    assert usage.output_tokens == 50
+    assert usage.cache_hit_rate == 0.8
+
+
+def test_usage_parsing_no_usage_block_returns_zeros() -> None:
+    """Defensive: a response missing the usage block (rare but possible
+    on streaming or error edge cases) shouldn't crash the wrapper."""
+    response = SimpleNamespace(output_text="", output=[])
+    usage = _usage_from_response(response)
+    assert usage.input_tokens == 0
+    assert usage.cached_input_tokens == 0
+    assert usage.output_tokens == 0
+
+
+def test_usage_parsing_no_input_tokens_details() -> None:
+    """Some models / SDK versions don't expose input_tokens_details.
+    Cached count defaults to 0 (worst-case overcount of billable
+    tokens, which is the safe direction)."""
+    response = SimpleNamespace(
+        output_text="",
+        output=[],
+        usage=SimpleNamespace(input_tokens=100, output_tokens=10, input_tokens_details=None),
+    )
+    usage = _usage_from_response(response)
+    assert usage.input_tokens == 100
+    assert usage.cached_input_tokens == 0
+    assert usage.output_tokens == 10
+
+
+def test_item_attr_handles_dict_and_object() -> None:
+    """Output items can be either dicts (test stubs) or pydantic-ish
+    objects (real SDK). _item_attr abstracts the difference."""
+    assert _item_attr({"name": "x"}, "name") == "x"
+    assert _item_attr({"name": "x"}, "missing") is None
+    obj = SimpleNamespace(name="y")
+    assert _item_attr(obj, "name") == "y"
+    assert _item_attr(obj, "missing") is None
+
+
+def main() -> int:
+    tests = [
+        test_embed_passes_text_and_returns_vector,
+        test_completion_request_shape,
+        test_structured_completion_sets_text_format_and_parses_json,
+        test_structured_completion_handles_invalid_json,
+        test_completion_with_tools_parses_function_calls,
+        test_completion_with_tools_no_tool_calls_terminal,
+        test_resolve_prefix_unknown_id_raises,
+        test_usage_parsing_with_cached_tokens,
+        test_usage_parsing_no_usage_block_returns_zeros,
+        test_usage_parsing_no_input_tokens_details,
+        test_item_attr_handles_dict_and_object,
+    ]
+    failed = 0
+    for t in tests:
+        try:
+            # Reset client between tests so stubs don't bleed.
+            client_module._client = None
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:
+            failed += 1
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ai-core/src/synthesis/synthesizer.py
+++ b/ai-core/src/synthesis/synthesizer.py
@@ -216,26 +216,84 @@ class SynthesizerLLM(Protocol):
         ...
 
 
+# JSON schema for the synthesizer's structured output. Passed to the
+# Responses API as `text.format` so the model is forced to produce a
+# matching shape -- no need for downstream JSON-repair / regex parsing.
+# Keep this OUTSIDE _default_llm_call so byte-stability of the prompt
+# prefix isn't accidentally tied to schema bytes.
+_SYNTHESIZER_OUTPUT_SCHEMA: dict = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["answer", "citations", "confidence"],
+    "properties": {
+        "answer": {
+            "type": "string",
+            "description": "The grounded answer to the user's question. "
+                           "Use [n] markers to cite items in `citations`.",
+        },
+        "citations": {
+            "type": "array",
+            "description": "Numbered citations the model used. Empty list "
+                           "is valid for refusals or 'no sources' answers.",
+            "items": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": ["n", "url", "snippet"],
+                "properties": {
+                    "n": {
+                        "type": "integer",
+                        "description": "1-indexed citation number "
+                                       "matching the [n] markers in `answer`.",
+                    },
+                    "url": {
+                        "type": "string",
+                        "description": "Source URL from the evidence bundle.",
+                    },
+                    "snippet": {
+                        "type": "string",
+                        "description": "Short quote (~50-150 chars) from the "
+                                       "source, shown in the citation chip.",
+                    },
+                },
+            },
+        },
+        "confidence": {
+            "type": "string",
+            "enum": ["low", "medium", "high"],
+            "description": "Self-reported confidence in the grounded answer. "
+                           "Use 'low' to trigger a post-processor refusal.",
+        },
+    },
+}
+
+
 def _default_llm_call(
     *,
     prefix_id: str,
     dynamic_suffix: str,
     model: str,
 ) -> tuple[dict, dict]:
-    """Placeholder LLM call. Replaced when src/llm/client.py lands.
+    """Real synthesizer call via the Responses API + structured outputs.
 
-    Raises NotImplementedError deliberately so an accidentally-live
-    synthesizer call surfaces immediately during development rather
-    than silently shipping a stub answer. Tests pass a stub via the
-    `llm` argument to `synthesize()` and never hit this.
+    Per the Responses migration guide, structured outputs go in
+    `text={"format": {"type": "json_schema", "name", "strict",
+    "schema"}}`. The output_text helper returns the JSON string, which
+    src/llm/client.structured_completion parses for us. The result is
+    a dict matching _SYNTHESIZER_OUTPUT_SCHEMA above; SynthesisRequest
+    -> parse_synthesizer_response then joins each citation back to its
+    evidence chunk so the post-processor's cross-campus check has the
+    metadata it needs.
     """
-    raise NotImplementedError(
-        "Synthesizer LLM client not yet wired. Wire src/llm/client.py "
-        "(see plan: Model & API freshness rule -- check OpenAI docs "
-        "before writing the call shape) and pass it as the `llm` "
-        "argument to synthesize(), or monkeypatch _default_llm_call "
-        "for tests."
+    from src.llm.client import structured_completion
+
+    parsed, usage = structured_completion(
+        prefix_id=prefix_id,
+        dynamic_suffix=dynamic_suffix,
+        response_schema=_SYNTHESIZER_OUTPUT_SCHEMA,
+        schema_name="synthesizer_output",
+        model=model,
     )
+    return parsed, usage.as_dict()
 
 
 # --- Top-level orchestration ----------------------------------------------


### PR DESCRIPTION
## Summary
The freshness rule has been satisfied (you provided the Responses API migration guide). This PR wires the four LLM helpers in `src/llm/client.py` against the **Responses API** — OpenAI's recommended API for new projects, not the legacy Chat Completions.

## Why Responses API (not Chat Completions)
Direct quotes from the migration guide you supplied:
- **"Responses is recommended for all new projects."**
- **40–80% better cache utilization** vs Chat Completions in OpenAI's internal tests — directly serves the Layer 4 cost-savings target.
- **"Starting with GPT-5.4, tool calling is not supported in Chat Completions with reasoning: none"** — Chat Completions is a dead end for the agent loop.
- Native multi-tool agentic loop in one API call.

## What changed

### `src/llm/client.py` — all four helpers wired
| Helper | What it calls now |
|---|---|
| `embed()` | `client.embeddings.create(...)` (call shape stable across SDK versions) |
| `completion()` | `client.responses.create(instructions=, input=, store=False)` |
| `structured_completion()` | adds `text={"format": {"type": "json_schema", "name", "strict": True, "schema"}}`, parses `output_text` → dict |
| `completion_with_tools()` | `tools=` in internally-tagged shape; parses `function_call` items from `response.output` into `ToolCall(id, name, arguments=dict)` |

`_usage_from_response()` reads `input_tokens`, `output_tokens`, and `input_tokens_details.cached_tokens` defensively.

### `src/agent/tool_registry.py`
- New `as_responses_tools()` returns the internally-tagged shape with `strict: True` (per migration guide: *"functions ARE strict by default"* in Responses).
- Legacy `as_openai_tools()` kept for backward compat.

### `src/agent/agent.py`
- `_default_llm_call` → calls `completion_with_tools`.
- Loop uses `as_responses_tools()`.
- `_tool_result_message` → returns `{"type": "function_call_output", "call_id", "output"}` (Responses shape) instead of legacy `{"role": "tool", ...}`.
- Loop's feed-back step appends the raw output items list (so `function_call` items round-trip with their `function_call_output` siblings by `call_id`), with a fallback for test stubs.

### `src/synthesis/synthesizer.py`
- `_SYNTHESIZER_OUTPUT_SCHEMA` defined at module level (kept off the hot path so byte-stability of the prompt prefix isn't tied to schema bytes).
- `_default_llm_call` → `structured_completion` with the schema.

## ZDR-friendly by default
`store=False` on every call. The bot's persistence happens in Postgres (`Conversation` / `Message`); we don't need OpenAI's stateful storage.

## Tests — 116/116 passing across all affected modules
```
src.agent.test_tool_registry      13/13  (+2 new for as_responses_tools)
src.agent.test_agent              14/14  (updated for new shape)
src.synthesis.test_synthesizer    16/16  unchanged
src.synthesis.test_post_processor 16/16  unchanged
src.synthesis.test_refusal_templates 8/8 unchanged
src.synthesis.test_corrections    15/15  unchanged
src.llm.test_client               11/11  NEW (Responses API request/response shape)
src.prompts.test_builder           9/9   unchanged
src.router.test_intent_knn        14/14  unchanged
```

`test_client.py` uses a stub client to verify both directions:
- **Inbound** (request shape): `instructions=` matches the registered prefix, `input=` matches the dynamic suffix, `store=False`, structured-output schema in `text.format`, tools in internally-tagged shape with `strict: true`.
- **Outbound** (response parsing): `output_text` returned for plain completions, JSON parsed for structured, `function_call` items decoded into `ToolCall` with `arguments` as `dict`, usage with cached tokens, defensive zero-fill when `usage` block missing.

## Test plan
- [x] All 9 affected test modules pass (116/116 total)
- [x] `test_client.py` runs without `OPENAI_API_KEY` (uses stub via `client_module._client = stub`)
- [ ] Smoke test against real OpenAI once `OPENAI_API_KEY` is in env (operator action — a single call to `embed("hello")` confirms wiring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)