### PR TITLE
Build retrieval layer (Layer 2): scope-filtered hybrid search + search_kb tool

### DIFF
--- a/ai-core/src/retrieval/__init__.py
+++ b/ai-core/src/retrieval/__init__.py
@@ -1,0 +1,30 @@
+"""
+Retrieval layer: pulls evidence chunks from Weaviate with scope-aware
+filtering, returns an EvidenceChunk bundle the synthesizer can cite.
+
+The agent calls this via the `search_kb` tool. The synthesizer never
+calls the retriever directly -- that boundary keeps the synthesizer's
+grounding contract enforceable (the synthesizer only sees an evidence
+bundle, never the search query).
+
+Public API:
+    search_kb(query, scope, *, weaviate, k=10) -> RetrievalResult
+
+See plan: Layer 2 (Retrieval and grounding).
+"""
+
+from src.retrieval.scope_filter import build_where_clause
+from src.retrieval.search import (
+    RetrievalRequest,
+    RetrievalResult,
+    WeaviateLike,
+    search_kb,
+)
+
+__all__ = [
+    "RetrievalRequest",
+    "RetrievalResult",
+    "WeaviateLike",
+    "build_where_clause",
+    "search_kb",
+]

--- a/ai-core/src/retrieval/scope_filter.py
+++ b/ai-core/src/retrieval/scope_filter.py
@@ -1,0 +1,144 @@
+"""
+Build the Weaviate `where` filter from a Scope.
+
+Pure logic. No Weaviate client, no I/O. Tests inject scope objects and
+assert on the resulting filter dict, then prod sends that same dict to
+the real client.
+
+Filter rules (from playbook §8):
+  - Campus: ALWAYS hard-filter to `scope.campus`. Cross-campus chunks
+    are excluded unless the chunk is tagged `campus="all"` (university-
+    wide content like Adobe licensing). The post-processor's cross-
+    campus guard is a defense-in-depth check; this filter is the first
+    line of defense.
+  - Library: HARD filter when scope.library is set. Otherwise leave
+    library unconstrained -- "what time does the library open" with
+    no library named should return campus-wide content and let
+    ranking surface the right building.
+  - Featured-service boost: when the user's intent maps to a featured
+    service (adobe_checkout, ill, makerspace, etc.), `featured_service`
+    is added as a "should match" hint. This is a SOFT filter --
+    chunks tagged with the matching service rank higher, but other
+    chunks can still appear if they're a strong text match.
+  - Deleted/tombstoned chunks always excluded.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class ScopeFilter:
+    """The resolved scope as the retriever needs it.
+
+    Slimmer than the full Scope dataclass -- the retriever only cares
+    about campus/library/featured_service. Build with from_scope() if
+    you have a real Scope; build directly in tests.
+    """
+
+    campus: str
+    library: Optional[str] = None
+    featured_service: Optional[str] = None
+    """Optional intent->service mapping (filled by the agent before
+    calling search_kb). When set, retrieval boosts chunks tagged with
+    this featured_service value."""
+
+
+# --- Where-clause builders -----------------------------------------------
+#
+# We emit the v4-Python-client `Filter`-style dict so callers can pass
+# it directly. The shape is:
+#
+#   {
+#     "operator": "And",
+#     "operands": [
+#       {"path": ["campus"], "operator": "Equal", "valueText": "oxford"},
+#       {"path": ["deleted"], "operator": "Equal", "valueBoolean": False},
+#       ...
+#     ]
+#   }
+#
+# This nested dict shape is what `weaviate.classes.query.Filter` (v4)
+# serializes to. The adapter in search.py calls the real client and is
+# free to translate the dict into typed Filter objects -- the contract
+# here is just "what filter do we want", not "how to talk to Weaviate".
+
+
+def _eq_text(field: str, value: str) -> dict:
+    return {"path": [field], "operator": "Equal", "valueText": value}
+
+
+def _eq_bool(field: str, value: bool) -> dict:
+    return {"path": [field], "operator": "Equal", "valueBoolean": value}
+
+
+def _or(*operands: dict) -> dict:
+    return {"operator": "Or", "operands": list(operands)}
+
+
+def _and(*operands: dict) -> dict:
+    if len(operands) == 1:
+        return operands[0]
+    return {"operator": "And", "operands": list(operands)}
+
+
+def build_where_clause(scope: ScopeFilter) -> dict:
+    """Build the hard-filter portion of a retrieval query.
+
+    The result is what gets passed to Weaviate's `.with_where()` (v3)
+    or `Filter.all_of(...)` (v4). Soft signals like featured_service
+    boosting are NOT in here -- they go through `build_should_match()`
+    so the retriever can apply them as a separate ranking nudge.
+
+    Returns:
+        Filter dict. Always non-empty (deleted=false at minimum).
+    """
+    clauses: list[dict] = [
+        # Tombstoned / deleted chunks are never returned.
+        _eq_bool("deleted", False),
+        # Campus: chunk must be on the user's campus OR be tagged "all"
+        # (university-wide content -- Adobe, NYT subscription, etc.).
+        _or(
+            _eq_text("campus", scope.campus),
+            _eq_text("campus", "all"),
+        ),
+    ]
+
+    # Library: hard-filter only if the user explicitly named one. A
+    # null library means "any building on this campus" -- ranking
+    # decides which surfaces. Same "all" escape hatch as campus.
+    if scope.library is not None:
+        clauses.append(
+            _or(
+                _eq_text("library", scope.library),
+                _eq_text("library", "all"),
+            )
+        )
+
+    return _and(*clauses)
+
+
+def build_should_match(scope: ScopeFilter) -> Optional[dict]:
+    """Build a soft "should match" filter that boosts chunks matching
+    the user's resolved featured_service intent.
+
+    The retriever applies this as a rank nudge, NOT a hard filter. A
+    chunk that doesn't carry `featured_service=adobe_checkout` can
+    still appear if its text is a strong match -- but a chunk that
+    DOES carry that tag wins the tie.
+
+    Returns None when the scope has no featured_service set; callers
+    skip the should-match step entirely.
+    """
+    if scope.featured_service is None:
+        return None
+    return _eq_text("featured_service", scope.featured_service)
+
+
+__all__ = [
+    "ScopeFilter",
+    "build_should_match",
+    "build_where_clause",
+]

--- a/ai-core/src/retrieval/search.py
+++ b/ai-core/src/retrieval/search.py
@@ -1,0 +1,213 @@
+"""
+Hybrid retrieval entrypoint: query Weaviate, return EvidenceChunks.
+
+`search_kb()` is the single function the agent's `search_kb` tool calls.
+Internally it:
+  1. Builds the scope filter (scope_filter.py).
+  2. Issues a Weaviate hybrid query (BM25 + vector).
+  3. Applies the featured-service soft boost.
+  4. Returns RetrievalResult containing EvidenceChunks ready for
+     `apply_corrections` -> synthesizer.
+
+The Weaviate client is injected via the `WeaviateLike` Protocol so this
+module is testable without the real client. Tests pass a stub that
+returns canned hits; prod injects the v4 client adapter.
+
+See plan: Layer 2 (Retrieval and grounding) + Data preparation
+playbook §8 (campus / library scope binding).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional, Protocol
+
+from src.retrieval.scope_filter import (
+    ScopeFilter,
+    build_should_match,
+    build_where_clause,
+)
+from src.synthesis.corrections import EvidenceChunk
+
+
+# --- Public types --------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RetrievalRequest:
+    """One retrieval call. Deliberately wide so the synthesizer's eval
+    log can record the full request shape for forensic replay."""
+
+    query: str
+    scope: ScopeFilter
+    k: int = 10
+    """Hybrid top-k. 10 is a reasonable default; the agent may bump
+    when the question phrasing suggests breadth (cross-campus
+    comparisons, broad policy questions)."""
+
+    alpha: float = 0.5
+    """Weaviate hybrid alpha: 0.0 = pure BM25, 1.0 = pure vector. 0.5
+    splits the difference. BM25 catches exact name matches ('Wertz',
+    'King 110') that pure vectors miss; vector catches paraphrases
+    ('art library' -> Wertz) that BM25 misses. Both matter."""
+
+
+@dataclass(frozen=True)
+class RetrievalResult:
+    """Bundle returned to the agent. The synthesizer reads `chunks`
+    after corrections are applied. The other fields are diagnostic.
+    """
+
+    chunks: list[EvidenceChunk] = field(default_factory=list)
+    raw_hit_count: int = 0
+    """How many hits Weaviate returned BEFORE our soft-boost reordering
+    or any local filtering. Useful when debugging 'why did retrieval
+    return nothing for this scope'."""
+
+    used_filter: Optional[dict] = None
+    """The where-clause we sent. Logged so eval-suite failures can be
+    reproduced exactly."""
+
+    error: Optional[str] = None
+    """Set when retrieval failed (Weaviate down, malformed filter,
+    etc.). When set, `chunks` is always empty and the agent should
+    treat this as NO_RESULTS for refusal purposes."""
+
+
+# --- Weaviate seam -------------------------------------------------------
+
+
+class WeaviateLike(Protocol):
+    """Minimal Weaviate interface the retrieval layer needs.
+
+    Wraps either v3 or v4 of the Weaviate client. Prod imports the v4
+    client and writes a thin adapter; tests pass a stub returning
+    canned hits. Keeps this module's import surface zero-cost in the
+    sandbox where Weaviate isn't installed.
+    """
+
+    def hybrid_search(
+        self,
+        *,
+        collection: str,
+        query: str,
+        where: dict,
+        alpha: float,
+        limit: int,
+        should_match: Optional[dict] = None,
+    ) -> list[dict]:
+        """Run a hybrid (BM25 + vector) query.
+
+        Returns a list of hit dicts shaped:
+            {
+                "chunk_id": str,
+                "source_url": str,
+                "text": str,
+                "campus": str | None,
+                "library": str | None,
+                "topic": str | None,
+                "featured_service": str | None,
+                "score": float,
+            }
+
+        Adapter is responsible for translating these back from the
+        Weaviate response shape (which differs across client versions).
+        """
+        ...
+
+
+# --- Entry point ---------------------------------------------------------
+
+
+def search_kb(
+    request: RetrievalRequest,
+    *,
+    weaviate: WeaviateLike,
+    collection: str = "Chunk_current",
+) -> RetrievalResult:
+    """Run a scope-filtered hybrid search and return EvidenceChunks.
+
+    Args:
+        request: Query + scope + k + alpha.
+        weaviate: Injectable client (Protocol). Prod: real v4 adapter.
+            Tests: a stub returning canned hits.
+        collection: Weaviate collection alias to query. Default points
+            at the live alias; ETL flips this between versions.
+
+    Returns:
+        RetrievalResult. On any error (network, malformed response),
+        `chunks=[]` and `error` is set so the agent can refuse via
+        the no_results / live_data_down trigger rather than crash.
+    """
+    where = build_where_clause(request.scope)
+    should_match = build_should_match(request.scope)
+
+    try:
+        hits = weaviate.hybrid_search(
+            collection=collection,
+            query=request.query,
+            where=where,
+            alpha=request.alpha,
+            limit=request.k,
+            should_match=should_match,
+        )
+    except Exception as e:
+        return RetrievalResult(
+            chunks=[],
+            raw_hit_count=0,
+            used_filter=where,
+            error=f"{type(e).__name__}: {e}",
+        )
+
+    # Translate hits -> EvidenceChunks. The adapter normalizes the
+    # response shape so we don't sprinkle isinstance / .get-defaults
+    # all over the codebase. Per-hit defensive default-handling here
+    # is for the edge case of a malformed adapter (returns a hit
+    # missing one of the required fields).
+    chunks: list[EvidenceChunk] = []
+    for h in hits:
+        chunk_id = h.get("chunk_id")
+        source_url = h.get("source_url")
+        text = h.get("text")
+        if not (chunk_id and source_url and text):
+            # Skip malformed hits silently; the diagnostic path is
+            # `raw_hit_count > len(chunks)` -- caller sees the gap.
+            continue
+        chunks.append(
+            EvidenceChunk(
+                chunk_id=chunk_id,
+                source_url=source_url,
+                text=text,
+                campus=h.get("campus"),
+                library=h.get("library"),
+                topic=h.get("topic"),
+                featured_service=h.get("featured_service"),
+                score=float(h.get("score", 0.0)),
+            )
+        )
+
+    # Featured-service soft-boost: the retriever returned hits in
+    # Weaviate's hybrid order, but we want chunks tagged with the
+    # matching featured_service to win ties. Stable sort by
+    # (-is_match, -score) preserves the underlying hybrid order
+    # within each tier.
+    if request.scope.featured_service is not None:
+        target = request.scope.featured_service
+        chunks.sort(
+            key=lambda c: (0 if c.featured_service == target else 1, -c.score),
+        )
+
+    return RetrievalResult(
+        chunks=chunks,
+        raw_hit_count=len(hits),
+        used_filter=where,
+        error=None,
+    )
+
+
+__all__ = [
+    "RetrievalRequest",
+    "RetrievalResult",
+    "WeaviateLike",
+    "search_kb",
+]

--- a/ai-core/src/retrieval/test_scope_filter.py
+++ b/ai-core/src/retrieval/test_scope_filter.py
@@ -1,0 +1,165 @@
+"""
+Unit tests for the Weaviate where-clause builder.
+
+Run: `python -m src.retrieval.test_scope_filter` from ai-core/.
+
+The where-clause is the FIRST line of defense against cross-campus
+leaks. The post-processor's cross-campus check is defense-in-depth;
+this filter is what stops Hamilton chunks from being seen by an Oxford
+query at all. Every clause must be load-bearing-tested.
+
+Tests:
+  1. Default Oxford scope: filters deleted=false AND (campus=oxford OR campus=all).
+  2. Hamilton scope: same shape, campus=hamilton.
+  3. Library set: adds (library=X OR library=all) clause.
+  4. Library unset: no library clause.
+  5. featured_service: build_should_match returns the hint dict.
+  6. featured_service unset: build_should_match returns None.
+  7. ScopeFilter dataclass shape preserved.
+  8. campus=all alternative path: a chunk tagged "all" passes both
+     the campus filter (via OR) and any library filter (via OR).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Allow running from ai-core/ as `python -m src.retrieval.test_scope_filter`.
+_HERE = Path(__file__).resolve().parent
+_AI_CORE = _HERE.parent.parent
+sys.path.insert(0, str(_AI_CORE))
+
+from src.retrieval.scope_filter import (  # noqa: E402
+    ScopeFilter,
+    build_should_match,
+    build_where_clause,
+)
+
+
+def _operands(clause: dict) -> list[dict]:
+    return clause.get("operands", [])
+
+
+def _flatten_clauses(clause: dict) -> list[dict]:
+    """Walk the And/Or tree and yield leaf {path, operator, valueX} dicts."""
+    if "operator" in clause and clause["operator"] in ("And", "Or"):
+        out = []
+        for c in clause["operands"]:
+            out.extend(_flatten_clauses(c))
+        return out
+    return [clause]
+
+
+def test_default_oxford_scope_filters_campus_and_deleted() -> None:
+    scope = ScopeFilter(campus="oxford")
+    clause = build_where_clause(scope)
+    assert clause["operator"] == "And"
+    leaves = _flatten_clauses(clause)
+    # Must include deleted=false.
+    assert any(
+        l.get("path") == ["deleted"] and l.get("valueBoolean") is False
+        for l in leaves
+    )
+    # Must include campus=oxford.
+    assert any(
+        l.get("path") == ["campus"] and l.get("valueText") == "oxford"
+        for l in leaves
+    )
+    # Must allow campus=all (university-wide chunks).
+    assert any(
+        l.get("path") == ["campus"] and l.get("valueText") == "all"
+        for l in leaves
+    )
+
+
+def test_hamilton_scope_swaps_campus() -> None:
+    scope = ScopeFilter(campus="hamilton")
+    clause = build_where_clause(scope)
+    leaves = _flatten_clauses(clause)
+    assert any(l.get("valueText") == "hamilton" for l in leaves)
+    assert not any(l.get("valueText") == "oxford" for l in leaves)
+
+
+def test_library_set_adds_library_clause() -> None:
+    scope = ScopeFilter(campus="oxford", library="king")
+    clause = build_where_clause(scope)
+    leaves = _flatten_clauses(clause)
+    library_leaves = [l for l in leaves if l.get("path") == ["library"]]
+    # Both library=king and library=all must be present (OR).
+    values = {l["valueText"] for l in library_leaves}
+    assert values == {"king", "all"}
+
+
+def test_library_unset_omits_library_clause() -> None:
+    scope = ScopeFilter(campus="oxford", library=None)
+    clause = build_where_clause(scope)
+    leaves = _flatten_clauses(clause)
+    assert not any(l.get("path") == ["library"] for l in leaves)
+
+
+def test_should_match_returns_featured_service_when_set() -> None:
+    scope = ScopeFilter(campus="oxford", featured_service="adobe_checkout")
+    sm = build_should_match(scope)
+    assert sm is not None
+    assert sm["path"] == ["featured_service"]
+    assert sm["valueText"] == "adobe_checkout"
+
+
+def test_should_match_returns_none_when_unset() -> None:
+    scope = ScopeFilter(campus="oxford", featured_service=None)
+    assert build_should_match(scope) is None
+
+
+def test_scope_filter_immutable() -> None:
+    """ScopeFilter is frozen; mutating raises. Prevents bugs where
+    a downstream caller modifies the scope mid-request."""
+    scope = ScopeFilter(campus="oxford")
+    try:
+        scope.campus = "hamilton"  # type: ignore[misc]
+    except Exception:
+        return
+    raise AssertionError("expected frozen dataclass to refuse mutation")
+
+
+def test_filter_structure_is_and_or_nested() -> None:
+    """The output is an And node whose operands include Or nodes for
+    campus (and library when set). Sanity-check the structural shape
+    so downstream adapter translation has stable input."""
+    scope = ScopeFilter(campus="oxford", library="king")
+    clause = build_where_clause(scope)
+    assert clause["operator"] == "And"
+    # Look for at least two Or sub-clauses (one per text-field
+    # OR-with-all): campus and library.
+    or_nodes = [op for op in clause["operands"] if op.get("operator") == "Or"]
+    assert len(or_nodes) >= 2
+
+
+def main() -> int:
+    tests = [
+        test_default_oxford_scope_filters_campus_and_deleted,
+        test_hamilton_scope_swaps_campus,
+        test_library_set_adds_library_clause,
+        test_library_unset_omits_library_clause,
+        test_should_match_returns_featured_service_when_set,
+        test_should_match_returns_none_when_unset,
+        test_scope_filter_immutable,
+        test_filter_structure_is_and_or_nested,
+    ]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:
+            failed += 1
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ai-core/src/retrieval/test_search.py
+++ b/ai-core/src/retrieval/test_search.py
@@ -1,0 +1,282 @@
+"""
+Unit tests for the search_kb retrieval entrypoint.
+
+Run: `python -m src.retrieval.test_search` from ai-core/.
+
+Tests use a stub WeaviateLike that returns canned hits, so the
+retrieval logic is fully testable without the real Weaviate client.
+
+Tests:
+  1. Happy path: hits translate to EvidenceChunks with all metadata.
+  2. Malformed hit (missing required field) is dropped silently;
+     raw_hit_count > len(chunks) signals the gap to debugger.
+  3. Weaviate raises -> RetrievalResult with error set, chunks=[].
+  4. Empty hits -> chunks=[], no error.
+  5. Featured-service soft boost: matching hits move to the front,
+     within-tier order preserved (stable sort).
+  6. Featured-service unset -> chunks come back in Weaviate order.
+  7. The where filter passed to Weaviate matches build_where_clause.
+  8. used_filter is recorded on the result for forensic replay.
+  9. used_filter is recorded EVEN when retrieval errored.
+ 10. score is coerced to float (defends against int/string from
+     adapter bugs).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+# Allow running from ai-core/ as `python -m src.retrieval.test_search`.
+_HERE = Path(__file__).resolve().parent
+_AI_CORE = _HERE.parent.parent
+sys.path.insert(0, str(_AI_CORE))
+
+from src.retrieval.scope_filter import ScopeFilter  # noqa: E402
+from src.retrieval.search import (  # noqa: E402
+    RetrievalRequest,
+    RetrievalResult,
+    search_kb,
+)
+
+
+# --- Stub adapter --------------------------------------------------------
+
+
+class StubWeaviate:
+    """Records what was asked + returns the configured response."""
+
+    def __init__(
+        self,
+        *,
+        hits: Optional[list[dict]] = None,
+        raises: Optional[Exception] = None,
+    ):
+        self.hits = hits or []
+        self.raises = raises
+        self.calls: list[dict] = []
+
+    def hybrid_search(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.raises is not None:
+            raise self.raises
+        return list(self.hits)
+
+
+def _hit(
+    chunk_id: str = "c1",
+    source_url: str = "https://lib.miamioh.edu/king/",
+    text: str = "King opens 7am.",
+    campus: str = "oxford",
+    library: str = "king",
+    topic: Optional[str] = "hours",
+    featured_service: Optional[str] = None,
+    score: float = 0.9,
+) -> dict:
+    return {
+        "chunk_id": chunk_id,
+        "source_url": source_url,
+        "text": text,
+        "campus": campus,
+        "library": library,
+        "topic": topic,
+        "featured_service": featured_service,
+        "score": score,
+    }
+
+
+# --- Tests ---------------------------------------------------------------
+
+
+def test_happy_path_translates_hits() -> None:
+    stub = StubWeaviate(hits=[_hit()])
+    req = RetrievalRequest(query="when does King close", scope=ScopeFilter(campus="oxford"))
+    out = search_kb(req, weaviate=stub)
+    assert out.error is None
+    assert out.raw_hit_count == 1
+    assert len(out.chunks) == 1
+    c = out.chunks[0]
+    assert c.chunk_id == "c1"
+    assert c.source_url == "https://lib.miamioh.edu/king/"
+    assert c.campus == "oxford"
+    assert c.library == "king"
+    assert c.score == 0.9
+
+
+def test_malformed_hit_dropped_silently() -> None:
+    """A hit missing chunk_id (or source_url, or text) is dropped, but
+    raw_hit_count counts it. Lets us see in logs that 'we got 5 hits
+    but only 3 became chunks' = 2 malformed -- adapter bug to chase."""
+    stub = StubWeaviate(hits=[
+        _hit(chunk_id="c1"),
+        {"source_url": "https://x", "text": "..."},  # missing chunk_id
+        _hit(chunk_id="c3"),
+    ])
+    req = RetrievalRequest(query="q", scope=ScopeFilter(campus="oxford"))
+    out = search_kb(req, weaviate=stub)
+    assert out.raw_hit_count == 3
+    assert len(out.chunks) == 2
+    assert [c.chunk_id for c in out.chunks] == ["c1", "c3"]
+
+
+def test_weaviate_raises_returns_error_result() -> None:
+    stub = StubWeaviate(raises=ConnectionError("Weaviate down"))
+    req = RetrievalRequest(query="q", scope=ScopeFilter(campus="oxford"))
+    out = search_kb(req, weaviate=stub)
+    assert out.error is not None
+    assert "ConnectionError" in out.error
+    assert "Weaviate down" in out.error
+    assert out.chunks == []
+    assert out.raw_hit_count == 0
+
+
+def test_empty_hits_no_error() -> None:
+    stub = StubWeaviate(hits=[])
+    req = RetrievalRequest(query="q", scope=ScopeFilter(campus="oxford"))
+    out = search_kb(req, weaviate=stub)
+    assert out.error is None
+    assert out.chunks == []
+    assert out.raw_hit_count == 0
+
+
+def test_featured_service_boost_reorders() -> None:
+    """A non-matching chunk with higher hybrid score gets BEHIND a
+    matching chunk with lower score -- that's the soft-boost design."""
+    stub = StubWeaviate(hits=[
+        # Higher hybrid score, but not adobe_checkout -> should drop behind.
+        _hit(chunk_id="c1", featured_service=None, score=0.95),
+        # Lower hybrid score but matching service -> should win.
+        _hit(chunk_id="c2", featured_service="adobe_checkout", score=0.7),
+        _hit(chunk_id="c3", featured_service=None, score=0.6),
+    ])
+    req = RetrievalRequest(
+        query="how do I get Photoshop",
+        scope=ScopeFilter(campus="oxford", featured_service="adobe_checkout"),
+    )
+    out = search_kb(req, weaviate=stub)
+    assert [c.chunk_id for c in out.chunks] == ["c2", "c1", "c3"]
+
+
+def test_featured_service_boost_stable_within_tier() -> None:
+    """Within the matching tier, original hybrid order is preserved.
+    Within the non-matching tier, same."""
+    stub = StubWeaviate(hits=[
+        _hit(chunk_id="c1", featured_service=None, score=0.9),
+        _hit(chunk_id="c2", featured_service="adobe_checkout", score=0.8),
+        _hit(chunk_id="c3", featured_service="adobe_checkout", score=0.6),
+        _hit(chunk_id="c4", featured_service=None, score=0.5),
+    ])
+    req = RetrievalRequest(
+        query="q", scope=ScopeFilter(campus="oxford", featured_service="adobe_checkout"),
+    )
+    out = search_kb(req, weaviate=stub)
+    # Matching tier (c2, c3) by score desc; non-matching (c1, c4) by score desc.
+    assert [c.chunk_id for c in out.chunks] == ["c2", "c3", "c1", "c4"]
+
+
+def test_no_featured_service_preserves_hybrid_order() -> None:
+    stub = StubWeaviate(hits=[
+        _hit(chunk_id="c1", score=0.9),
+        _hit(chunk_id="c2", score=0.8),
+        _hit(chunk_id="c3", score=0.7),
+    ])
+    req = RetrievalRequest(query="q", scope=ScopeFilter(campus="oxford"))
+    out = search_kb(req, weaviate=stub)
+    assert [c.chunk_id for c in out.chunks] == ["c1", "c2", "c3"]
+
+
+def test_where_filter_passed_to_weaviate() -> None:
+    stub = StubWeaviate(hits=[])
+    req = RetrievalRequest(
+        query="q", scope=ScopeFilter(campus="hamilton", library="rentschler"),
+    )
+    search_kb(req, weaviate=stub)
+    assert len(stub.calls) == 1
+    where = stub.calls[0]["where"]
+    # Walk to find campus=hamilton.
+    text = repr(where)
+    assert "hamilton" in text
+    assert "rentschler" in text
+    assert "deleted" in text
+
+
+def test_used_filter_recorded_on_success() -> None:
+    stub = StubWeaviate(hits=[_hit()])
+    req = RetrievalRequest(query="q", scope=ScopeFilter(campus="oxford"))
+    out = search_kb(req, weaviate=stub)
+    assert out.used_filter is not None
+    assert "operator" in out.used_filter
+
+
+def test_used_filter_recorded_even_on_error() -> None:
+    """When Weaviate errors, the filter we WOULD have used is still
+    recorded -- helps debug 'why did this query fail'."""
+    stub = StubWeaviate(raises=RuntimeError("boom"))
+    req = RetrievalRequest(query="q", scope=ScopeFilter(campus="oxford"))
+    out = search_kb(req, weaviate=stub)
+    assert out.error is not None
+    assert out.used_filter is not None
+
+
+def test_score_coerced_to_float() -> None:
+    """If the adapter returns int (or string), we coerce to float so
+    downstream sorting/eval doesn't blow up on type mismatch."""
+    stub = StubWeaviate(hits=[
+        {**_hit(chunk_id="c1"), "score": 1},  # int
+        {**_hit(chunk_id="c2"), "score": "0.5"},  # string (defensive)
+    ])
+    req = RetrievalRequest(query="q", scope=ScopeFilter(campus="oxford"))
+    out = search_kb(req, weaviate=stub)
+    for c in out.chunks:
+        assert isinstance(c.score, float)
+
+
+def test_alpha_passed_through() -> None:
+    """alpha (BM25 vs vector blend) reaches the adapter unchanged."""
+    stub = StubWeaviate(hits=[])
+    req = RetrievalRequest(query="q", scope=ScopeFilter(campus="oxford"), alpha=0.75)
+    search_kb(req, weaviate=stub)
+    assert stub.calls[0]["alpha"] == 0.75
+
+
+def test_k_passed_through_as_limit() -> None:
+    stub = StubWeaviate(hits=[])
+    req = RetrievalRequest(query="q", scope=ScopeFilter(campus="oxford"), k=20)
+    search_kb(req, weaviate=stub)
+    assert stub.calls[0]["limit"] == 20
+
+
+def main() -> int:
+    tests = [
+        test_happy_path_translates_hits,
+        test_malformed_hit_dropped_silently,
+        test_weaviate_raises_returns_error_result,
+        test_empty_hits_no_error,
+        test_featured_service_boost_reorders,
+        test_featured_service_boost_stable_within_tier,
+        test_no_featured_service_preserves_hybrid_order,
+        test_where_filter_passed_to_weaviate,
+        test_used_filter_recorded_on_success,
+        test_used_filter_recorded_even_on_error,
+        test_score_coerced_to_float,
+        test_alpha_passed_through,
+        test_k_passed_through_as_limit,
+    ]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:
+            failed += 1
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ai-core/src/tools/search_kb_tool.py
+++ b/ai-core/src/tools/search_kb_tool.py
@@ -1,0 +1,204 @@
+"""
+Wraps `src.retrieval.search.search_kb` as an agent Tool.
+
+The agent registers this tool at startup. When the LLM emits a
+`search_kb` tool call with arguments `{"query": str}`, the registry
+dispatches here. We:
+
+  1. Pull the resolved scope from the per-request context (campus,
+     library, intent->featured_service mapping).
+  2. Call the retrieval entrypoint.
+  3. Return a JSON-serializable result the LLM can read AND the
+     synthesizer's evidence-bundle path can consume.
+
+The scope context is passed in at tool-construction time
+(`make_search_kb_tool(weaviate, scope, intent)`) so the Tool's
+handler closes over it. This avoids threading scope through every
+LLM tool-call argument and keeps the LLM-visible schema minimal --
+the model only picks the QUERY; the system supplies the scope.
+
+See plan: Layer 2 (Retrieval and grounding) -> "Provenance bundle".
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from src.agent.tool_registry import Tool, ToolError
+from src.retrieval.scope_filter import ScopeFilter
+from src.retrieval.search import (
+    RetrievalRequest,
+    RetrievalResult,
+    WeaviateLike,
+    search_kb,
+)
+
+
+# --- Intent -> featured_service mapping ----------------------------------
+#
+# When the kNN classifier picked one of the featured-service intents,
+# we map it to the chunk's `featured_service` tag for the soft boost.
+# Non-featured intents (`hours`, `room_booking`, `policy_question`,
+# `librarian_lookup`, `service_howto`, `cross_campus_comparison`,
+# `human_handoff`, `out_of_scope`) get no boost -- ranking decides.
+
+_INTENT_TO_FEATURED: dict[str, str] = {
+    "adobe_access": "adobe_checkout",
+    "ill_request": "ill",
+    "makerspace_info": "makerspace",
+    "special_collections": "special_collections",
+    "digital_collections": "digital_collections",
+    "newspapers": "newspapers",
+}
+
+
+def _intent_to_featured(intent: Optional[str]) -> Optional[str]:
+    if intent is None:
+        return None
+    return _INTENT_TO_FEATURED.get(intent)
+
+
+# --- Tool description (the LLM reads this) -------------------------------
+#
+# The description and parameters are what the LLM uses to decide WHEN
+# to call the tool. Keep it short, concrete, and unambiguous about
+# what the tool DOES and DOES NOT do (e.g., it doesn't make decisions,
+# it returns evidence).
+
+_DESCRIPTION = (
+    "Search the library knowledge base for evidence relevant to the "
+    "user's question. Returns a list of {chunk_id, source_url, "
+    "snippet, library, campus, score} items. Call this whenever the "
+    "answer requires information about library services, policies, "
+    "spaces, or other content that lives on the library website. The "
+    "scope (campus + library) is determined by the system from the "
+    "user's resolved scope -- you only choose the search QUERY."
+)
+
+_PARAMETERS = {
+    "type": "object",
+    "properties": {
+        "query": {
+            "type": "string",
+            "description": (
+                "Natural-language search query. Use the user's exact "
+                "phrasing when possible -- BM25 catches name matches "
+                "the embedding misses ('Wertz', 'King 110')."
+            ),
+        },
+        "k": {
+            "type": "integer",
+            "description": (
+                "Number of evidence chunks to return. Default 10. Bump "
+                "to 20 for broad/comparative questions; drop to 5 for "
+                "narrow lookups."
+            ),
+            "default": 10,
+        },
+    },
+    "required": ["query"],
+    "additionalProperties": False,
+}
+
+
+# --- Result shape (what the LLM reads back) ------------------------------
+#
+# When the LLM calls search_kb, it gets back a tool-result message
+# whose content is the JSON of `_result_to_dict(result)`. We strip
+# fields the model doesn't need (e.g. used_filter is for forensic
+# logs, not the LLM) and present a clean evidence list with 1-indexed
+# numbering matching what citations[] will use.
+
+
+def _result_to_dict(result: RetrievalResult) -> dict:
+    if result.error is not None:
+        return {
+            "error": result.error,
+            "evidence": [],
+            "raw_hit_count": result.raw_hit_count,
+        }
+    return {
+        "evidence": [
+            {
+                "n": i + 1,  # 1-indexed; matches synthesizer citation numbering
+                "chunk_id": c.chunk_id,
+                "source_url": c.source_url,
+                "snippet": c.text,
+                "library": c.library,
+                "campus": c.campus,
+                "topic": c.topic,
+                "featured_service": c.featured_service,
+                "score": c.score,
+            }
+            for i, c in enumerate(result.chunks)
+        ],
+        "raw_hit_count": result.raw_hit_count,
+    }
+
+
+# --- Tool factory --------------------------------------------------------
+
+
+def make_search_kb_tool(
+    *,
+    weaviate: WeaviateLike,
+    scope: ScopeFilter,
+    intent: Optional[str] = None,
+    collection: str = "Chunk_current",
+) -> Tool:
+    """Build the agent Tool wrapping search_kb for one request.
+
+    Args:
+        weaviate: Real or stub WeaviateLike adapter.
+        scope: Resolved (campus, library) for THIS request. Closes
+            over the handler so the LLM-visible schema stays minimal.
+        intent: kNN classifier's chosen intent. Used to map to the
+            chunk's featured_service tag for soft boosting.
+        collection: Weaviate collection alias to query. Default points
+            at the live alias; ETL atomic-swaps this between versions.
+
+    Returns:
+        A Tool ready to register with ToolRegistry.
+    """
+    # Build the per-request scope-with-featured_service once. Reused
+    # on every tool call within this request (LLM may call search_kb
+    # multiple times with different queries).
+    scope_with_feature = ScopeFilter(
+        campus=scope.campus,
+        library=scope.library,
+        featured_service=_intent_to_featured(intent),
+    )
+
+    def handler(args: dict) -> Any:
+        query = args.get("query")
+        if not isinstance(query, str) or not query.strip():
+            raise ToolError("search_kb requires a non-empty `query` string.")
+        k = int(args.get("k", 10))
+        if k < 1 or k > 50:
+            # Bound the requested k -- defends against the LLM passing
+            # k=10000 because of a bad chain-of-thought.
+            raise ToolError(f"search_kb k={k} out of range (1..50).")
+
+        result = search_kb(
+            RetrievalRequest(query=query.strip(), scope=scope_with_feature, k=k),
+            weaviate=weaviate,
+            collection=collection,
+        )
+
+        # Empty + no error == NO_RESULTS (the agent / synthesizer
+        # decides what to do with that). We don't raise here; the LLM
+        # may still want to try a different query before refusing.
+        return _result_to_dict(result)
+
+    return Tool(
+        name="search_kb",
+        description=_DESCRIPTION,
+        parameters=_PARAMETERS,
+        handler=handler,
+        is_read_only=True,
+    )
+
+
+__all__ = [
+    "make_search_kb_tool",
+]

--- a/ai-core/src/tools/test_search_kb_tool.py
+++ b/ai-core/src/tools/test_search_kb_tool.py
@@ -1,0 +1,251 @@
+"""
+Unit tests for the search_kb tool wrapper.
+
+Run: `python -m src.tools.test_search_kb_tool` from ai-core/.
+
+The wrapper is what the LLM calls; it converts the raw RetrievalResult
+into the shape the LLM and synthesizer expect, and binds the per-
+request scope so the LLM doesn't have to (or can't) override it.
+
+Tests:
+  1. Tool factory returns a Tool with correct name + read_only=True.
+  2. Calling with a valid query dispatches to search_kb and returns
+     evidence in the documented shape.
+  3. evidence[].n is 1-indexed and matches the citation numbering
+     the synthesizer will emit.
+  4. Empty query raises ToolError (LLM forgot to fill the field).
+  5. k out of range raises ToolError (LLM passed k=10000).
+  6. intent -> featured_service mapping fires the soft boost.
+  7. intent=None or unknown intent skips the boost.
+  8. WeaviateLike adapter receives the right collection name.
+  9. error result from search_kb passes through to the tool result
+     with `error` field set.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+# Allow running from ai-core/ as `python -m src.tools.test_search_kb_tool`.
+_HERE = Path(__file__).resolve().parent
+_AI_CORE = _HERE.parent.parent
+sys.path.insert(0, str(_AI_CORE))
+
+from src.agent.tool_registry import ToolError  # noqa: E402
+from src.retrieval.scope_filter import ScopeFilter  # noqa: E402
+from src.tools.search_kb_tool import make_search_kb_tool  # noqa: E402
+
+
+class StubWeaviate:
+    def __init__(self, hits=None, raises=None):
+        self.hits = hits or []
+        self.raises = raises
+        self.calls = []
+
+    def hybrid_search(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.raises is not None:
+            raise self.raises
+        return list(self.hits)
+
+
+def _hit(chunk_id="c1", source_url="https://lib/", text="snip", **kw):
+    return {
+        "chunk_id": chunk_id, "source_url": source_url, "text": text,
+        "campus": kw.get("campus", "oxford"),
+        "library": kw.get("library", "king"),
+        "topic": kw.get("topic"),
+        "featured_service": kw.get("featured_service"),
+        "score": kw.get("score", 0.5),
+    }
+
+
+# --- Tests ---------------------------------------------------------------
+
+
+def test_factory_returns_correct_tool_metadata() -> None:
+    tool = make_search_kb_tool(
+        weaviate=StubWeaviate(), scope=ScopeFilter(campus="oxford"),
+    )
+    assert tool.name == "search_kb"
+    assert tool.is_read_only is True
+    assert "query" in tool.parameters["properties"]
+    assert "k" in tool.parameters["properties"]
+    assert tool.parameters["required"] == ["query"]
+
+
+def test_handler_dispatches_and_shapes_result() -> None:
+    stub = StubWeaviate(hits=[_hit("c1"), _hit("c2", score=0.4)])
+    tool = make_search_kb_tool(
+        weaviate=stub, scope=ScopeFilter(campus="oxford"),
+    )
+    result = tool.handler({"query": "when does king close"})
+    assert "evidence" in result
+    assert "error" not in result
+    assert len(result["evidence"]) == 2
+    e = result["evidence"][0]
+    # 1-indexed numbering matches synthesizer citation [n] convention.
+    assert e["n"] == 1
+    assert result["evidence"][1]["n"] == 2
+    # Each evidence row carries provenance + scope metadata.
+    assert e["chunk_id"] == "c1"
+    assert e["source_url"] == "https://lib/"
+    assert e["library"] == "king"
+    assert e["campus"] == "oxford"
+
+
+def test_empty_query_raises_tool_error() -> None:
+    tool = make_search_kb_tool(
+        weaviate=StubWeaviate(), scope=ScopeFilter(campus="oxford"),
+    )
+    for bad in [{"query": ""}, {"query": "   "}, {}]:
+        try:
+            tool.handler(bad)
+        except ToolError as e:
+            assert "query" in str(e).lower()
+            continue
+        raise AssertionError(f"expected ToolError for {bad!r}")
+
+
+def test_k_out_of_range_raises() -> None:
+    tool = make_search_kb_tool(
+        weaviate=StubWeaviate(), scope=ScopeFilter(campus="oxford"),
+    )
+    for bad_k in [0, -1, 51, 10000]:
+        try:
+            tool.handler({"query": "q", "k": bad_k})
+        except ToolError as e:
+            assert "out of range" in str(e)
+            continue
+        raise AssertionError(f"expected ToolError for k={bad_k}")
+
+
+def test_k_in_range_accepted() -> None:
+    stub = StubWeaviate(hits=[_hit()])
+    tool = make_search_kb_tool(
+        weaviate=stub, scope=ScopeFilter(campus="oxford"),
+    )
+    tool.handler({"query": "q", "k": 25})
+    assert stub.calls[0]["limit"] == 25
+
+
+def test_intent_maps_to_featured_service_boost() -> None:
+    """When intent='adobe_access', a chunk tagged adobe_checkout
+    should win against an unflagged chunk with higher hybrid score.
+    Verifies the intent->service mapping is wired correctly."""
+    stub = StubWeaviate(hits=[
+        _hit("c1", featured_service=None, score=0.9),
+        _hit("c2", featured_service="adobe_checkout", score=0.6),
+    ])
+    tool = make_search_kb_tool(
+        weaviate=stub,
+        scope=ScopeFilter(campus="oxford"),
+        intent="adobe_access",
+    )
+    result = tool.handler({"query": "where is photoshop"})
+    assert result["evidence"][0]["chunk_id"] == "c2"
+    assert result["evidence"][1]["chunk_id"] == "c1"
+
+
+def test_unknown_intent_skips_boost() -> None:
+    """An intent that has no featured_service mapping ('hours',
+    'human_handoff') means no soft boost -- chunks come back in
+    Weaviate hybrid order."""
+    stub = StubWeaviate(hits=[
+        _hit("c1", featured_service=None, score=0.9),
+        _hit("c2", featured_service="adobe_checkout", score=0.6),
+    ])
+    tool = make_search_kb_tool(
+        weaviate=stub,
+        scope=ScopeFilter(campus="oxford"),
+        intent="hours",  # no mapping
+    )
+    result = tool.handler({"query": "q"})
+    assert result["evidence"][0]["chunk_id"] == "c1"
+
+
+def test_intent_none_skips_boost() -> None:
+    stub = StubWeaviate(hits=[
+        _hit("c1", featured_service=None, score=0.9),
+        _hit("c2", featured_service="adobe_checkout", score=0.6),
+    ])
+    tool = make_search_kb_tool(
+        weaviate=stub,
+        scope=ScopeFilter(campus="oxford"),
+        intent=None,
+    )
+    result = tool.handler({"query": "q"})
+    assert result["evidence"][0]["chunk_id"] == "c1"
+
+
+def test_collection_name_passed_through() -> None:
+    """ETL atomic-swap rollouts pass a different collection alias
+    (e.g. Chunk_pending). The tool factory must respect it."""
+    stub = StubWeaviate(hits=[_hit()])
+    tool = make_search_kb_tool(
+        weaviate=stub, scope=ScopeFilter(campus="oxford"),
+        collection="Chunk_v2",
+    )
+    tool.handler({"query": "q"})
+    assert stub.calls[0]["collection"] == "Chunk_v2"
+
+
+def test_search_kb_error_passes_through_to_tool_result() -> None:
+    """When Weaviate raises, the tool's result dict carries `error`
+    instead of `evidence`. The LLM reads this and may try a different
+    query (or give up and let the synthesizer refuse)."""
+    stub = StubWeaviate(raises=ConnectionError("Weaviate down"))
+    tool = make_search_kb_tool(
+        weaviate=stub, scope=ScopeFilter(campus="oxford"),
+    )
+    result = tool.handler({"query": "q"})
+    assert "error" in result
+    assert "ConnectionError" in result["error"]
+    assert result["evidence"] == []
+
+
+def test_result_is_json_serializable() -> None:
+    """The agent loop wraps tool results in JSON before sending them
+    to the LLM. If the dict contains non-JSON types this would crash."""
+    stub = StubWeaviate(hits=[_hit()])
+    tool = make_search_kb_tool(
+        weaviate=stub, scope=ScopeFilter(campus="oxford"),
+    )
+    result = tool.handler({"query": "q"})
+    json.dumps(result)  # raises if any field isn't serializable
+
+
+def main() -> int:
+    tests = [
+        test_factory_returns_correct_tool_metadata,
+        test_handler_dispatches_and_shapes_result,
+        test_empty_query_raises_tool_error,
+        test_k_out_of_range_raises,
+        test_k_in_range_accepted,
+        test_intent_maps_to_featured_service_boost,
+        test_unknown_intent_skips_boost,
+        test_intent_none_skips_boost,
+        test_collection_name_passed_through,
+        test_search_kb_error_passes_through_to_tool_result,
+        test_result_is_json_serializable,
+    ]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:
+            failed += 1
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Plan §Layer 2 was missing entirely. This adds the bridge between the kNN classifier (intent) and the synthesizer (evidence bundle): scope-filtered hybrid Weaviate search returning `EvidenceChunk`s ready for `apply_corrections` → synthesizer.

## Architecture

| File | Purpose |
|---|---|
| `src/retrieval/scope_filter.py` | **Pure**: builds the Weaviate where-clause from a Scope. Campus hard-filtered (with `"all"` escape for university-wide chunks). Library hard-filtered when set, omitted when null. featured_service is a SOFT boost. |
| `src/retrieval/search.py` | `search_kb()` entrypoint. Injectable `WeaviateLike` Protocol. Translates hits → `EvidenceChunk`s. Applies featured_service stable-sort soft boost. Returns `RetrievalResult` with diagnostics (`raw_hit_count`, `used_filter`, `error`). |
| `src/tools/search_kb_tool.py` | Tool factory. Closes over per-request scope so LLM-visible schema is just `{query, k}`. Maps intent → featured_service. Bounds `k ∈ [1, 50]`. |

## Defense-in-depth pairing
**Layer 2 hard-filter (this PR):** cross-campus chunks excluded at the Weaviate query level.
**Post-processor cross-campus check (PR #22):** catches anything that slips through.
Two independent layers between a Hamilton question and an Oxford citation.

## Tool result shape (what the LLM reads back)
```json
{
  "evidence": [
    {"n": 1, "chunk_id": "...", "source_url": "...",
     "snippet": "...", "library": "king", "campus": "oxford",
     "topic": "hours", "featured_service": null, "score": 0.9}
  ],
  "raw_hit_count": 10
}
```
Citation numbering is 1-indexed; matches the `[n]` convention the synthesizer emits and `CitationChip.jsx` renders.

## Tests — 32 new, all pass

| File | Tests | What it locks |
|---|---|---|
| `test_scope_filter.py` | 8 | And/Or filter structure; campus + library + featured_service clauses; immutability |
| `test_search.py` | 13 | Happy path, malformed-hit drop with `raw_hit_count` gap signal, error pass-through, empty hits, featured-service boost reorder + stable within-tier, where filter passed through, `used_filter` recorded **even on error**, score coerced to float, alpha + k pass-through |
| `test_search_kb_tool.py` | 11 | Factory metadata, dispatch shape, 1-indexed `n` matches synthesizer convention, empty/oversized `k` validation, intent mapping fires boost, unknown/None intent skips boost, collection name pass-through, error pass-through, JSON-serializable result |

## Independence
Pure Python. No DB, no Weaviate. Safe to merge. The real Weaviate adapter (which translates between the v4 client's typed Filter objects and our dict shape) is a separate small module — landing in a follow-up PR alongside ETL wiring.

## Test plan
- [x] `python -m src.retrieval.test_scope_filter` — 8/8 pass
- [x] `python -m src.retrieval.test_search` — 13/13 pass
- [x] `python -m src.tools.test_search_kb_tool` — 11/11 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)