### PR TITLE
Per-intent capability registry: short-circuit account/news/find_resource/databases

### DIFF
--- a/ai-core/scripts/test_digest_email.py
+++ b/ai-core/scripts/test_digest_email.py
@@ -1,0 +1,270 @@
+"""
+Unit tests for the weekly digest-email message builders.
+
+Run: `python -m scripts.test_digest_email` from ai-core/.
+
+The Op 1 review loop depends on this email actually going out and
+being readable. The DB and SMTP layers are gated on Prisma + the
+mail relay (NotImplementedError until week 7), but the message-
+building logic is pure and testable today.
+
+A bug in the subject line ("Chatbot weekly digest -- 0 conversations
+to review") that fires every Monday for librarians with nothing to
+do erodes trust fast -- they'll mark it as spam and miss the real
+asks. Tests pin the contract.
+
+Tests:
+  1. Subject: zero -> "nothing to review" wording (no count).
+  2. Subject: singular -> "1 conversation" (no plural-s).
+  3. Subject: plural -> "N conversations".
+  4. Text body: zero -> no review URL, friendly nothing-to-do line.
+  5. Text body: with all flag types -> bullet list of each non-zero.
+  6. Text body: includes the review_queue_url when unreviewed > 0.
+  7. HTML body: zero -> short message, no link.
+  8. HTML body: with content -> contains the link href.
+  9. HTML body: librarian name with `<` is HTML-escaped.
+ 10. _escape: <, >, &, " all escaped.
+ 11. build_digest: composes all four DigestEmail fields.
+ 12. Single-flag bullet list (only thumbs_down) doesn't show empty rows.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Allow running from ai-core/ as `python -m scripts.test_digest_email`.
+_HERE = Path(__file__).resolve().parent
+_AI_CORE = _HERE.parent
+sys.path.insert(0, str(_AI_CORE))
+
+from scripts.digest_email import (  # noqa: E402
+    DigestEmail,
+    LibrarianSummary,
+    _escape,
+    build_digest,
+    build_html_body,
+    build_subject,
+    build_text_body,
+)
+
+
+def _summary(
+    *,
+    name: str = "Jane Liaison",
+    email: str = "jane@miamioh.edu",
+    unreviewed: int = 0,
+    thumbs_down: int = 0,
+    low_conf: int = 0,
+    refusal: int = 0,
+    review_url: str = "https://lib.miamioh.edu/admin/reviews?librarian=42",
+) -> LibrarianSummary:
+    return LibrarianSummary(
+        librarian_id=42,
+        librarian_email=email,
+        librarian_name=name,
+        campus="oxford",
+        unreviewed_count=unreviewed,
+        thumbs_down_count=thumbs_down,
+        low_confidence_count=low_conf,
+        refusal_count=refusal,
+        review_queue_url=review_url,
+    )
+
+
+# --- Subject ---
+
+
+def test_subject_zero_unreviewed_says_nothing_to_review() -> None:
+    s = build_subject(_summary(unreviewed=0))
+    assert "nothing to review" in s
+    # No count appears for the zero case.
+    assert "0 conversation" not in s
+
+
+def test_subject_singular_no_plural_s() -> None:
+    s = build_subject(_summary(unreviewed=1))
+    assert "1 conversation " in s
+    assert "1 conversations" not in s  # no rogue 's'
+
+
+def test_subject_plural_has_s() -> None:
+    s = build_subject(_summary(unreviewed=12))
+    assert "12 conversations" in s
+
+
+# --- Text body ---
+
+
+def test_text_body_zero_omits_review_link() -> None:
+    body = build_text_body(_summary(unreviewed=0))
+    assert "Hi Jane Liaison," in body
+    assert "No unreviewed" in body
+    # No URL when nothing to review.
+    assert "https://" not in body
+    # Sign-off still present.
+    assert "Miami University Libraries" in body
+
+
+def test_text_body_includes_review_url_when_nonzero() -> None:
+    url = "https://lib.miamioh.edu/admin/reviews?librarian=42"
+    body = build_text_body(_summary(unreviewed=5, review_url=url))
+    assert url in body
+    assert "5 unreviewed" in body
+    assert "5 unreviewed chatbot conversations" in body  # plural-s present
+
+
+def test_text_body_singular_no_plural_s() -> None:
+    body = build_text_body(_summary(unreviewed=1))
+    assert "1 unreviewed chatbot conversation " in body
+    assert "1 unreviewed chatbot conversations" not in body
+
+
+def test_text_body_renders_all_three_flags() -> None:
+    body = build_text_body(
+        _summary(unreviewed=10, thumbs_down=2, low_conf=3, refusal=4)
+    )
+    assert "2 had user thumbs-down ratings" in body
+    assert "3 were low-confidence answers" in body
+    assert "4 were refusals worth spot-checking" in body
+
+
+def test_text_body_skips_zero_flags() -> None:
+    """Bullet list omits flags that are 0 (don't show '0 thumbs-down')."""
+    body = build_text_body(
+        _summary(unreviewed=10, thumbs_down=2, low_conf=0, refusal=0)
+    )
+    assert "thumbs-down" in body
+    assert "low-confidence" not in body
+    assert "refusals worth" not in body
+
+
+# --- HTML body ---
+
+
+def test_html_body_zero_no_link() -> None:
+    html = build_html_body(_summary(unreviewed=0))
+    assert "No unreviewed" in html
+    assert "<a href=" not in html
+    assert "Hi Jane Liaison" in html
+
+
+def test_html_body_nonzero_includes_link() -> None:
+    url = "https://example/admin?librarian=42"
+    html = build_html_body(_summary(unreviewed=3, review_url=url))
+    assert f'<a href="{url}">' in html
+    assert "Review them here" in html
+
+
+def test_html_body_renders_flag_bullets() -> None:
+    html = build_html_body(
+        _summary(unreviewed=5, thumbs_down=2, low_conf=1, refusal=0)
+    )
+    assert "<li>2 had user thumbs-down ratings</li>" in html
+    assert "<li>1 were low-confidence answers</li>" in html
+    # refusal=0 -> no <li> for it.
+    assert "refusals worth" not in html
+
+
+def test_html_body_no_bullets_when_no_flags() -> None:
+    """unreviewed > 0 but all flags zero -> still want the link, but
+    NOT an empty <ul></ul>."""
+    html = build_html_body(_summary(unreviewed=2))
+    assert "<ul>" not in html
+    assert "Review them here" in html
+
+
+def test_html_body_escapes_librarian_name() -> None:
+    """A name containing < or & in the HTML must be escaped --
+    otherwise injecting attribute-breakers via librarian-name input
+    becomes a vector. (No real attack surface today since names come
+    from Postgres, but defense in depth.)"""
+    html = build_html_body(_summary(name="<script>alert(1)</script>"))
+    assert "<script>" not in html
+    assert "&lt;script&gt;" in html
+
+
+def test_html_body_escapes_review_url() -> None:
+    """Same defense for the URL field -- a malformed URL with `"` would
+    break out of the href attribute otherwise."""
+    bad_url = 'https://x.com/" onclick="alert(1)'
+    html = build_html_body(_summary(unreviewed=1, review_url=bad_url))
+    # Quote in the URL is escaped.
+    assert '"' not in bad_url or "&quot;" in html
+    assert "onclick=" in html  # the literal text appears, but as escaped text
+    # The href attribute opens with " and we don't break out of it.
+    assert 'href="https://x.com/&quot; onclick=&quot;alert(1)"' in html
+
+
+# --- _escape ---
+
+
+def test_escape_handles_each_char() -> None:
+    assert _escape("a < b") == "a &lt; b"
+    assert _escape("a > b") == "a &gt; b"
+    assert _escape('"hello"') == "&quot;hello&quot;"
+    assert _escape("Tom & Jerry") == "Tom &amp; Jerry"
+    # Combined.
+    assert (
+        _escape('<a href="x">Tom & Jerry</a>')
+        == "&lt;a href=&quot;x&quot;&gt;Tom &amp; Jerry&lt;/a&gt;"
+    )
+
+
+def test_escape_amp_first() -> None:
+    """`&` must be escaped FIRST; otherwise &lt; becomes &amp;lt;."""
+    assert _escape("<") == "&lt;"
+    # If the order were wrong this would be &amp;lt;.
+
+
+# --- build_digest composer ---
+
+
+def test_build_digest_composes_all_fields() -> None:
+    summary = _summary(unreviewed=7, thumbs_down=2, email="bob@x.edu",
+                       review_url="https://x/admin")
+    digest = build_digest(summary)
+    assert isinstance(digest, DigestEmail)
+    assert digest.to_email == "bob@x.edu"
+    assert "7 conversations" in digest.subject
+    assert "https://x/admin" in digest.text_body
+    assert 'href="https://x/admin"' in digest.html_body
+
+
+def main() -> int:
+    tests = [
+        test_subject_zero_unreviewed_says_nothing_to_review,
+        test_subject_singular_no_plural_s,
+        test_subject_plural_has_s,
+        test_text_body_zero_omits_review_link,
+        test_text_body_includes_review_url_when_nonzero,
+        test_text_body_singular_no_plural_s,
+        test_text_body_renders_all_three_flags,
+        test_text_body_skips_zero_flags,
+        test_html_body_zero_no_link,
+        test_html_body_nonzero_includes_link,
+        test_html_body_renders_flag_bullets,
+        test_html_body_no_bullets_when_no_flags,
+        test_html_body_escapes_librarian_name,
+        test_html_body_escapes_review_url,
+        test_escape_handles_each_char,
+        test_escape_amp_first,
+        test_build_digest_composes_all_fields,
+    ]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:
+            failed += 1
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ai-core/src/api/admin/test_validators.py
+++ b/ai-core/src/api/admin/test_validators.py
@@ -1,0 +1,330 @@
+"""
+Unit tests for the admin-router validators (pure logic).
+
+Run: `python -m src.api.admin.test_validators` from ai-core/.
+
+The reviews and corrections routers each have a pure validator that
+runs BEFORE the (currently-stubbed) DB call. Bugs in validation are
+the worst kind of admin-API bug:
+
+  - Permissive: librarians can submit malformed corrections that
+    crash retrieval at runtime ("pin action without query_pattern").
+  - Restrictive: librarians can't submit legitimate verdicts because
+    a typo'd validator rejects them.
+
+Both endpoints route through these pure functions today (the wired
+DB calls in week 7 will sit BEHIND the validators). Locking the
+contract now means the wiring won't introduce a regression.
+
+Tests cover:
+  validate_verdict (reviews_router):
+    - happy path verdict
+    - bad verdict label
+    - empty message_id
+    - non-positive librarian_id
+    - oversized note (> 2000 chars)
+    - VALID_VERDICTS lock-in (4 documented values)
+
+  validate_correction (corrections_router):
+    - happy path each action: suppress, replace, pin, blacklist_url
+    - bad action label
+    - bad scope label
+    - missing reason
+    - missing created_by
+    - replace without replacement
+    - pin without query_pattern
+    - blacklist_url with non-url scope
+    - suppress with non-chunk scope
+    - default_expiry returns now+180d
+
+  build_*_router placeholder fallback when fastapi is missing
+  (smoke check that import doesn't crash).
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+# Allow running from ai-core/ as `python -m src.api.admin.test_validators`.
+_HERE = Path(__file__).resolve().parent
+_AI_CORE = _HERE.parent.parent.parent
+sys.path.insert(0, str(_AI_CORE))
+
+from src.api.admin.corrections_router import (  # noqa: E402
+    DEFAULT_EXPIRY_DAYS,
+    VALID_ACTIONS,
+    VALID_SCOPES,
+    CorrectionInput,
+    build_corrections_router,
+    default_expiry,
+    validate_correction,
+)
+from src.api.admin.reviews_router import (  # noqa: E402
+    VALID_VERDICTS,
+    ReviewVerdict,
+    build_reviews_router,
+    validate_verdict,
+)
+
+
+# --- validate_verdict ---
+
+
+def _good_verdict(**kw) -> ReviewVerdict:
+    defaults = {
+        "message_id": "msg-123",
+        "librarian_id": 42,
+        "verdict": "correct",
+        "note": "looks good",
+    }
+    defaults.update(kw)
+    return ReviewVerdict(**defaults)
+
+
+def test_validate_verdict_happy_path() -> None:
+    assert validate_verdict(_good_verdict()) is None
+
+
+def test_validate_verdict_unknown_label() -> None:
+    err = validate_verdict(_good_verdict(verdict="amazing"))
+    assert err is not None
+    assert "verdict must be one of" in err
+
+
+def test_validate_verdict_empty_message_id() -> None:
+    err = validate_verdict(_good_verdict(message_id=""))
+    assert err == "message_id is required"
+
+
+def test_validate_verdict_non_positive_librarian_id() -> None:
+    err = validate_verdict(_good_verdict(librarian_id=0))
+    assert err == "librarian_id must be positive"
+    err = validate_verdict(_good_verdict(librarian_id=-1))
+    assert err == "librarian_id must be positive"
+
+
+def test_validate_verdict_oversized_note() -> None:
+    long_note = "x" * 2001
+    err = validate_verdict(_good_verdict(note=long_note))
+    assert err is not None
+    assert "exceeds 2000" in err
+
+
+def test_validate_verdict_at_limit_note_ok() -> None:
+    """Boundary: exactly 2000 chars is allowed."""
+    note_2000 = "x" * 2000
+    assert validate_verdict(_good_verdict(note=note_2000)) is None
+
+
+def test_validate_verdict_no_note_ok() -> None:
+    assert validate_verdict(_good_verdict(note=None)) is None
+
+
+def test_valid_verdicts_locked_in() -> None:
+    """The four documented verdicts. A future PR adding a 5th must
+    update this test (and downstream consumers like the eval harness's
+    judge prompts). Removing one is what this lock catches."""
+    expected = {"correct", "partial", "wrong", "should_refuse"}
+    assert set(VALID_VERDICTS) == expected
+
+
+# --- validate_correction ---
+
+
+def _good_correction(**kw) -> CorrectionInput:
+    defaults = {
+        "scope": "chunk",
+        "target": "chunk-uuid-123",
+        "action": "suppress",
+        "reason": "Wrong answer for room booking",
+        "created_by": "lib@miamioh.edu",
+        "replacement": None,
+        "query_pattern": None,
+        "expires_at": None,
+    }
+    defaults.update(kw)
+    return CorrectionInput(**defaults)
+
+
+def test_validate_correction_suppress_happy() -> None:
+    assert validate_correction(_good_correction()) is None
+
+
+def test_validate_correction_replace_happy() -> None:
+    c = _good_correction(action="replace", replacement="corrected text")
+    assert validate_correction(c) is None
+
+
+def test_validate_correction_pin_happy() -> None:
+    c = _good_correction(
+        scope="chunk", action="pin",
+        query_pattern=r".*makerspace.*",
+    )
+    assert validate_correction(c) is None
+
+
+def test_validate_correction_blacklist_happy() -> None:
+    c = _good_correction(
+        scope="url", action="blacklist_url",
+        target="https://example/bad",
+    )
+    assert validate_correction(c) is None
+
+
+def test_validate_correction_bad_action() -> None:
+    err = validate_correction(_good_correction(action="delete"))
+    assert err is not None
+    assert "action must be one of" in err
+
+
+def test_validate_correction_bad_scope() -> None:
+    err = validate_correction(_good_correction(scope="elsewhere"))
+    assert err is not None
+    assert "scope must be one of" in err
+
+
+def test_validate_correction_missing_reason() -> None:
+    err = validate_correction(_good_correction(reason=""))
+    assert err == "reason is required"
+    # Whitespace-only also rejected.
+    err = validate_correction(_good_correction(reason="   "))
+    assert err == "reason is required"
+
+
+def test_validate_correction_missing_created_by() -> None:
+    err = validate_correction(_good_correction(created_by=""))
+    assert err == "created_by is required"
+
+
+def test_validate_correction_replace_without_replacement() -> None:
+    err = validate_correction(_good_correction(action="replace"))
+    assert err is not None
+    assert "replacement" in err
+
+
+def test_validate_correction_pin_without_query_pattern() -> None:
+    err = validate_correction(_good_correction(action="pin"))
+    assert err is not None
+    assert "query_pattern" in err
+
+
+def test_validate_correction_blacklist_with_chunk_scope() -> None:
+    """blacklist_url is by definition URL-scoped; chunk scope is
+    nonsensical and would route the wrong table."""
+    err = validate_correction(_good_correction(
+        action="blacklist_url", scope="chunk",
+    ))
+    assert err is not None
+    assert "scope=url" in err
+
+
+def test_validate_correction_suppress_with_url_scope() -> None:
+    """suppress is by definition chunk-scoped; URL-suppress is what
+    blacklist_url is for. Distinct actions, distinct scopes."""
+    err = validate_correction(_good_correction(
+        action="suppress", scope="url",
+    ))
+    assert err is not None
+    assert "scope=chunk" in err
+
+
+# --- default_expiry ---
+
+
+def test_default_expiry_180_days_from_now() -> None:
+    """Six-month auto-renewal cadence per plan §Op 2."""
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    out = default_expiry(now)
+    expected = now + timedelta(days=DEFAULT_EXPIRY_DAYS)
+    assert out == expected
+    # 180 days is the documented value.
+    assert DEFAULT_EXPIRY_DAYS == 180
+
+
+def test_default_expiry_uses_utc_now_by_default() -> None:
+    out = default_expiry()
+    delta = out - datetime.now(timezone.utc)
+    # Within a couple seconds of expected.
+    assert abs((delta - timedelta(days=180)).total_seconds()) < 5
+
+
+# --- VALID_ACTIONS / VALID_SCOPES lock-in ---
+
+
+def test_valid_actions_locked_in() -> None:
+    expected = {"suppress", "replace", "pin", "blacklist_url"}
+    assert set(VALID_ACTIONS) == expected
+
+
+def test_valid_scopes_locked_in() -> None:
+    expected = {"url", "chunk", "intent", "global"}
+    assert set(VALID_SCOPES) == expected
+
+
+# --- Router build smoke checks ---
+
+
+def test_build_reviews_router_imports_without_crashing() -> None:
+    """fastapi may or may not be installed; either way build_router
+    returns SOMETHING (real router or _PlaceholderRouter shim).
+    Imports must not raise."""
+    out = build_reviews_router({"db": object()})
+    assert out is not None
+    # Both shapes have a `.routes` attribute.
+    assert hasattr(out, "routes")
+
+
+def test_build_corrections_router_imports_without_crashing() -> None:
+    out = build_corrections_router({"db": object()})
+    assert out is not None
+    assert hasattr(out, "routes")
+
+
+def main() -> int:
+    tests = [
+        test_validate_verdict_happy_path,
+        test_validate_verdict_unknown_label,
+        test_validate_verdict_empty_message_id,
+        test_validate_verdict_non_positive_librarian_id,
+        test_validate_verdict_oversized_note,
+        test_validate_verdict_at_limit_note_ok,
+        test_validate_verdict_no_note_ok,
+        test_valid_verdicts_locked_in,
+        test_validate_correction_suppress_happy,
+        test_validate_correction_replace_happy,
+        test_validate_correction_pin_happy,
+        test_validate_correction_blacklist_happy,
+        test_validate_correction_bad_action,
+        test_validate_correction_bad_scope,
+        test_validate_correction_missing_reason,
+        test_validate_correction_missing_created_by,
+        test_validate_correction_replace_without_replacement,
+        test_validate_correction_pin_without_query_pattern,
+        test_validate_correction_blacklist_with_chunk_scope,
+        test_validate_correction_suppress_with_url_scope,
+        test_default_expiry_180_days_from_now,
+        test_default_expiry_uses_utc_now_by_default,
+        test_valid_actions_locked_in,
+        test_valid_scopes_locked_in,
+        test_build_reviews_router_imports_without_crashing,
+        test_build_corrections_router_imports_without_crashing,
+    ]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:
+            failed += 1
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ai-core/src/graph/new_orchestrator.py
+++ b/ai-core/src/graph/new_orchestrator.py
@@ -50,6 +50,11 @@ from src.observability.metrics import (
     record_refusal,
     record_request,
 )
+from src.router.intent_capabilities import (
+    CapabilityTier,
+    IntentCapability,
+    get_intent_capability,
+)
 from src.router.intent_knn import Classification, IntentKNN, MARGIN_HIGH, MARGIN_LOW
 from src.scope.resolver import Scope, resolve_scope, resolve_session_origin
 from src.synthesis.corrections import EvidenceChunk, ManualCorrection
@@ -196,6 +201,31 @@ def run_turn(
         latency_ms = int((time.monotonic() - turn_start) * 1000)
         record_request(endpoint="/chat", status="clarify", latency_s=latency_ms / 1000)
         return _clarify_response(classification, scope, latency_ms)
+
+    # --- 2.5. Per-intent capability check ---
+    # Some intents (account, events_news, find_resource, databases) are
+    # deliberately not LLM-answerable: the answer is an authoritative
+    # URL or a privacy refusal. Skip agent + synth entirely and return
+    # the templated response. See src/router/intent_capabilities.py.
+    capability = get_intent_capability(classification.intent)
+    if capability.tier == CapabilityTier.POINT_TO_URL:
+        latency_ms = int((time.monotonic() - turn_start) * 1000)
+        record_request(endpoint="/chat", status="point_to_url",
+                       latency_s=latency_ms / 1000)
+        return _capability_response(
+            classification, scope, capability, latency_ms,
+            is_refusal=False,
+        )
+    if capability.tier == CapabilityTier.REFUSE:
+        latency_ms = int((time.monotonic() - turn_start) * 1000)
+        record_request(endpoint="/chat", status="refusal",
+                       latency_s=latency_ms / 1000)
+        if capability.refusal_trigger:
+            record_refusal(trigger=capability.refusal_trigger)
+        return _capability_response(
+            classification, scope, capability, latency_ms,
+            is_refusal=True,
+        )
 
     # --- 3. Service-availability pre-check ---
     # If the user asked about MakerSpace at Middletown (say), skip
@@ -436,6 +466,51 @@ def _shape_response(
         agent_stopped_reason=agent_outcome.stopped_reason,
         latency_ms=total_latency_ms,
         cited_chunk_ids=cited_chunk_ids,
+    )
+
+
+def _capability_response(
+    classification: Classification,
+    scope: Scope,
+    capability: IntentCapability,
+    latency_ms: int,
+    *,
+    is_refusal: bool,
+) -> TurnResponse:
+    """Templated TurnResponse for POINT_TO_URL or REFUSE intents.
+
+    The capability registry's `short_message` already includes the
+    canonical URL, so we don't need synthesizer + post-processor to
+    compose anything. The citation list is the canonical URL alone --
+    the UI renders one citation chip linking to the right page.
+
+    Zero LLM tokens consumed. Latency is just the routing path.
+    """
+    citations: list[dict] = []
+    if capability.canonical_url:
+        citations.append({
+            "n": 1,
+            "url": capability.canonical_url,
+            "snippet": "",  # the short_message body already explains
+        })
+
+    return TurnResponse(
+        answer=capability.short_message,
+        is_refusal=is_refusal,
+        refusal_trigger=capability.refusal_trigger or None,
+        citations=citations,
+        # Confidence is "high" for both POINT_TO_URL and REFUSE: the
+        # response is deterministic (templated), so the bot is fully
+        # confident in what it's emitting -- no LLM uncertainty here.
+        confidence="high",
+        intent=classification.intent,
+        scope=scope.as_filter(),
+        model_used="(none -- capability registry)",
+        tokens={"input": 0, "cached_input": 0, "output": 0},
+        fired_corrections=[],
+        agent_stopped_reason=capability.tier.value,
+        latency_ms=latency_ms,
+        cited_chunk_ids=[],
     )
 
 

--- a/ai-core/src/graph/test_new_orchestrator.py
+++ b/ai-core/src/graph/test_new_orchestrator.py
@@ -249,6 +249,112 @@ def test_clarification_short_circuits_before_agent() -> None:
     assert resp.confidence == "low"
 
 
+# --- Capability-registry early-out paths --------------------------------
+
+
+def test_databases_intent_short_circuits_to_a_z_page() -> None:
+    """Per librarian decision: never look up DB by name. Always route
+    to the A-Z list. Saves agent + synth tokens AND avoids the
+    name-misspelling failure mode."""
+    deps = _build_deps(
+        classification=_classification("databases"),
+        evidence_in_search_kb_result=[_evidence_dict("c1")],
+    )
+    request = TurnRequest(
+        user_message="do you have JSTOR",
+        conversation_id="conv-1",
+    )
+    resp = run_turn(request, deps)
+    assert not resp.is_refusal
+    assert resp.agent_stopped_reason == "point_to_url"
+    # Zero LLM tokens -- agent + synth skipped entirely.
+    assert resp.tokens == {"input": 0, "cached_input": 0, "output": 0}
+    # Citation is the A-Z page itself.
+    assert len(resp.citations) == 1
+    assert "az/databases" in resp.citations[0]["url"]
+    assert "Databases A-Z" in resp.answer
+
+
+def test_find_resource_intent_short_circuits_to_primo() -> None:
+    deps = _build_deps(
+        classification=_classification("find_resource"),
+        evidence_in_search_kb_result=[_evidence_dict("c1")],
+    )
+    request = TurnRequest(
+        user_message="do you have a copy of Hamlet",
+        conversation_id="conv-1",
+    )
+    resp = run_turn(request, deps)
+    assert not resp.is_refusal
+    assert resp.agent_stopped_reason == "point_to_url"
+    assert resp.tokens["input"] == 0
+    assert "primo" in resp.citations[0]["url"].lower()
+    assert "Primo" in resp.answer
+    # ILL fallback also mentioned for "we don't have it" path.
+    assert "Interlibrary Loan" in resp.answer
+
+
+def test_account_intent_short_circuits_with_privacy_refusal() -> None:
+    deps = _build_deps(
+        classification=_classification("account"),
+        evidence_in_search_kb_result=[_evidence_dict("c1")],
+    )
+    request = TurnRequest(
+        user_message="how much do I owe?",
+        conversation_id="conv-1",
+    )
+    resp = run_turn(request, deps)
+    assert resp.is_refusal
+    assert resp.refusal_trigger == "account_privacy"
+    assert resp.tokens["input"] == 0
+    assert "MyAccount" in resp.answer
+    assert "can't access" in resp.answer.lower()
+
+
+def test_events_news_intent_short_circuits_with_news_refusal() -> None:
+    deps = _build_deps(
+        classification=_classification("events_news"),
+        evidence_in_search_kb_result=[_evidence_dict("c1")],
+    )
+    request = TurnRequest(
+        user_message="what events are happening this week",
+        conversation_id="conv-1",
+    )
+    resp = run_turn(request, deps)
+    assert resp.is_refusal
+    assert resp.refusal_trigger == "news_excluded"
+    assert resp.tokens["input"] == 0
+    # The refusal must explain WHY (stale events would mislead).
+    assert (
+        "old event" in resp.answer.lower()
+        or "stale" in resp.answer.lower()
+    )
+    # Points to the live News & Events page.
+    assert "news-events" in resp.citations[0]["url"]
+
+
+def test_capability_early_out_logs_telemetry() -> None:
+    """The log_turn callback fires with the right shape even when the
+    orchestrator short-circuits before the agent."""
+    captured: list[dict] = []
+    deps = _build_deps(
+        classification=_classification("databases"),
+        evidence_in_search_kb_result=[_evidence_dict("c1")],
+        log_capture=captured,
+    )
+    # The orchestrator's log_turn is invoked from the agent path; for
+    # short-circuit responses we don't currently call it (the response
+    # IS the log). This test pins that behavior so a future change to
+    # log short-circuits is intentional, not accidental.
+    request = TurnRequest(user_message="any", conversation_id="conv-1")
+    resp = run_turn(request, deps)
+    assert resp.intent == "databases"
+    assert resp.agent_stopped_reason == "point_to_url"
+    # No log_turn call yet for short-circuits -- documented behavior.
+    # If we add it later, change this assertion in the same PR.
+    assert captured == []
+
+
 def test_service_unavailable_short_circuits_to_refusal() -> None:
     """If the service isn't offered at this campus, post-processor
     short-circuits to SERVICE_NOT_AT_BUILDING regardless of
@@ -499,6 +605,11 @@ def main() -> int:
     tests = [
         test_happy_path_returns_answer,
         test_clarification_short_circuits_before_agent,
+        test_databases_intent_short_circuits_to_a_z_page,
+        test_find_resource_intent_short_circuits_to_primo,
+        test_account_intent_short_circuits_with_privacy_refusal,
+        test_events_news_intent_short_circuits_with_news_refusal,
+        test_capability_early_out_logs_telemetry,
         test_service_unavailable_short_circuits_to_refusal,
         test_low_confidence_synthesis_becomes_refusal,
         test_token_accumulation,

--- a/ai-core/src/router/intent_capabilities.py
+++ b/ai-core/src/router/intent_capabilities.py
@@ -1,0 +1,203 @@
+"""
+Per-intent capability registry: tells the orchestrator whether to
+run the full agent loop or short-circuit to a templated response.
+
+Going from 14 to 31 intents broadened ROUTING coverage. It did NOT
+broaden ANSWERING coverage. Some intents are deliberately not
+answerable by the bot:
+
+  - `account`        privacy (only the user can see their checkouts/fines)
+  - `events_news`    excluded by ETL design (stale event/news content
+                     is the prime suspect for "fake service" hallucinations)
+  - `find_resource`  catalog search -- specialized; route to Primo
+  - `databases`      database lookup -- users routinely misspell
+                     names ("Web of Science" vs "Web of Knowledge");
+                     authoritative source is the A-Z page
+
+For these, running the agent + synth costs budget for an answer that
+SHOULD be a deterministic templated response. The registry lets the
+orchestrator skip the agent and return the right shape directly.
+
+Three tiers:
+
+  READY            run the agent normally; grounding contract handles
+                   refusal naturally (no_results, low_confidence, etc.)
+  POINT_TO_URL     skip agent + synth; return a templated message that
+                   describes the right tool/page and links to it
+  REFUSE           skip agent + synth; return a refusal explaining why
+                   the bot can't answer + the right next step
+
+Default: READY. Every intent resolves to a capability via
+`get_intent_capability` -- no None returns, no missing-key crashes.
+
+See plan: Citation and refusal contract; Operations Op 2.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+
+class CapabilityTier(str, Enum):
+    """How the orchestrator handles each intent.
+
+    String-valued for log-friendly serialization.
+    """
+
+    READY = "ready"
+    """Run the full agent loop. Most intents are this."""
+
+    POINT_TO_URL = "point_to_url"
+    """Skip agent. Return a templated 'here's how + here's the URL'
+    message. Renders as an answer (not a refusal) in the UI -- the
+    user got a useful response, just not from the LLM."""
+
+    REFUSE = "refuse"
+    """Skip agent. Return a templated refusal explaining why the bot
+    can't help + pointing to the right next step."""
+
+
+@dataclass(frozen=True)
+class IntentCapability:
+    """One row in the registry."""
+
+    intent: str
+    tier: CapabilityTier
+    canonical_url: Optional[str] = None
+    """The single URL that's the authoritative answer for this intent
+    (or None for READY intents that don't have one canonical URL)."""
+
+    short_message: str = ""
+    """Templated body. Rendered verbatim to the user. Should NOT
+    contain placeholders -- this isn't the format() pipeline of
+    refusal_templates."""
+
+    refusal_trigger: str = ""
+    """For REFUSE tier: the refusal_trigger value logged with the
+    response (matches a key in synthesis/refusal_templates). Empty
+    for non-REFUSE."""
+
+
+# --- POINT_TO_URL intents ------------------------------------------------
+#
+# The bot describes the service in one sentence and links to where the
+# REAL answer lives. Saves agent + synthesizer tokens; the answer is
+# more accurate than what the LLM would compose.
+
+_POINT_TO_URL: dict[str, IntentCapability] = {
+    "databases": IntentCapability(
+        intent="databases",
+        tier=CapabilityTier.POINT_TO_URL,
+        canonical_url="https://libguides.lib.miamioh.edu/az/databases",
+        short_message=(
+            "To find articles or browse research databases, use the "
+            "library's Databases A-Z list. It's the authoritative "
+            "index of every database the library subscribes to -- "
+            "organized alphabetically and by subject -- and links "
+            "directly into each database with proper authentication.\n\n"
+            "Why send you there instead of looking up a specific "
+            "database name? Database names overlap and shift "
+            "(\"Web of Science\" vs \"Web of Knowledge\", \"PsycINFO\" "
+            "vs \"Psychology and Behavioral Sciences Collection\"); "
+            "the A-Z page disambiguates them with current names + "
+            "subject tags.\n\n"
+            "Databases A-Z: https://libguides.lib.miamioh.edu/az/databases"
+        ),
+    ),
+    "find_resource": IntentCapability(
+        intent="find_resource",
+        tier=CapabilityTier.POINT_TO_URL,
+        canonical_url="https://miamioh.primo.exlibrisgroup.com/discovery/search?vid=01OHIOLINK_MIAMI:miami",
+        short_message=(
+            "To find a specific book, article, journal, or DVD at "
+            "Miami University Libraries, search Primo -- the library "
+            "catalog. It searches across our physical collection, "
+            "ebooks, journal articles, and OhioLINK partner libraries "
+            "in one place.\n\n"
+            "Primo: https://miamioh.primo.exlibrisgroup.com/\n\n"
+            "If Primo says \"no results\" and you think the library "
+            "should have it, you can request it through Interlibrary "
+            "Loan: https://www.lib.miamioh.edu/use/borrow/ill/"
+        ),
+    ),
+}
+
+
+# --- REFUSE intents ------------------------------------------------------
+#
+# Bot can't answer for principled reasons. Templated refusal explains
+# why and points to the right next step.
+
+_REFUSE: dict[str, IntentCapability] = {
+    "account": IntentCapability(
+        intent="account",
+        tier=CapabilityTier.REFUSE,
+        canonical_url="https://ohiolink-mu.primo.exlibrisgroup.com/discovery/account?vid=01OHIOLINK_MIAMI:miami",
+        short_message=(
+            "I can't access your library account -- only you can. "
+            "To see your current checkouts, holds, due dates, or "
+            "fines, sign in to MyAccount with your Miami credentials.\n\n"
+            "MyAccount: https://ohiolink-mu.primo.exlibrisgroup.com/discovery/account?vid=01OHIOLINK_MIAMI:miami\n\n"
+            "If you need help with something MyAccount doesn't show "
+            "(e.g., a fine you think is wrong), please contact "
+            "circulation at (513) 529-4141 or chat with a librarian "
+            "via Ask Us."
+        ),
+        refusal_trigger="account_privacy",
+    ),
+    "events_news": IntentCapability(
+        intent="events_news",
+        tier=CapabilityTier.REFUSE,
+        canonical_url="https://www.lib.miamioh.edu/about/news-events/",
+        short_message=(
+            "I don't have information about library events, news, or "
+            "exhibits. The bot is intentionally limited to evergreen "
+            "service and policy content -- old event listings are a "
+            "common source of misleading answers, so they're excluded.\n\n"
+            "For current events, exhibits, and library news, please "
+            "visit the News & Events page directly: "
+            "https://www.lib.miamioh.edu/about/news-events/"
+        ),
+        refusal_trigger="news_excluded",
+    ),
+}
+
+
+# --- Public lookup -------------------------------------------------------
+
+
+def get_intent_capability(intent: str) -> IntentCapability:
+    """Look up an intent's capability tier.
+
+    Returns READY for any intent not explicitly registered as
+    POINT_TO_URL or REFUSE. This means: the default for new intents
+    (or typo'd intents) is to run the agent and let the grounding
+    contract handle refusal naturally. Better to err on the side of
+    letting the agent try than silently refuse.
+    """
+    if intent in _POINT_TO_URL:
+        return _POINT_TO_URL[intent]
+    if intent in _REFUSE:
+        return _REFUSE[intent]
+    return IntentCapability(intent=intent, tier=CapabilityTier.READY)
+
+
+def all_capabilities() -> dict[str, IntentCapability]:
+    """All explicitly-registered capabilities. READY intents are NOT
+    included -- they have no special configuration. Used by tests
+    and the admin dashboard's intent-coverage view.
+    """
+    out: dict[str, IntentCapability] = {}
+    out.update(_POINT_TO_URL)
+    out.update(_REFUSE)
+    return out
+
+
+__all__ = [
+    "CapabilityTier",
+    "IntentCapability",
+    "all_capabilities",
+    "get_intent_capability",
+]

--- a/ai-core/src/router/test_intent_capabilities.py
+++ b/ai-core/src/router/test_intent_capabilities.py
@@ -1,0 +1,242 @@
+"""
+Unit tests for the per-intent capability registry.
+
+Run: `python -m src.router.test_intent_capabilities` from ai-core/.
+
+The registry decides whether the orchestrator runs the agent or
+short-circuits to a templated response. Bugs go two ways:
+
+  - False POINT_TO_URL or REFUSE for an intent that should run the
+    agent: the librarian-flagged "circulation_basic" question gets
+    a generic refusal instead of a real answer.
+  - False READY for an intent that should short-circuit: the bot
+    burns agent + synth tokens trying to answer "how much do I owe"
+    and produces a hallucinated balance.
+
+Tests pin every registered capability and every default behavior.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Allow running from ai-core/ as `python -m src.router.test_intent_capabilities`.
+_HERE = Path(__file__).resolve().parent
+_AI_CORE = _HERE.parent.parent
+sys.path.insert(0, str(_AI_CORE))
+
+from src.router.intent_capabilities import (  # noqa: E402
+    CapabilityTier,
+    IntentCapability,
+    all_capabilities,
+    get_intent_capability,
+)
+from src.router.intent_knn import INTENTS  # noqa: E402
+
+
+# --- POINT_TO_URL intents ------------------------------------------------
+
+
+def test_databases_is_point_to_url() -> None:
+    """Per librarian decision: never look up DB by name; always route
+    to A-Z. Users misspell DB names too often to risk a wrong-DB
+    answer."""
+    cap = get_intent_capability("databases")
+    assert cap.tier == CapabilityTier.POINT_TO_URL
+    assert "libguides.lib.miamioh.edu/az/databases" in cap.canonical_url
+    assert "Databases A-Z" in cap.short_message
+    # Defends the design decision in the body so it's readable to
+    # future maintainers.
+    assert "Web of Science" in cap.short_message  # the disambiguation example
+
+
+def test_find_resource_is_point_to_url_to_primo() -> None:
+    cap = get_intent_capability("find_resource")
+    assert cap.tier == CapabilityTier.POINT_TO_URL
+    assert "primo" in cap.canonical_url.lower()
+    assert "Primo" in cap.short_message
+    # Includes the ILL fallback for "we don't have it" path.
+    assert "Interlibrary Loan" in cap.short_message
+
+
+# --- REFUSE intents ------------------------------------------------------
+
+
+def test_account_is_refuse_with_privacy_trigger() -> None:
+    cap = get_intent_capability("account")
+    assert cap.tier == CapabilityTier.REFUSE
+    assert cap.refusal_trigger == "account_privacy"
+    assert cap.canonical_url is not None
+    assert "MyAccount" in cap.short_message
+    # The refusal must be explicit -- "I can't access your account",
+    # not just "I don't know" -- so the user understands the boundary.
+    assert "can't access your library account" in cap.short_message
+
+
+def test_events_news_is_refuse_with_news_excluded_trigger() -> None:
+    cap = get_intent_capability("events_news")
+    assert cap.tier == CapabilityTier.REFUSE
+    assert cap.refusal_trigger == "news_excluded"
+    assert cap.canonical_url is not None
+    # Must explain WHY (stale events are misleading).
+    assert (
+        "old event" in cap.short_message.lower()
+        or "stale" in cap.short_message.lower()
+    )
+
+
+# --- READY default ------------------------------------------------------
+
+
+def test_unregistered_intent_defaults_to_ready() -> None:
+    """Any intent not explicitly POINT_TO_URL or REFUSE runs the
+    agent. Default-allow is safer than default-deny: a typo'd intent
+    name produces a real answer attempt rather than silently
+    refusing."""
+    cap = get_intent_capability("hours")
+    assert cap.tier == CapabilityTier.READY
+    assert cap.canonical_url is None
+    assert cap.short_message == ""
+    assert cap.refusal_trigger == ""
+
+
+def test_makerspace_is_ready() -> None:
+    """Sanity check that bread-and-butter intents stay READY."""
+    cap = get_intent_capability("makerspace_3d")
+    assert cap.tier == CapabilityTier.READY
+
+
+def test_subject_librarian_is_ready() -> None:
+    cap = get_intent_capability("subject_librarian")
+    assert cap.tier == CapabilityTier.READY
+
+
+def test_interlibrary_loan_is_ready() -> None:
+    """ILL stays READY -- the agent calls point_to_url to return
+    the form. Per plan: action vs guidance distinction."""
+    cap = get_intent_capability("interlibrary_loan")
+    assert cap.tier == CapabilityTier.READY
+
+
+def test_unknown_intent_string_does_not_crash() -> None:
+    """Defensive: garbage input doesn't crash the lookup."""
+    cap = get_intent_capability("totally_made_up_intent_xyz")
+    assert cap.tier == CapabilityTier.READY
+
+
+# --- Coverage / lock-in -------------------------------------------------
+
+
+def test_every_registered_capability_has_canonical_url() -> None:
+    """POINT_TO_URL and REFUSE both require a destination URL --
+    that's the whole point. A registry entry without one is a bug."""
+    for cap in all_capabilities().values():
+        assert cap.canonical_url, (
+            f"{cap.intent} has tier={cap.tier} but no canonical_url"
+        )
+
+
+def test_every_registered_capability_has_short_message() -> None:
+    for cap in all_capabilities().values():
+        assert cap.short_message.strip(), (
+            f"{cap.intent} has empty short_message"
+        )
+
+
+def test_refuse_capabilities_have_refusal_trigger() -> None:
+    for cap in all_capabilities().values():
+        if cap.tier == CapabilityTier.REFUSE:
+            assert cap.refusal_trigger, (
+                f"REFUSE capability {cap.intent} missing refusal_trigger"
+            )
+
+
+def test_point_to_url_capabilities_have_no_refusal_trigger() -> None:
+    """POINT_TO_URL is an answer, not a refusal -- the trigger field
+    should be empty."""
+    for cap in all_capabilities().values():
+        if cap.tier == CapabilityTier.POINT_TO_URL:
+            assert not cap.refusal_trigger, (
+                f"POINT_TO_URL capability {cap.intent} should not have "
+                f"a refusal_trigger; got {cap.refusal_trigger!r}"
+            )
+
+
+def test_registered_intents_are_in_INTENTS_tuple() -> None:
+    """Every key in the registry must be a real intent. A typo'd key
+    here would silently never fire."""
+    for intent in all_capabilities():
+        assert intent in INTENTS, (
+            f"capability registered for unknown intent: {intent!r}"
+        )
+
+
+def test_every_intent_resolves_without_crash() -> None:
+    """Smoke check: get_intent_capability handles every intent the
+    classifier might return."""
+    for intent in INTENTS:
+        cap = get_intent_capability(intent)
+        assert cap is not None
+        assert cap.tier in (
+            CapabilityTier.READY,
+            CapabilityTier.POINT_TO_URL,
+            CapabilityTier.REFUSE,
+        )
+
+
+def test_capability_tier_string_values() -> None:
+    """JSON-serializable enum values for log shipping."""
+    assert CapabilityTier.READY.value == "ready"
+    assert CapabilityTier.POINT_TO_URL.value == "point_to_url"
+    assert CapabilityTier.REFUSE.value == "refuse"
+
+
+def test_intent_capability_dataclass_immutability() -> None:
+    """Frozen dataclass -- prevents callers from mutating registry
+    entries (which would persist across requests)."""
+    cap = get_intent_capability("databases")
+    try:
+        cap.canonical_url = "https://attacker.example/"  # type: ignore[misc]
+    except Exception:
+        return
+    raise AssertionError("expected frozen dataclass to reject mutation")
+
+
+def main() -> int:
+    tests = [
+        test_databases_is_point_to_url,
+        test_find_resource_is_point_to_url_to_primo,
+        test_account_is_refuse_with_privacy_trigger,
+        test_events_news_is_refuse_with_news_excluded_trigger,
+        test_unregistered_intent_defaults_to_ready,
+        test_makerspace_is_ready,
+        test_subject_librarian_is_ready,
+        test_interlibrary_loan_is_ready,
+        test_unknown_intent_string_does_not_crash,
+        test_every_registered_capability_has_canonical_url,
+        test_every_registered_capability_has_short_message,
+        test_refuse_capabilities_have_refusal_trigger,
+        test_point_to_url_capabilities_have_no_refusal_trigger,
+        test_registered_intents_are_in_INTENTS_tuple,
+        test_every_intent_resolves_without_crash,
+        test_capability_tier_string_values,
+        test_intent_capability_dataclass_immutability,
+    ]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:
+            failed += 1
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ai-core/src/synthesis/refusal_templates.py
+++ b/ai-core/src/synthesis/refusal_templates.py
@@ -24,7 +24,7 @@ from typing import Optional
 
 
 class RefusalTrigger(str, Enum):
-    """The nine reasons a turn can downgrade to a refusal.
+    """The reasons a turn can downgrade to a refusal.
 
     String-valued so the enum is JSON-serializable for logging and
     eval-suite reporting without a custom encoder.
@@ -39,8 +39,8 @@ class RefusalTrigger(str, Enum):
 
     # Intent / capability side
     OUT_OF_SCOPE = "out_of_scope"
-    """kNN classifier picked `out_of_scope` (e.g. catalog searches,
-    sports scores, homework help)."""
+    """kNN classifier picked `out_of_scope` (e.g. sports scores,
+    homework help, weather)."""
 
     CAPABILITY_LIMIT = "capability_limit"
     """capability_scope.py flagged this as a thing the bot cannot do
@@ -49,6 +49,17 @@ class RefusalTrigger(str, Enum):
     LIVE_DATA_DOWN = "live_data_down"
     """LibCal / LibAnswers tool call failed or timed out. The bot
     refuses with this trigger instead of guessing stale hours."""
+
+    # Per-intent capability registry (intent_capabilities.py) hits
+    ACCOUNT_PRIVACY = "account_privacy"
+    """User asked about MY checkouts/fines/holds. Bot has no access to
+    user-specific account state and must point to MyAccount login."""
+
+    NEWS_EXCLUDED = "news_excluded"
+    """User asked about library news / events / exhibits. ETL design
+    excludes /about/news-events/* (stale event content is the prime
+    source of "fake service" hallucinations). Point to the live
+    News & Events page."""
 
     # Synthesizer side
     MODEL_SELF_FLAGGED = "model_self_flagged"
@@ -148,6 +159,21 @@ _TEMPLATES: dict[RefusalTrigger, str] = {
         "There isn't a {service_name} at the {campus_display} campus "
         "library. {service_name} is at {service_available_at}. For help "
         "at {campus_display}, ask the library staff through Ask Us."
+    ),
+    # Per-intent capability refusals. The full body (including the
+    # canonical URL) lives in intent_capabilities.py -- the orchestrator
+    # uses that copy directly. These short fallbacks cover the case
+    # where someone calls render_refusal() on these triggers without
+    # going through the capability registry first.
+    RefusalTrigger.ACCOUNT_PRIVACY: (
+        "I can't see your library account. To view your checkouts, "
+        "holds, and fines, sign in to MyAccount with your Miami "
+        "credentials."
+    ),
+    RefusalTrigger.NEWS_EXCLUDED: (
+        "I don't have library events, news, or exhibits indexed. "
+        "Please check the News & Events page on the library website "
+        "directly for current listings."
     ),
 }
 

--- a/ai-core/src/synthesis/test_refusal_templates.py
+++ b/ai-core/src/synthesis/test_refusal_templates.py
@@ -49,6 +49,10 @@ SCOPE_FREE_TRIGGERS = [
     RefusalTrigger.LIVE_DATA_DOWN,
     RefusalTrigger.MODEL_SELF_FLAGGED,
     RefusalTrigger.CITATION_INVALID,
+    # Per-intent capability registry refusals (intent_capabilities.py
+    # routes here when classifier picks `account` or `events_news`).
+    RefusalTrigger.ACCOUNT_PRIVACY,
+    RefusalTrigger.NEWS_EXCLUDED,
 ]
 
 SCOPED_TRIGGERS = [


### PR DESCRIPTION
## Why
You asked: "with 31 intents, are you ready to answer all of them?" The honest answer was no — some intents are deliberately not LLM-answerable. This PR builds the explicit registry that decides per-intent whether to run the agent or short-circuit to a templated response.

**Targets at https://github.com/Meng-V/chatbot/tree/claude/intent-taxonomy-v2** — should be merged AFTER PR #33.

## What lives where now

| Intent | Tier | Behavior |
|---|---|---|
| `account` | **REFUSE** | Privacy: bot has no access to user-specific data. Templated refusal pointing to MyAccount. |
| `events_news` | **REFUSE** | Plan §"Data preparation playbook" excludes `/about/news-events/*` (stale event content = misleading). Points to live News & Events page. |
| `find_resource` | **POINT_TO_URL** | Catalog search → Primo. Includes ILL fallback for "we don't have it". |
| `databases` | **POINT_TO_URL** | **Per your decision**: never look up DB by name; users routinely misspell ("Web of Science" vs "Web of Knowledge"). Always route to https://libguides.lib.miamioh.edu/az/databases — the body explains why. |
| All other 27 intents | **READY** | Run the agent normally; grounding contract handles refusal naturally |

## Architecture
```python
# Step 2.5 in new_orchestrator.py (after classification, before agent)
capability = get_intent_capability(classification.intent)
if capability.tier in (POINT_TO_URL, REFUSE):
    return _capability_response(...)  # zero LLM tokens
# else READY: continue with agent run
```

`_capability_response`:
- Returns the templated `short_message` body verbatim (no LLM)
- Single citation pointing at `canonical_url`
- `model_used="(none -- capability registry)"`
- `tokens={"input": 0, "cached_input": 0, "output": 0}` — zero spend
- `agent_stopped_reason="point_to_url"` or `"refuse"` for telemetry

Saves agent + synth tokens for these 4 intents on every turn that hits them.

## What changed
| File | Change |
|---|---|
| `src/router/intent_capabilities.py` | **New**: registry + `get_intent_capability()` + `all_capabilities()` |
| `src/router/test_intent_capabilities.py` | **New**: 17 tests |
| `src/synthesis/refusal_templates.py` | +`ACCOUNT_PRIVACY` + `NEWS_EXCLUDED` triggers + short fallback templates |
| `src/synthesis/test_refusal_templates.py` | Added the 2 new triggers to the coverage list |
| `src/graph/new_orchestrator.py` | Imported registry; added step 2.5 early-out; added `_capability_response` helper |
| `src/graph/test_new_orchestrator.py` | +5 integration tests for the short-circuit paths |

## Tests — 43 across 3 files
| File | Tests |
|---|---|
| `test_intent_capabilities.py` | 17/17 |
| `test_new_orchestrator.py` | 18/18 (was 13; +5 for capability paths) |
| `test_refusal_templates.py` | 8/8 (new triggers picked up via existing coverage check) |

## What this does NOT do
- Doesn't add tier=READY-with-tools registry for the agent path. Per the design, READY intents trust the agent's grounding contract; this PR doesn't second-guess that.
- Doesn't add a `NEEDS_ETL` tier for `circulation_basic` / `renewal` / `loan_policy` etc. Those will work once the first ETL run indexes the LibGuide content (issue #20). If they fail in production before that, we add the tier in a follow-up.

## Test plan
- [x] `python -m src.router.test_intent_capabilities` — 17/17 pass
- [x] `python -m src.graph.test_new_orchestrator` — 18/18 pass
- [x] `python -m src.synthesis.test_refusal_templates` — 8/8 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)