### PR TITLE
LibChat transcript cleaner + exemplar packer + disk loader

### DIFF
--- a/ai-core/scripts/build_exemplars_jsonl.py
+++ b/ai-core/scripts/build_exemplars_jsonl.py
@@ -1,0 +1,146 @@
+"""
+Pack the librarian-labeled CSV into the JSONL the kNN classifier loads.
+
+Input:  ai-core/src/router/exemplars/exemplars_for_labeling.csv
+        (columns: utterance, suggested_intent, intent)
+Output: ai-core/src/router/exemplars/exemplars.jsonl
+        (one JSON object per line: {intent, utterance, source})
+
+Validation rules (this script REFUSES to write if any fire):
+  1. `intent` must be one of the 14 documented INTENTS in
+     src/router/intent_knn.INTENTS. Typo => fail loud (no silent
+     mislabels in the training data).
+  2. utterance must be non-empty and <= 250 chars (matches cleaner).
+  3. Each intent should have at least N exemplars (default 20). If any
+     intent is below the floor, write the file but exit non-zero so
+     CI / cron catches it.
+  4. Duplicate utterances within an intent => warning (not fatal).
+
+Run:
+    python scripts/build_exemplars_jsonl.py \\
+        --input ai-core/src/router/exemplars/exemplars_for_labeling.csv \\
+        --output ai-core/src/router/exemplars/exemplars.jsonl
+
+See plan: Layer 3 -> "Intent kNN classifier".
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_AI_CORE = _HERE.parent
+sys.path.insert(0, str(_AI_CORE))
+
+from src.router.intent_knn import INTENTS  # noqa: E402
+
+
+MIN_PER_INTENT_FLOOR = 20
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument(
+        "--input",
+        type=Path,
+        default=Path("ai-core/src/router/exemplars/exemplars_for_labeling.csv"),
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("ai-core/src/router/exemplars/exemplars.jsonl"),
+    )
+    parser.add_argument(
+        "--floor",
+        type=int,
+        default=MIN_PER_INTENT_FLOOR,
+        help=f"Minimum exemplars per intent (default {MIN_PER_INTENT_FLOOR}).",
+    )
+    args = parser.parse_args()
+
+    if not args.input.exists():
+        print(f"input not found: {args.input}", file=sys.stderr)
+        return 2
+
+    valid_intents = set(INTENTS)
+    rows: list[dict] = []
+    by_intent: dict[str, list[str]] = defaultdict(list)
+    bad_intent_rows: list[tuple[int, str, str]] = []
+
+    with open(args.input, encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for line_no, row in enumerate(reader, start=2):  # +1 header
+            utterance = (row.get("utterance") or "").strip()
+            intent = (row.get("intent") or "").strip()
+            if not intent:
+                continue  # unlabeled rows are skipped (librarian can iterate)
+            if not utterance:
+                continue
+            if len(utterance) > 250:
+                bad_intent_rows.append((line_no, intent, "utterance > 250 chars"))
+                continue
+            if intent not in valid_intents:
+                bad_intent_rows.append((line_no, intent, f"unknown intent {intent!r}"))
+                continue
+            rows.append({
+                "intent": intent,
+                "utterance": utterance,
+                "source": "libchat_2025",
+            })
+            by_intent[intent].append(utterance)
+
+    if bad_intent_rows:
+        print(f"REFUSING to write -- {len(bad_intent_rows)} invalid rows:", file=sys.stderr)
+        for line_no, intent, reason in bad_intent_rows[:20]:
+            print(f"  line {line_no}: {reason} (intent={intent!r})", file=sys.stderr)
+        print(f"\nValid intents: {sorted(valid_intents)}", file=sys.stderr)
+        return 3
+
+    # Coverage check
+    below_floor = []
+    for intent in INTENTS:
+        n = len(by_intent.get(intent, []))
+        if n < args.floor:
+            below_floor.append((intent, n))
+
+    # Write JSONL
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with open(args.output, "w", encoding="utf-8") as f:
+        for r in rows:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+
+    print(f"Wrote {len(rows)} exemplars to {args.output}")
+    print()
+    print("Per-intent counts:")
+    for intent in INTENTS:
+        n = len(by_intent.get(intent, []))
+        flag = " " if n >= args.floor else " ⚠"
+        print(f" {flag} {intent:30s} {n:4d}")
+
+    # Dup check (within intent)
+    for intent, utters in by_intent.items():
+        dups = [u for u, c in Counter(utters).items() if c > 1]
+        if dups:
+            print(f"\nWarning: {len(dups)} duplicate utterance(s) in {intent}:")
+            for d in dups[:5]:
+                print(f"  - {d!r}")
+
+    if below_floor:
+        print()
+        print(f"Below floor of {args.floor} exemplars -- file written but exiting nonzero:", file=sys.stderr)
+        for intent, n in below_floor:
+            print(f"  {intent}: {n}", file=sys.stderr)
+        return 1
+
+    print()
+    print(f"All {len(INTENTS)} intents at or above floor of {args.floor}. Ready to ship.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ai-core/scripts/clean_libchat_transcripts.py
+++ b/ai-core/scripts/clean_libchat_transcripts.py
@@ -1,0 +1,391 @@
+"""
+Clean LibChat transcript exports into a labeling-ready CSV for the
+intent-kNN classifier exemplar set.
+
+Run:
+    python scripts/clean_libchat_transcripts.py \\
+        --input /path/to/tran_raw_2025.csv \\
+        --output ai-core/src/router/exemplars/exemplars_for_labeling.csv
+
+Pipeline:
+  1. Read the LibChat CSV (the export schema as of 2025).
+  2. Pull `Initial Question` (the first user message of each session --
+     exactly what the kNN classifier sees at routing time).
+  3. Strip PII: emails, phone numbers, Bronco IDs, MUnetIDs.
+  4. Reject rows that are too short (< 10 chars), too long (> 250 chars),
+     or that look like account-help boilerplate the bot must NOT answer.
+  5. Normalize whitespace; dedupe by lowercased-stripped form.
+  6. Run keyword-based PRE-LABELING to give the librarian a head start.
+     Output column `suggested_intent` is the heuristic guess; `intent`
+     is left blank for the human to fill (override or accept).
+  7. Write a CSV with three columns:
+        utterance,suggested_intent,intent
+     Plus a coverage-report markdown to ./labeling_coverage_report.md
+     so the librarian can see how many candidates per intent.
+
+The librarian then opens the CSV, fills in the `intent` column (accept
+suggestion = copy from suggested_intent, override = type their own),
+saves. A second script `build_exemplars_jsonl.py` (TODO when labeling
+is done) consumes that file into ai-core/src/router/exemplars/exemplars.jsonl.
+
+See plan: Layer 3 -> "Intent kNN classifier".
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Optional
+
+
+# --- PII patterns ---------------------------------------------------------
+#
+# Drop entire row if any of these appear. These are the patterns we WILL
+# see in real LibChat data; the bot's classifier should never train on
+# them and the eval set must never log them.
+
+_EMAIL_RE = re.compile(r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}")
+_PHONE_RE = re.compile(r"\b(?:\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b")
+# Miami student/employee IDs are 8 digits. Stricter form: starts with
+# +<digit><7 more> -- avoids matching course numbers like "BIO 115".
+_BRONCO_ID_RE = re.compile(r"\b[89]\d{7}\b")
+# MUnetID == Miami's user account names; usually 6-8 chars + numbers.
+# If the user is asking about "my account smith21" -> drop. We're
+# conservative here: only flag if "munetid" or "my account" appears AND
+# a token that looks like a username.
+_ACCOUNT_BOILERPLATE_RE = re.compile(
+    r"\b(my account|my login|reset (my )?password|my munetid|munet id|my id (number|card))\b",
+    re.IGNORECASE,
+)
+
+# Hard-reject phrases: these are out-of-scope for the bot AND usually
+# wrap PII anyway (account-help / fines / patron-record questions).
+# Rather than label them out_of_scope, drop them entirely so the
+# `out_of_scope` cluster trains on cleaner negatives (catalog searches,
+# sports scores, etc.) rather than account-help noise.
+_HARD_REJECT_PHRASES = (
+    "i can't log in",
+    "i cannot log in",
+    "my account is locked",
+    "forgot my password",
+    "password reset",
+    "i was charged",
+    "remove the fine",
+    "remove a fine",
+    "waive the fine",
+    "my fines",
+)
+
+# Length bounds. Tuned to drop greetings and multi-question paragraphs
+# while keeping the sweet spot the kNN learns best from.
+MIN_LEN = 10
+MAX_LEN = 250
+
+
+# --- Greeting filter ------------------------------------------------------
+#
+# "Hi", "Hello", "Anyone there?" -- not useful for the classifier.
+
+_GREETING_RE = re.compile(
+    r"^(hi|hello|hey|good (morning|afternoon|evening)|"
+    r"anyone there|anybody there|is anyone here|is anyone there)\b[\s!?.,]*$",
+    re.IGNORECASE,
+)
+
+
+# --- Keyword pre-labeling -------------------------------------------------
+#
+# Maps each of the 14 intents to a list of (keyword, weight) tuples.
+# The PRE-LABELER picks the highest-scoring intent. Ties or zero score
+# -> "unknown" (librarian must pick).
+#
+# This is intentionally rough -- it's a head start for the librarian,
+# NOT the actual classifier. Kept readable so the librarian can
+# eyeball "did the keyword guess get this right" without reading code.
+
+_KEYWORDS: dict[str, list[tuple[str, float]]] = {
+    "hours": [
+        ("hours", 2.0), ("open", 1.0), ("close", 1.0), ("when does", 1.5),
+        ("what time", 1.5), ("closed", 1.0), ("opening time", 2.0),
+        ("closing time", 2.0), ("today", 0.5), ("tonight", 0.7),
+        ("weekend", 0.7), ("sunday", 0.7),
+    ],
+    "room_booking": [
+        ("book a room", 3.0), ("reserve a room", 3.0), ("study room", 2.0),
+        ("group study", 2.0), ("book a study", 3.0), ("reserve a study", 3.0),
+        ("room reservation", 2.5), ("conference room", 2.0),
+    ],
+    "librarian_lookup": [
+        ("subject librarian", 3.0), ("liaison", 2.5), ("librarian for", 2.5),
+        ("who is the librarian", 3.0), ("contact a librarian", 2.0),
+        ("subject specialist", 2.0),
+    ],
+    "service_howto": [
+        ("how do i print", 3.0), ("printing", 1.5), ("scan", 1.5),
+        ("scanner", 2.0), ("wifi", 2.0), ("wi-fi", 2.0), ("password",  0.0),  # password handled by reject
+        ("how do i", 0.5),
+    ],
+    "policy_question": [
+        ("loan period", 3.0), ("how long can i", 2.0), ("renew", 1.5),
+        ("food in the library", 2.0), ("can i bring", 1.0),
+        ("policy", 1.0), ("rules", 1.0), ("late fee", 2.0),
+    ],
+    "adobe_access": [
+        ("adobe", 3.0), ("photoshop", 3.0), ("illustrator", 3.0),
+        ("indesign", 3.0), ("premiere", 2.5), ("acrobat", 2.5),
+        ("creative cloud", 3.0), ("after effects", 2.5),
+    ],
+    "ill_request": [
+        ("interlibrary loan", 3.0), ("ill ", 2.5), (" ill?", 2.5),
+        ("ohiolink", 2.5), ("borrow from another", 2.5),
+        ("from another library", 2.5), ("from another university", 2.5),
+        ("get a book from", 1.5), ("request a book", 1.5),
+        ("article delivery", 2.5),
+    ],
+    "makerspace_info": [
+        ("makerspace", 3.0), ("maker space", 3.0), ("3d printer", 3.0),
+        ("3d printing", 3.0), ("vinyl cutter", 3.0),
+        ("sewing machine", 2.5), ("laser cutter", 3.0),
+    ],
+    "special_collections": [
+        ("special collections", 3.0), ("archives", 2.0), ("archivist", 2.5),
+        ("rare book", 2.5), ("manuscript", 2.0), ("finding aid", 3.0),
+        ("havighurst", 3.0), ("scua", 2.0),
+    ],
+    "digital_collections": [
+        ("digital collection", 3.0), ("digital exhibit", 3.0),
+        ("online exhibit", 2.5), ("digital archive", 2.5),
+    ],
+    "newspapers": [
+        ("new york times", 3.0), ("nyt", 2.0), ("wall street journal", 3.0),
+        ("wsj", 2.0), ("newspaper", 2.0), ("cincinnati enquirer", 3.0),
+        ("washington post", 2.5), ("financial times", 2.5),
+    ],
+    "cross_campus_comparison": [
+        ("all campuses", 3.0), ("every campus", 3.0),
+        ("all libraries", 2.5), ("every miami library", 3.0),
+        ("hamilton and middletown", 2.0), ("oxford and hamilton", 2.0),
+    ],
+    "human_handoff": [
+        ("talk to a person", 3.0), ("talk to a human", 3.0),
+        ("talk to someone", 2.5), ("speak to a librarian", 2.5),
+        ("real person", 2.5),
+    ],
+    # out_of_scope is never auto-suggested -- librarian decides.
+}
+
+
+def _strip_pii(s: str) -> str:
+    """Mask emails, phones, IDs in the utterance text. Used after the
+    drop check -- if PII is present we drop the row, but if a row
+    SLIPS THROUGH (e.g. partial email), we mask before writing."""
+    s = _EMAIL_RE.sub("[EMAIL]", s)
+    s = _PHONE_RE.sub("[PHONE]", s)
+    s = _BRONCO_ID_RE.sub("[ID]", s)
+    return s
+
+
+def _has_pii(s: str) -> bool:
+    if _EMAIL_RE.search(s):
+        return True
+    if _PHONE_RE.search(s):
+        return True
+    if _BRONCO_ID_RE.search(s):
+        return True
+    if _ACCOUNT_BOILERPLATE_RE.search(s):
+        return True
+    return False
+
+
+def _is_hard_reject(s: str) -> bool:
+    lower = s.lower()
+    return any(p in lower for p in _HARD_REJECT_PHRASES)
+
+
+def _is_greeting(s: str) -> bool:
+    return bool(_GREETING_RE.match(s.strip()))
+
+
+def _normalize(s: str) -> str:
+    """Trim, collapse whitespace, normalize newlines to spaces."""
+    s = s.replace("\r", " ").replace("\n", " ")
+    s = re.sub(r"\s+", " ", s).strip()
+    return s
+
+
+def _suggest_intent(utterance: str) -> Optional[str]:
+    """Pick the highest-scoring intent by keyword match, or None."""
+    lower = utterance.lower()
+    scores: dict[str, float] = defaultdict(float)
+    for intent, words in _KEYWORDS.items():
+        for kw, weight in words:
+            if kw in lower:
+                scores[intent] += weight
+    if not scores:
+        return None
+    best = max(scores.items(), key=lambda kv: kv[1])
+    if best[1] < 1.0:
+        return None
+    return best[0]
+
+
+def clean(input_path: Path, output_path: Path, report_path: Path) -> None:
+    """Run the cleaning pipeline and write the labeling-ready CSV."""
+    raw_count = 0
+    drop_short = 0
+    drop_long = 0
+    drop_pii = 0
+    drop_hard_reject = 0
+    drop_greeting = 0
+    drop_dup = 0
+
+    seen: set[str] = set()
+    rows_out: list[dict] = []
+
+    with open(input_path, encoding="utf-8-sig") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            raw_count += 1
+            iq = (row.get("Initial Question") or "").strip()
+            if not iq:
+                continue
+
+            iq = _normalize(iq)
+
+            # Hard length bounds
+            if len(iq) < MIN_LEN:
+                drop_short += 1
+                continue
+            if len(iq) > MAX_LEN:
+                drop_long += 1
+                continue
+
+            # Greeting filter
+            if _is_greeting(iq):
+                drop_greeting += 1
+                continue
+
+            # PII filter (whole-row drop)
+            if _has_pii(iq):
+                drop_pii += 1
+                continue
+
+            # Hard-reject phrases (account help etc.)
+            if _is_hard_reject(iq):
+                drop_hard_reject += 1
+                continue
+
+            # Belt-and-suspenders mask in case anything slipped through
+            iq_clean = _strip_pii(iq)
+
+            # Dedup by lowercased + alphanum-only signature so
+            # punctuation / case differences don't fragment the dedup.
+            sig = re.sub(r"[^a-z0-9 ]", "", iq_clean.lower())
+            if sig in seen:
+                drop_dup += 1
+                continue
+            seen.add(sig)
+
+            suggested = _suggest_intent(iq_clean) or ""
+            rows_out.append({
+                "utterance": iq_clean,
+                "suggested_intent": suggested,
+                "intent": "",
+            })
+
+    # Write the labeling CSV
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=["utterance", "suggested_intent", "intent"])
+        w.writeheader()
+        for r in rows_out:
+            w.writerow(r)
+
+    # Coverage report
+    by_intent = Counter(r["suggested_intent"] or "(unknown)" for r in rows_out)
+    lines = [
+        f"# LibChat exemplar cleaning report",
+        "",
+        f"- Input file:  `{input_path.name}`",
+        f"- Raw rows:    **{raw_count}**",
+        f"- Kept after cleaning: **{len(rows_out)}**",
+        "",
+        "## Drops",
+        f"- too short (<{MIN_LEN} chars): {drop_short}",
+        f"- too long (>{MAX_LEN} chars):  {drop_long}",
+        f"- greetings:                    {drop_greeting}",
+        f"- contained PII (drop whole):   {drop_pii}",
+        f"- account-help hard reject:     {drop_hard_reject}",
+        f"- duplicate of an earlier row:  {drop_dup}",
+        "",
+        "## Suggested-intent distribution (heuristic, librarian overrides)",
+        "",
+        "| Suggested intent | Count |",
+        "|---|---|",
+    ]
+    for intent, count in by_intent.most_common():
+        lines.append(f"| `{intent}` | {count} |")
+    lines.extend([
+        "",
+        "## Next step",
+        "",
+        f"1. Open `{output_path.name}` in a spreadsheet.",
+        "2. For each row, fill in the `intent` column. Accept the "
+        "suggestion = copy from `suggested_intent`. Override if wrong.",
+        "3. Use these labels (anything else = typo, will fail validation):",
+        "   `hours`, `room_booking`, `librarian_lookup`, `service_howto`,",
+        "   `policy_question`, `adobe_access`, `ill_request`,",
+        "   `makerspace_info`, `special_collections`, `digital_collections`,",
+        "   `newspapers`, `cross_campus_comparison`, `human_handoff`,",
+        "   `out_of_scope`",
+        "4. Aim for ~50 per intent (more is fine). Rows you can't classify",
+        "   confidently can be dropped (delete the row) -- partial labeling",
+        "   is FINE; we'd rather have 600 confident labels than 2300 noisy ones.",
+        "5. Save and send back; a follow-up script will pack the labeled",
+        "   CSV into `ai-core/src/router/exemplars/exemplars.jsonl`.",
+    ])
+    report_path.write_text("\n".join(lines), encoding="utf-8")
+
+    # Stdout summary
+    print(f"Read {raw_count} raw rows.")
+    print(f"Wrote {len(rows_out)} cleaned rows to {output_path}")
+    print(f"Coverage report: {report_path}")
+    print()
+    print("Drops:")
+    print(f"  short:        {drop_short}")
+    print(f"  long:         {drop_long}")
+    print(f"  greetings:    {drop_greeting}")
+    print(f"  PII:          {drop_pii}")
+    print(f"  hard-reject:  {drop_hard_reject}")
+    print(f"  duplicates:   {drop_dup}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--input", type=Path, required=True)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("ai-core/src/router/exemplars/exemplars_for_labeling.csv"),
+    )
+    parser.add_argument(
+        "--report",
+        type=Path,
+        default=Path("ai-core/src/router/exemplars/labeling_coverage_report.md"),
+    )
+    args = parser.parse_args()
+
+    if not args.input.exists():
+        print(f"input not found: {args.input}", file=sys.stderr)
+        return 2
+
+    clean(args.input, args.output, args.report)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ai-core/scripts/clean_libchat_transcripts.py
+++ b/ai-core/scripts/clean_libchat_transcripts.py
@@ -233,8 +233,14 @@ def _suggest_intent(utterance: str) -> Optional[str]:
     return best[0]
 
 
-def clean(input_path: Path, output_path: Path, report_path: Path) -> None:
-    """Run the cleaning pipeline and write the labeling-ready CSV."""
+def clean(input_paths: list[Path], output_path: Path, report_path: Path) -> None:
+    """Run the cleaning pipeline across one or more LibChat exports and
+    write a unified labeling-ready CSV.
+
+    Multiple inputs are concatenated and dedup is global -- a row that
+    appears in 2024 AND 2025 is kept once. The `source` column tracks
+    which file(s) it came from for traceability.
+    """
     raw_count = 0
     drop_short = 0
     drop_long = 0
@@ -243,64 +249,67 @@ def clean(input_path: Path, output_path: Path, report_path: Path) -> None:
     drop_greeting = 0
     drop_dup = 0
 
-    seen: set[str] = set()
-    rows_out: list[dict] = []
+    seen: dict[str, dict] = {}  # signature -> row (so we can update sources)
 
-    with open(input_path, encoding="utf-8-sig") as f:
-        reader = csv.DictReader(f)
-        for row in reader:
-            raw_count += 1
-            iq = (row.get("Initial Question") or "").strip()
-            if not iq:
-                continue
+    for input_path in input_paths:
+        source_label = input_path.stem  # e.g. "tran_raw_2024"
+        with open(input_path, encoding="utf-8-sig") as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                raw_count += 1
+                iq = (row.get("Initial Question") or "").strip()
+                if not iq:
+                    continue
 
-            iq = _normalize(iq)
+                iq = _normalize(iq)
 
-            # Hard length bounds
-            if len(iq) < MIN_LEN:
-                drop_short += 1
-                continue
-            if len(iq) > MAX_LEN:
-                drop_long += 1
-                continue
+                if len(iq) < MIN_LEN:
+                    drop_short += 1
+                    continue
+                if len(iq) > MAX_LEN:
+                    drop_long += 1
+                    continue
 
-            # Greeting filter
-            if _is_greeting(iq):
-                drop_greeting += 1
-                continue
+                if _is_greeting(iq):
+                    drop_greeting += 1
+                    continue
 
-            # PII filter (whole-row drop)
-            if _has_pii(iq):
-                drop_pii += 1
-                continue
+                if _has_pii(iq):
+                    drop_pii += 1
+                    continue
 
-            # Hard-reject phrases (account help etc.)
-            if _is_hard_reject(iq):
-                drop_hard_reject += 1
-                continue
+                if _is_hard_reject(iq):
+                    drop_hard_reject += 1
+                    continue
 
-            # Belt-and-suspenders mask in case anything slipped through
-            iq_clean = _strip_pii(iq)
+                iq_clean = _strip_pii(iq)
+                sig = re.sub(r"[^a-z0-9 ]", "", iq_clean.lower())
 
-            # Dedup by lowercased + alphanum-only signature so
-            # punctuation / case differences don't fragment the dedup.
-            sig = re.sub(r"[^a-z0-9 ]", "", iq_clean.lower())
-            if sig in seen:
-                drop_dup += 1
-                continue
-            seen.add(sig)
+                if sig in seen:
+                    drop_dup += 1
+                    # Track that this utterance also appeared in this source.
+                    existing_sources = seen[sig]["source"]
+                    if source_label not in existing_sources.split(","):
+                        seen[sig]["source"] = existing_sources + "," + source_label
+                    continue
 
-            suggested = _suggest_intent(iq_clean) or ""
-            rows_out.append({
-                "utterance": iq_clean,
-                "suggested_intent": suggested,
-                "intent": "",
-            })
+                suggested = _suggest_intent(iq_clean) or ""
+                seen[sig] = {
+                    "utterance": iq_clean,
+                    "suggested_intent": suggested,
+                    "intent": "",
+                    "source": source_label,
+                }
+
+    rows_out = list(seen.values())
 
     # Write the labeling CSV
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with open(output_path, "w", encoding="utf-8", newline="") as f:
-        w = csv.DictWriter(f, fieldnames=["utterance", "suggested_intent", "intent"])
+        w = csv.DictWriter(
+            f,
+            fieldnames=["utterance", "suggested_intent", "intent", "source"],
+        )
         w.writeheader()
         for r in rows_out:
             w.writerow(r)
@@ -310,8 +319,8 @@ def clean(input_path: Path, output_path: Path, report_path: Path) -> None:
     lines = [
         f"# LibChat exemplar cleaning report",
         "",
-        f"- Input file:  `{input_path.name}`",
-        f"- Raw rows:    **{raw_count}**",
+        f"- Input files: {', '.join(f'`{p.name}`' for p in input_paths)}",
+        f"- Raw rows (total across inputs): **{raw_count}**",
         f"- Kept after cleaning: **{len(rows_out)}**",
         "",
         "## Drops",
@@ -366,7 +375,13 @@ def clean(input_path: Path, output_path: Path, report_path: Path) -> None:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
-    parser.add_argument("--input", type=Path, required=True)
+    parser.add_argument(
+        "--input",
+        type=Path,
+        nargs="+",
+        required=True,
+        help="One or more LibChat CSV exports (multi-year inputs are merged + globally deduped).",
+    )
     parser.add_argument(
         "--output",
         type=Path,
@@ -379,8 +394,10 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    if not args.input.exists():
-        print(f"input not found: {args.input}", file=sys.stderr)
+    missing = [p for p in args.input if not p.exists()]
+    if missing:
+        for p in missing:
+            print(f"input not found: {p}", file=sys.stderr)
         return 2
 
     clean(args.input, args.output, args.report)

--- a/ai-core/src/router/exemplars/.gitignore
+++ b/ai-core/src/router/exemplars/.gitignore
@@ -1,0 +1,6 @@
+# Per-environment build outputs of scripts/clean_libchat_transcripts.py
+# (the labeling-ready CSV and its coverage report). Both are derived
+# from the raw transcript export and may contain partially-cleaned PII
+# until the librarian's labeling pass completes -- keep out of git.
+exemplars_for_labeling.csv
+labeling_coverage_report.md

--- a/ai-core/src/router/intent_knn.py
+++ b/ai-core/src/router/intent_knn.py
@@ -235,6 +235,51 @@ def build_classifier(
     return IntentKNN(exemplars=exemplars, embedder=embedder)
 
 
+# --- Disk-backed exemplar loader ------------------------------------------
+
+
+_EXEMPLARS_PATH = (
+    __import__("pathlib").Path(__file__).parent / "exemplars" / "exemplars.jsonl"
+)
+"""Where the labeled exemplar JSONL lives. Built by
+scripts/build_exemplars_jsonl.py from the librarian-labeled CSV.
+Returns an empty list if the file doesn't exist yet (graceful early-
+launch behavior; the classifier returns out_of_scope-needs-clarify
+on every call until exemplars are populated)."""
+
+
+def load_exemplars_from_disk(
+    path: "Optional[__import__('pathlib').Path]" = None,
+) -> list[tuple[str, str]]:
+    """Read labeled exemplars from the JSONL file produced by
+    scripts/build_exemplars_jsonl.py.
+
+    Returns a list of (intent, utterance) tuples ready to pass to
+    `build_classifier()`. Returns an empty list if the file doesn't
+    exist -- callers fall through to the empty-classifier degradation
+    path.
+    """
+    import json
+    from pathlib import Path
+
+    p = path if path is not None else _EXEMPLARS_PATH
+    if not p.exists():
+        return []
+    out: list[tuple[str, str]] = []
+    with open(p, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("//"):
+                continue
+            obj = json.loads(line)
+            intent = obj.get("intent", "")
+            utterance = obj.get("utterance", "")
+            if not intent or not utterance:
+                continue
+            out.append((intent, utterance))
+    return out
+
+
 # --- Intent registry ------------------------------------------------------
 #
 # The canonical list of intent labels the classifier may return.


### PR DESCRIPTION
## Summary
Two scripts plus a loader that turn raw LibChat transcript exports into the JSONL the kNN classifier reads. Tested against the 2025 export (`tran_raw_2025.csv`, 2,373 rows).

## What's in the box

### `scripts/clean_libchat_transcripts.py`
Reads the raw CSV, pulls the `Initial Question` field (the first user message — exactly what the kNN classifier sees at routing time), and produces a labeling-ready CSV.

Pipeline:
1. **PII strip**: drop the row if it contains an email, phone, Bronco ID (`8xxxxxxx`), or account-help boilerplate ("my password", "my account"). Belt-and-suspenders mask anything that slips through.
2. **Length bounds**: drop < 10 chars (greetings) or > 250 chars (multi-question paragraphs).
3. **Hard-reject**: drop "can't log in", "remove the fine", etc. — out-of-scope AND PII-adjacent; keeps `out_of_scope` trained on cleaner negatives.
4. **Dedupe** by lowercased + alphanum-only signature.
5. **Keyword pre-labeling**: ~14 weighted keyword buckets pre-suggest an intent. The librarian accepts or overrides — head start, not the actual classifier.
6. Writes `exemplars_for_labeling.csv` (3 columns: `utterance`, `suggested_intent`, `intent`) plus a coverage Markdown report.

### `scripts/build_exemplars_jsonl.py`
Consumes the labeled CSV after the librarian's pass:
- **Validates** every `intent` value against the canonical `INTENTS` tuple — typo → REFUSE to write (no silent mislabels in training data).
- **Reports** per-intent counts; warns + exits non-zero if any intent is below the floor (default 20 exemplars).
- **Warns** on duplicate utterances within an intent.
- Emits `ai-core/src/router/exemplars/exemplars.jsonl` ready for the classifier to load.

### `src/router/intent_knn.py`
- New `load_exemplars_from_disk()` reads the JSONL produced above.
- Returns `[]` if the file doesn't exist — graceful early-launch behavior; the classifier's empty-exemplar path returns `out_of_scope`-needs-clarification on every call until labels ship.

### `src/router/exemplars/.gitignore`
- Excludes `exemplars_for_labeling.csv` and `labeling_coverage_report.md` (PII-adjacent until labeling completes; stays local).
- `exemplars.jsonl` is **intended** to be committed once labeling is done.

## First-run results against `tran_raw_2025.csv`

```
Read 2373 raw rows.
Wrote 1972 cleaned rows.

Drops:
  short:        30
  long:        324
  greetings:     0
  PII:          32
  hard-reject:   1
  duplicates:   14

Pre-labeled by keyword heuristic (383 of 1972):
  ill_request          130
  newspapers            80
  hours                 43
  room_booking          41
  adobe_access          35
  policy_question       21
  service_howto         11
  makerspace_info        7
  special_collections    6
  librarian_lookup       4
  human_handoff          3
  digital_collections    2
  (unknown)           1589   ← librarian's labeling pass
```

## Tests
- 14/14 existing `intent_knn` tests still pass
- Cleaner + packer are scripts; will get their own tests in a follow-up if useful (the validation in `build_exemplars_jsonl.py` already prevents bad data from landing)

## Next step (librarian)
1. Run `python ai-core/scripts/clean_libchat_transcripts.py --input tran_raw_2025.csv` (already done — output is in the worktree)
2. Open `exemplars_for_labeling.csv` in a spreadsheet
3. Fill in the `intent` column for the 1,589 unknowns (and override any wrong heuristic guesses). Aim for ~50 per intent; partial labeling is fine.
4. Run `python ai-core/scripts/build_exemplars_jsonl.py` — validates and writes `exemplars.jsonl`
5. Commit `exemplars.jsonl` (no PII; safe to ship)

🤖 Generated with [Claude Code](https://claude.com/claude-code)