### PR TITLE
Tests for digest_email + admin router validators (43 tests)

### DIFF
--- a/ai-core/scripts/test_digest_email.py
+++ b/ai-core/scripts/test_digest_email.py
@@ -1,0 +1,270 @@
+"""
+Unit tests for the weekly digest-email message builders.
+
+Run: `python -m scripts.test_digest_email` from ai-core/.
+
+The Op 1 review loop depends on this email actually going out and
+being readable. The DB and SMTP layers are gated on Prisma + the
+mail relay (NotImplementedError until week 7), but the message-
+building logic is pure and testable today.
+
+A bug in the subject line ("Chatbot weekly digest -- 0 conversations
+to review") that fires every Monday for librarians with nothing to
+do erodes trust fast -- they'll mark it as spam and miss the real
+asks. Tests pin the contract.
+
+Tests:
+  1. Subject: zero -> "nothing to review" wording (no count).
+  2. Subject: singular -> "1 conversation" (no plural-s).
+  3. Subject: plural -> "N conversations".
+  4. Text body: zero -> no review URL, friendly nothing-to-do line.
+  5. Text body: with all flag types -> bullet list of each non-zero.
+  6. Text body: includes the review_queue_url when unreviewed > 0.
+  7. HTML body: zero -> short message, no link.
+  8. HTML body: with content -> contains the link href.
+  9. HTML body: librarian name with `<` is HTML-escaped.
+ 10. _escape: <, >, &, " all escaped.
+ 11. build_digest: composes all four DigestEmail fields.
+ 12. Single-flag bullet list (only thumbs_down) doesn't show empty rows.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Allow running from ai-core/ as `python -m scripts.test_digest_email`.
+_HERE = Path(__file__).resolve().parent
+_AI_CORE = _HERE.parent
+sys.path.insert(0, str(_AI_CORE))
+
+from scripts.digest_email import (  # noqa: E402
+    DigestEmail,
+    LibrarianSummary,
+    _escape,
+    build_digest,
+    build_html_body,
+    build_subject,
+    build_text_body,
+)
+
+
+def _summary(
+    *,
+    name: str = "Jane Liaison",
+    email: str = "jane@miamioh.edu",
+    unreviewed: int = 0,
+    thumbs_down: int = 0,
+    low_conf: int = 0,
+    refusal: int = 0,
+    review_url: str = "https://lib.miamioh.edu/admin/reviews?librarian=42",
+) -> LibrarianSummary:
+    return LibrarianSummary(
+        librarian_id=42,
+        librarian_email=email,
+        librarian_name=name,
+        campus="oxford",
+        unreviewed_count=unreviewed,
+        thumbs_down_count=thumbs_down,
+        low_confidence_count=low_conf,
+        refusal_count=refusal,
+        review_queue_url=review_url,
+    )
+
+
+# --- Subject ---
+
+
+def test_subject_zero_unreviewed_says_nothing_to_review() -> None:
+    s = build_subject(_summary(unreviewed=0))
+    assert "nothing to review" in s
+    # No count appears for the zero case.
+    assert "0 conversation" not in s
+
+
+def test_subject_singular_no_plural_s() -> None:
+    s = build_subject(_summary(unreviewed=1))
+    assert "1 conversation " in s
+    assert "1 conversations" not in s  # no rogue 's'
+
+
+def test_subject_plural_has_s() -> None:
+    s = build_subject(_summary(unreviewed=12))
+    assert "12 conversations" in s
+
+
+# --- Text body ---
+
+
+def test_text_body_zero_omits_review_link() -> None:
+    body = build_text_body(_summary(unreviewed=0))
+    assert "Hi Jane Liaison," in body
+    assert "No unreviewed" in body
+    # No URL when nothing to review.
+    assert "https://" not in body
+    # Sign-off still present.
+    assert "Miami University Libraries" in body
+
+
+def test_text_body_includes_review_url_when_nonzero() -> None:
+    url = "https://lib.miamioh.edu/admin/reviews?librarian=42"
+    body = build_text_body(_summary(unreviewed=5, review_url=url))
+    assert url in body
+    assert "5 unreviewed" in body
+    assert "5 unreviewed chatbot conversations" in body  # plural-s present
+
+
+def test_text_body_singular_no_plural_s() -> None:
+    body = build_text_body(_summary(unreviewed=1))
+    assert "1 unreviewed chatbot conversation " in body
+    assert "1 unreviewed chatbot conversations" not in body
+
+
+def test_text_body_renders_all_three_flags() -> None:
+    body = build_text_body(
+        _summary(unreviewed=10, thumbs_down=2, low_conf=3, refusal=4)
+    )
+    assert "2 had user thumbs-down ratings" in body
+    assert "3 were low-confidence answers" in body
+    assert "4 were refusals worth spot-checking" in body
+
+
+def test_text_body_skips_zero_flags() -> None:
+    """Bullet list omits flags that are 0 (don't show '0 thumbs-down')."""
+    body = build_text_body(
+        _summary(unreviewed=10, thumbs_down=2, low_conf=0, refusal=0)
+    )
+    assert "thumbs-down" in body
+    assert "low-confidence" not in body
+    assert "refusals worth" not in body
+
+
+# --- HTML body ---
+
+
+def test_html_body_zero_no_link() -> None:
+    html = build_html_body(_summary(unreviewed=0))
+    assert "No unreviewed" in html
+    assert "<a href=" not in html
+    assert "Hi Jane Liaison" in html
+
+
+def test_html_body_nonzero_includes_link() -> None:
+    url = "https://example/admin?librarian=42"
+    html = build_html_body(_summary(unreviewed=3, review_url=url))
+    assert f'<a href="{url}">' in html
+    assert "Review them here" in html
+
+
+def test_html_body_renders_flag_bullets() -> None:
+    html = build_html_body(
+        _summary(unreviewed=5, thumbs_down=2, low_conf=1, refusal=0)
+    )
+    assert "<li>2 had user thumbs-down ratings</li>" in html
+    assert "<li>1 were low-confidence answers</li>" in html
+    # refusal=0 -> no <li> for it.
+    assert "refusals worth" not in html
+
+
+def test_html_body_no_bullets_when_no_flags() -> None:
+    """unreviewed > 0 but all flags zero -> still want the link, but
+    NOT an empty <ul></ul>."""
+    html = build_html_body(_summary(unreviewed=2))
+    assert "<ul>" not in html
+    assert "Review them here" in html
+
+
+def test_html_body_escapes_librarian_name() -> None:
+    """A name containing < or & in the HTML must be escaped --
+    otherwise injecting attribute-breakers via librarian-name input
+    becomes a vector. (No real attack surface today since names come
+    from Postgres, but defense in depth.)"""
+    html = build_html_body(_summary(name="<script>alert(1)</script>"))
+    assert "<script>" not in html
+    assert "&lt;script&gt;" in html
+
+
+def test_html_body_escapes_review_url() -> None:
+    """Same defense for the URL field -- a malformed URL with `"` would
+    break out of the href attribute otherwise."""
+    bad_url = 'https://x.com/" onclick="alert(1)'
+    html = build_html_body(_summary(unreviewed=1, review_url=bad_url))
+    # Quote in the URL is escaped.
+    assert '"' not in bad_url or "&quot;" in html
+    assert "onclick=" in html  # the literal text appears, but as escaped text
+    # The href attribute opens with " and we don't break out of it.
+    assert 'href="https://x.com/&quot; onclick=&quot;alert(1)"' in html
+
+
+# --- _escape ---
+
+
+def test_escape_handles_each_char() -> None:
+    assert _escape("a < b") == "a &lt; b"
+    assert _escape("a > b") == "a &gt; b"
+    assert _escape('"hello"') == "&quot;hello&quot;"
+    assert _escape("Tom & Jerry") == "Tom &amp; Jerry"
+    # Combined.
+    assert (
+        _escape('<a href="x">Tom & Jerry</a>')
+        == "&lt;a href=&quot;x&quot;&gt;Tom &amp; Jerry&lt;/a&gt;"
+    )
+
+
+def test_escape_amp_first() -> None:
+    """`&` must be escaped FIRST; otherwise &lt; becomes &amp;lt;."""
+    assert _escape("<") == "&lt;"
+    # If the order were wrong this would be &amp;lt;.
+
+
+# --- build_digest composer ---
+
+
+def test_build_digest_composes_all_fields() -> None:
+    summary = _summary(unreviewed=7, thumbs_down=2, email="bob@x.edu",
+                       review_url="https://x/admin")
+    digest = build_digest(summary)
+    assert isinstance(digest, DigestEmail)
+    assert digest.to_email == "bob@x.edu"
+    assert "7 conversations" in digest.subject
+    assert "https://x/admin" in digest.text_body
+    assert 'href="https://x/admin"' in digest.html_body
+
+
+def main() -> int:
+    tests = [
+        test_subject_zero_unreviewed_says_nothing_to_review,
+        test_subject_singular_no_plural_s,
+        test_subject_plural_has_s,
+        test_text_body_zero_omits_review_link,
+        test_text_body_includes_review_url_when_nonzero,
+        test_text_body_singular_no_plural_s,
+        test_text_body_renders_all_three_flags,
+        test_text_body_skips_zero_flags,
+        test_html_body_zero_no_link,
+        test_html_body_nonzero_includes_link,
+        test_html_body_renders_flag_bullets,
+        test_html_body_no_bullets_when_no_flags,
+        test_html_body_escapes_librarian_name,
+        test_html_body_escapes_review_url,
+        test_escape_handles_each_char,
+        test_escape_amp_first,
+        test_build_digest_composes_all_fields,
+    ]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:
+            failed += 1
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ai-core/src/api/admin/test_validators.py
+++ b/ai-core/src/api/admin/test_validators.py
@@ -1,0 +1,330 @@
+"""
+Unit tests for the admin-router validators (pure logic).
+
+Run: `python -m src.api.admin.test_validators` from ai-core/.
+
+The reviews and corrections routers each have a pure validator that
+runs BEFORE the (currently-stubbed) DB call. Bugs in validation are
+the worst kind of admin-API bug:
+
+  - Permissive: librarians can submit malformed corrections that
+    crash retrieval at runtime ("pin action without query_pattern").
+  - Restrictive: librarians can't submit legitimate verdicts because
+    a typo'd validator rejects them.
+
+Both endpoints route through these pure functions today (the wired
+DB calls in week 7 will sit BEHIND the validators). Locking the
+contract now means the wiring won't introduce a regression.
+
+Tests cover:
+  validate_verdict (reviews_router):
+    - happy path verdict
+    - bad verdict label
+    - empty message_id
+    - non-positive librarian_id
+    - oversized note (> 2000 chars)
+    - VALID_VERDICTS lock-in (4 documented values)
+
+  validate_correction (corrections_router):
+    - happy path each action: suppress, replace, pin, blacklist_url
+    - bad action label
+    - bad scope label
+    - missing reason
+    - missing created_by
+    - replace without replacement
+    - pin without query_pattern
+    - blacklist_url with non-url scope
+    - suppress with non-chunk scope
+    - default_expiry returns now+180d
+
+  build_*_router placeholder fallback when fastapi is missing
+  (smoke check that import doesn't crash).
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+# Allow running from ai-core/ as `python -m src.api.admin.test_validators`.
+_HERE = Path(__file__).resolve().parent
+_AI_CORE = _HERE.parent.parent.parent
+sys.path.insert(0, str(_AI_CORE))
+
+from src.api.admin.corrections_router import (  # noqa: E402
+    DEFAULT_EXPIRY_DAYS,
+    VALID_ACTIONS,
+    VALID_SCOPES,
+    CorrectionInput,
+    build_corrections_router,
+    default_expiry,
+    validate_correction,
+)
+from src.api.admin.reviews_router import (  # noqa: E402
+    VALID_VERDICTS,
+    ReviewVerdict,
+    build_reviews_router,
+    validate_verdict,
+)
+
+
+# --- validate_verdict ---
+
+
+def _good_verdict(**kw) -> ReviewVerdict:
+    defaults = {
+        "message_id": "msg-123",
+        "librarian_id": 42,
+        "verdict": "correct",
+        "note": "looks good",
+    }
+    defaults.update(kw)
+    return ReviewVerdict(**defaults)
+
+
+def test_validate_verdict_happy_path() -> None:
+    assert validate_verdict(_good_verdict()) is None
+
+
+def test_validate_verdict_unknown_label() -> None:
+    err = validate_verdict(_good_verdict(verdict="amazing"))
+    assert err is not None
+    assert "verdict must be one of" in err
+
+
+def test_validate_verdict_empty_message_id() -> None:
+    err = validate_verdict(_good_verdict(message_id=""))
+    assert err == "message_id is required"
+
+
+def test_validate_verdict_non_positive_librarian_id() -> None:
+    err = validate_verdict(_good_verdict(librarian_id=0))
+    assert err == "librarian_id must be positive"
+    err = validate_verdict(_good_verdict(librarian_id=-1))
+    assert err == "librarian_id must be positive"
+
+
+def test_validate_verdict_oversized_note() -> None:
+    long_note = "x" * 2001
+    err = validate_verdict(_good_verdict(note=long_note))
+    assert err is not None
+    assert "exceeds 2000" in err
+
+
+def test_validate_verdict_at_limit_note_ok() -> None:
+    """Boundary: exactly 2000 chars is allowed."""
+    note_2000 = "x" * 2000
+    assert validate_verdict(_good_verdict(note=note_2000)) is None
+
+
+def test_validate_verdict_no_note_ok() -> None:
+    assert validate_verdict(_good_verdict(note=None)) is None
+
+
+def test_valid_verdicts_locked_in() -> None:
+    """The four documented verdicts. A future PR adding a 5th must
+    update this test (and downstream consumers like the eval harness's
+    judge prompts). Removing one is what this lock catches."""
+    expected = {"correct", "partial", "wrong", "should_refuse"}
+    assert set(VALID_VERDICTS) == expected
+
+
+# --- validate_correction ---
+
+
+def _good_correction(**kw) -> CorrectionInput:
+    defaults = {
+        "scope": "chunk",
+        "target": "chunk-uuid-123",
+        "action": "suppress",
+        "reason": "Wrong answer for room booking",
+        "created_by": "lib@miamioh.edu",
+        "replacement": None,
+        "query_pattern": None,
+        "expires_at": None,
+    }
+    defaults.update(kw)
+    return CorrectionInput(**defaults)
+
+
+def test_validate_correction_suppress_happy() -> None:
+    assert validate_correction(_good_correction()) is None
+
+
+def test_validate_correction_replace_happy() -> None:
+    c = _good_correction(action="replace", replacement="corrected text")
+    assert validate_correction(c) is None
+
+
+def test_validate_correction_pin_happy() -> None:
+    c = _good_correction(
+        scope="chunk", action="pin",
+        query_pattern=r".*makerspace.*",
+    )
+    assert validate_correction(c) is None
+
+
+def test_validate_correction_blacklist_happy() -> None:
+    c = _good_correction(
+        scope="url", action="blacklist_url",
+        target="https://example/bad",
+    )
+    assert validate_correction(c) is None
+
+
+def test_validate_correction_bad_action() -> None:
+    err = validate_correction(_good_correction(action="delete"))
+    assert err is not None
+    assert "action must be one of" in err
+
+
+def test_validate_correction_bad_scope() -> None:
+    err = validate_correction(_good_correction(scope="elsewhere"))
+    assert err is not None
+    assert "scope must be one of" in err
+
+
+def test_validate_correction_missing_reason() -> None:
+    err = validate_correction(_good_correction(reason=""))
+    assert err == "reason is required"
+    # Whitespace-only also rejected.
+    err = validate_correction(_good_correction(reason="   "))
+    assert err == "reason is required"
+
+
+def test_validate_correction_missing_created_by() -> None:
+    err = validate_correction(_good_correction(created_by=""))
+    assert err == "created_by is required"
+
+
+def test_validate_correction_replace_without_replacement() -> None:
+    err = validate_correction(_good_correction(action="replace"))
+    assert err is not None
+    assert "replacement" in err
+
+
+def test_validate_correction_pin_without_query_pattern() -> None:
+    err = validate_correction(_good_correction(action="pin"))
+    assert err is not None
+    assert "query_pattern" in err
+
+
+def test_validate_correction_blacklist_with_chunk_scope() -> None:
+    """blacklist_url is by definition URL-scoped; chunk scope is
+    nonsensical and would route the wrong table."""
+    err = validate_correction(_good_correction(
+        action="blacklist_url", scope="chunk",
+    ))
+    assert err is not None
+    assert "scope=url" in err
+
+
+def test_validate_correction_suppress_with_url_scope() -> None:
+    """suppress is by definition chunk-scoped; URL-suppress is what
+    blacklist_url is for. Distinct actions, distinct scopes."""
+    err = validate_correction(_good_correction(
+        action="suppress", scope="url",
+    ))
+    assert err is not None
+    assert "scope=chunk" in err
+
+
+# --- default_expiry ---
+
+
+def test_default_expiry_180_days_from_now() -> None:
+    """Six-month auto-renewal cadence per plan §Op 2."""
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    out = default_expiry(now)
+    expected = now + timedelta(days=DEFAULT_EXPIRY_DAYS)
+    assert out == expected
+    # 180 days is the documented value.
+    assert DEFAULT_EXPIRY_DAYS == 180
+
+
+def test_default_expiry_uses_utc_now_by_default() -> None:
+    out = default_expiry()
+    delta = out - datetime.now(timezone.utc)
+    # Within a couple seconds of expected.
+    assert abs((delta - timedelta(days=180)).total_seconds()) < 5
+
+
+# --- VALID_ACTIONS / VALID_SCOPES lock-in ---
+
+
+def test_valid_actions_locked_in() -> None:
+    expected = {"suppress", "replace", "pin", "blacklist_url"}
+    assert set(VALID_ACTIONS) == expected
+
+
+def test_valid_scopes_locked_in() -> None:
+    expected = {"url", "chunk", "intent", "global"}
+    assert set(VALID_SCOPES) == expected
+
+
+# --- Router build smoke checks ---
+
+
+def test_build_reviews_router_imports_without_crashing() -> None:
+    """fastapi may or may not be installed; either way build_router
+    returns SOMETHING (real router or _PlaceholderRouter shim).
+    Imports must not raise."""
+    out = build_reviews_router({"db": object()})
+    assert out is not None
+    # Both shapes have a `.routes` attribute.
+    assert hasattr(out, "routes")
+
+
+def test_build_corrections_router_imports_without_crashing() -> None:
+    out = build_corrections_router({"db": object()})
+    assert out is not None
+    assert hasattr(out, "routes")
+
+
+def main() -> int:
+    tests = [
+        test_validate_verdict_happy_path,
+        test_validate_verdict_unknown_label,
+        test_validate_verdict_empty_message_id,
+        test_validate_verdict_non_positive_librarian_id,
+        test_validate_verdict_oversized_note,
+        test_validate_verdict_at_limit_note_ok,
+        test_validate_verdict_no_note_ok,
+        test_valid_verdicts_locked_in,
+        test_validate_correction_suppress_happy,
+        test_validate_correction_replace_happy,
+        test_validate_correction_pin_happy,
+        test_validate_correction_blacklist_happy,
+        test_validate_correction_bad_action,
+        test_validate_correction_bad_scope,
+        test_validate_correction_missing_reason,
+        test_validate_correction_missing_created_by,
+        test_validate_correction_replace_without_replacement,
+        test_validate_correction_pin_without_query_pattern,
+        test_validate_correction_blacklist_with_chunk_scope,
+        test_validate_correction_suppress_with_url_scope,
+        test_default_expiry_180_days_from_now,
+        test_default_expiry_uses_utc_now_by_default,
+        test_valid_actions_locked_in,
+        test_valid_scopes_locked_in,
+        test_build_reviews_router_imports_without_crashing,
+        test_build_corrections_router_imports_without_crashing,
+    ]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:
+            failed += 1
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Two more SCAFFOLD modules with rich pure-logic surface had no tests. **43 new tests across two files, all pass locally.** The DB and SMTP layers are gated on Prisma + the mail relay (`NotImplementedError` until week 7 wiring), but message-building + request-validation can land coverage today.

## `test_digest_email.py` — 17 tests
The Op 1 review loop depends on the Monday digest actually going out and being readable. Bug in the subject line ("Chatbot weekly digest — 0 conversations to review" firing every week for librarians with nothing to do) → marked as spam → real asks missed.

- ✅ Subject line: zero ("nothing to review") / singular (no plural-s) / plural
- ✅ Text body: zero unreviewed → no review URL; nonzero → URL present
- ✅ Bullet list renders only non-zero flags (no "0 thumbs-down" rows)
- ✅ HTML body: zero / nonzero shapes; `<a href="…">` populated; `<ul>` omitted when no bullets
- ✅ HTML body: librarian name + review URL HTML-escaped (defense in depth — names come from Postgres but injection-via-name-field is a reasonable defense)
- ✅ `_escape`: `<`, `>`, `&`, `"` all handled; `&` escaped FIRST so `&lt;` doesn't become `&amp;lt;`
- ✅ `build_digest`: composes all four `DigestEmail` fields correctly

## `test_validators.py` — 26 tests for admin routers

Both `/admin/reviews` and `/admin/corrections` route through pure validators today; the wired DB calls in week 7 sit BEHIND those validators. Locking the contract now prevents the wiring from introducing a regression.

**`validate_verdict` (reviews_router):**
- ✅ happy path; unknown verdict label; empty `message_id`; non-positive `librarian_id`
- ✅ Oversized note (>2000 chars) rejected; at-limit (2000) accepted; no note OK
- ✅ **Lock-in**: `VALID_VERDICTS` = `{correct, partial, wrong, should_refuse}` (the 4 documented values)

**`validate_correction` (corrections_router):**
- ✅ Happy path each action: `suppress`, `replace`, `pin`, `blacklist_url`
- ✅ Bad action / scope label rejected
- ✅ Missing `reason` (whitespace too) → "no anonymous corrections"
- ✅ Missing `created_by` → audit trail enforcement
- ✅ `replace` without `replacement` rejected
- ✅ `pin` without `query_pattern` rejected
- ✅ `blacklist_url` with non-url scope → distinct actions, distinct scopes
- ✅ `suppress` with non-chunk scope → same
- ✅ `default_expiry()` returns `now+180d` (6-month auto-renewal)
- ✅ **Lock-in**: `VALID_ACTIONS` and `VALID_SCOPES` cover documented values

**Router smoke checks:**
- ✅ `build_reviews_router({"db": stub})` returns something with `.routes` (real FastAPI router or `_PlaceholderRouter` shim) — imports don't crash either way

## Independence
Pure Python. No DB, no LLM, no I/O. Safe to merge.

## Test plan
- [x] `python -m scripts.test_digest_email` — 17/17 pass
- [x] `python -m src.api.admin.test_validators` — 26/26 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)