### PR TITLE
etl: hash chunk_id → uuid5 for Weaviate + surface embed errors (PR #44 hotfix)

### DIFF
--- a/ai-core/scripts/etl/upsert.py
+++ b/ai-core/scripts/etl/upsert.py
@@ -135,9 +135,15 @@ def embed_chunks(
             for item in resp.data:
                 out.append(list(item.embedding))
         except Exception as e:  # noqa: BLE001 -- never let one batch kill the run
+            # Include the actual error text in the log message so the
+            # default logging format surfaces it (extras aren't shown by
+            # default). Also log batch position + the longest input's
+            # length -- OpenAI's most common 400 cause is a single
+            # chunk exceeding the 8192-token cap.
+            max_chars = max((len(t) for t in texts), default=0)
             logger.error(
-                "embed batch failed",
-                extra={"batch_start": i, "batch_size": len(batch), "error": str(e)},
+                "embed batch failed [batch_start=%d size=%d max_chars=%d]: %s",
+                i, len(batch), max_chars, e,
             )
             # Pad with empty vectors so positions line up; upsert drops these.
             out.extend([[]] * len(batch))

--- a/ai-core/src/weaviate/etl_adapter.py
+++ b/ai-core/src/weaviate/etl_adapter.py
@@ -40,10 +40,29 @@ from __future__ import annotations
 
 import datetime as dt
 import logging
+import uuid
 from dataclasses import dataclass, field
 from typing import Any, Iterable, Optional
 
 logger = logging.getLogger(__name__)
+
+
+# Fixed namespace for converting the ETL's chunk_id (a short hex string
+# like "c-d8cb85a69c92d7ef") into a deterministic UUID5. Weaviate v4
+# strictly validates that an object's id field is a UUID; the chunker
+# emits arbitrary strings, so we hash them through uuid5 at this boundary.
+# Same chunk_id -> same UUID across runs, preserving idempotency.
+_CHUNK_NS = uuid.UUID("c0000000-0000-0000-c0c0-c0c0c0c0c0c0")
+
+
+def _chunk_uuid(chunk_id: str) -> str:
+    """Convert the ETL's chunk_id (arbitrary string) to a stable UUID
+    for use as a Weaviate object id.
+
+    Deterministic: `_chunk_uuid("c-abc") == _chunk_uuid("c-abc")` on every
+    call, so dedup / upsert by chunk_id still works.
+    """
+    return str(uuid.uuid5(_CHUNK_NS, chunk_id))
 
 
 # ----------------------------------------------------------------------------
@@ -56,6 +75,13 @@ logger = logging.getLogger(__name__)
 # Keep them in lockstep -- a schema/code mismatch produces silent prop drops.
 _CHUNK_PROPERTIES: tuple[tuple[str, str], ...] = (
     # (name, weaviate v4 DataType enum name)
+    # The Weaviate object's UUID is derived from `chunk_id` via uuid5
+    # (see `_chunk_uuid`). The original chunk_id string is ALSO stored
+    # as a property so callers can:
+    #   * Look up by chunk_id (filter on this property)
+    #   * Join back to ChunkProvenance.chunkId (Postgres uses the
+    #     original 'c-...' format, not the UUID5).
+    ("chunk_id", "TEXT"),
     ("document_id", "TEXT"),
     ("source_url", "TEXT"),
     ("text", "TEXT"),
@@ -167,19 +193,28 @@ class WeaviateETLAdapter:
     ) -> None:
         """Insert if new, replace if exists. Idempotent on chunk_id.
 
-        The chunk_id MUST be a valid UUID string (the chunker emits
-        these). v4 uses the UUID as the object's primary key, so the
-        ETL's "chunk_id is the dedup key" contract maps directly.
+        The chunker emits chunk_ids in the format 'c-<16 hex>' (see
+        `scripts/etl/chunker._derive_chunk_id`). Weaviate v4 requires
+        the object's id to be a valid UUID, so we hash the chunk_id
+        through uuid5 (`_chunk_uuid`) before sending. The original
+        chunk_id is stored as a property for callers that need to
+        look up by it OR join to `ChunkProvenance.chunkId` (Postgres
+        uses the original 'c-...' format).
         """
         self._ensure_collection(collection)
         coll = self.client.collections.get(collection)
+        obj_uuid = _chunk_uuid(chunk_id)
+        # Always include `chunk_id` as a property so the original
+        # identifier survives the UUID conversion. Callers may also
+        # have set it; if so we overwrite-with-same-value (no-op).
+        props_with_chunk_id = {**properties, "chunk_id": chunk_id}
         # `replace` is the upsert primitive in v4 if you key on UUID.
         # It creates if not found, replaces if found. Equivalent to
         # PUT in REST terms.
         try:
             coll.data.replace(
-                uuid=chunk_id,
-                properties=properties,
+                uuid=obj_uuid,
+                properties=props_with_chunk_id,
                 vector=vector,
             )
         except Exception as e:  # noqa: BLE001
@@ -187,14 +222,15 @@ class WeaviateETLAdapter:
             # back to insert.
             try:
                 coll.data.insert(
-                    uuid=chunk_id,
-                    properties=properties,
+                    uuid=obj_uuid,
+                    properties=props_with_chunk_id,
                     vector=vector,
                 )
             except Exception as e2:  # noqa: BLE001
                 raise RuntimeError(
                     f"Weaviate upsert failed for chunk_id={chunk_id!r} "
-                    f"in {collection!r}: replace={e!r}, insert={e2!r}"
+                    f"(uuid={obj_uuid}) in {collection!r}: "
+                    f"replace={e!r}, insert={e2!r}"
                 ) from e2
 
     def get_chunk(
@@ -209,6 +245,11 @@ class WeaviateETLAdapter:
         decision. We don't return the vector (it's not needed for the
         dedup check + dragging 3072 floats through this hot path would
         be wasteful).
+
+        Like upsert_chunk, this hashes chunk_id -> UUID5 before the
+        Weaviate fetch. The returned `properties` includes the original
+        `chunk_id` field that upsert_chunk stored, so callers see the
+        unaltered identifier.
         """
         if collection not in self._created_collections:
             # Collection doesn't exist -> object doesn't exist. Avoid
@@ -222,8 +263,9 @@ class WeaviateETLAdapter:
             self._created_collections.add(collection)
 
         coll = self.client.collections.get(collection)
+        obj_uuid = _chunk_uuid(chunk_id)
         try:
-            obj = coll.query.fetch_object_by_id(chunk_id)
+            obj = coll.query.fetch_object_by_id(obj_uuid)
         except Exception as e:  # noqa: BLE001
             logger.warning(
                 "get_chunk failed",

--- a/ai-core/src/weaviate/test_etl_adapter.py
+++ b/ai-core/src/weaviate/test_etl_adapter.py
@@ -33,7 +33,11 @@ _HERE = Path(__file__).resolve().parent
 _AI_CORE = _HERE.parent.parent
 sys.path.insert(0, str(_AI_CORE))
 
-from src.weaviate.etl_adapter import WeaviateETLAdapter, _CHUNK_PROPERTIES
+from src.weaviate.etl_adapter import (
+    WeaviateETLAdapter,
+    _CHUNK_PROPERTIES,
+    _chunk_uuid,
+)
 
 
 # --- Stub v4 client surface --------------------------------------------
@@ -233,6 +237,12 @@ def test_ensure_collection_creates_with_documented_properties() -> None:
     assert expected_names.issubset(created_names), (
         f"missing properties: {expected_names - created_names}"
     )
+    # chunk_id is the property that holds the original (pre-UUID5)
+    # identifier. Its presence in the schema is load-bearing -- without
+    # it, callers can't look up by chunk_id and ChunkProvenance joins
+    # break. Lock this in explicitly so a future refactor doesn't
+    # silently drop it.
+    assert "chunk_id" in created_names
 
 
 def test_ensure_collection_idempotent_after_first_call() -> None:
@@ -262,9 +272,56 @@ def test_upsert_chunk_writes_via_replace() -> None:
         vector=[0.1, 0.2, 0.3],
     )
     stored = a.client.collections._collections["Chunk_v1"].objects
-    assert "cid-1" in stored
-    assert stored["cid-1"]["properties"]["text"] == "hello"
-    assert stored["cid-1"]["vector"] == [0.1, 0.2, 0.3]
+    # The adapter writes the object under uuid5(chunk_id), not the raw
+    # chunk_id (Weaviate v4 422s on non-UUID ids -- the bug PR #44
+    # ended up with in prod).
+    stored_uuid = _chunk_uuid("cid-1")
+    assert stored_uuid in stored
+    assert stored[stored_uuid]["properties"]["text"] == "hello"
+    assert stored[stored_uuid]["vector"] == [0.1, 0.2, 0.3]
+    # And the original chunk_id is preserved as a property.
+    assert stored[stored_uuid]["properties"]["chunk_id"] == "cid-1"
+
+
+def test_chunk_uuid_is_deterministic() -> None:
+    """Same chunk_id must always produce the same UUID. Without this
+    property, dedup-by-chunk-id breaks on re-runs."""
+    a = _chunk_uuid("c-d8cb85a69c92d7ef")
+    b = _chunk_uuid("c-d8cb85a69c92d7ef")
+    assert a == b
+
+
+def test_chunk_uuid_distinguishes_different_ids() -> None:
+    """Different chunk_ids must produce different UUIDs. Otherwise
+    two unrelated chunks would collide in Weaviate."""
+    assert _chunk_uuid("c-foo") != _chunk_uuid("c-bar")
+
+
+def test_chunk_uuid_returns_valid_uuid_string() -> None:
+    """The returned string must parse as a UUID -- that's the whole
+    point of the conversion (Weaviate v4 validates this)."""
+    import uuid as _u
+    out = _chunk_uuid("c-d8cb85a69c92d7ef")
+    # Will raise ValueError if not a valid UUID.
+    _u.UUID(out)
+
+
+def test_upsert_then_get_chunk_roundtrip_via_chunk_id() -> None:
+    """Callers refer to chunks by the original chunk_id; the UUID5
+    conversion is internal to the adapter. Roundtrip through the
+    adapter's public surface must work regardless."""
+    a = _adapter()
+    a.upsert_chunk(
+        collection="Chunk_v1",
+        chunk_id="c-deterministic-test-id",
+        properties={"text": "roundtrip", "content_hash": "abc123"},
+        vector=[0.5, 0.5],
+    )
+    got = a.get_chunk(collection="Chunk_v1", chunk_id="c-deterministic-test-id")
+    assert got is not None
+    assert got["text"] == "roundtrip"
+    assert got["content_hash"] == "abc123"
+    assert got["chunk_id"] == "c-deterministic-test-id"
 
 
 def test_upsert_chunk_falls_back_to_insert_when_replace_fails() -> None:
@@ -281,8 +338,12 @@ def test_upsert_chunk_falls_back_to_insert_when_replace_fails() -> None:
         properties={"text": "via-insert"},
         vector=[1.0],
     )
-    # Fallback succeeded.
-    assert coll.objects["cid-2"]["properties"]["text"] == "via-insert"
+    # Fallback succeeded. Adapter hashes chunk_id -> UUID5 for the
+    # Weaviate id, so the stub's objects dict is keyed by that UUID.
+    stored_uuid = _chunk_uuid("cid-2")
+    assert coll.objects[stored_uuid]["properties"]["text"] == "via-insert"
+    # Original chunk_id is preserved as a property.
+    assert coll.objects[stored_uuid]["properties"]["chunk_id"] == "cid-2"
 
 
 def test_get_chunk_returns_properties_on_hit() -> None:
@@ -325,10 +386,13 @@ def test_soft_delete_by_url_tombstones_non_seen_only() -> None:
     )
     assert tombstoned == ["u3"]
     coll = a.client.collections._collections["Chunk_v1"]
-    assert coll.objects["c3"]["properties"]["deleted"] is True
-    assert coll.objects["c1"]["properties"]["deleted"] is False
+    # Stub's objects dict is keyed by the adapter's uuid5(chunk_id).
+    c1_uuid = _chunk_uuid("c1")
+    c3_uuid = _chunk_uuid("c3")
+    assert coll.objects[c3_uuid]["properties"]["deleted"] is True
+    assert coll.objects[c1_uuid]["properties"]["deleted"] is False
     # Tombstoned chunk should have a tombstoned_at timestamp.
-    assert coll.objects["c3"]["properties"].get("tombstoned_at")
+    assert coll.objects[c3_uuid]["properties"].get("tombstoned_at")
 
 
 def test_soft_delete_by_url_idempotent_on_already_deleted() -> None:
@@ -388,6 +452,10 @@ def main() -> int:
         test_ensure_collection_idempotent_after_first_call,
         test_ensure_collection_skips_create_if_already_exists,
         test_upsert_chunk_writes_via_replace,
+        test_chunk_uuid_is_deterministic,
+        test_chunk_uuid_distinguishes_different_ids,
+        test_chunk_uuid_returns_valid_uuid_string,
+        test_upsert_then_get_chunk_roundtrip_via_chunk_id,
         test_upsert_chunk_falls_back_to_insert_when_replace_fails,
         test_get_chunk_returns_properties_on_hit,
         test_get_chunk_returns_none_for_missing_object,


### PR DESCRIPTION
## What broke

First real \`--phase apply\` against \`ulblwebt04\` + the server's Weaviate v1.27.3 hit two bugs in PR #44's adapter code:

### 1. Weaviate 422 — \`id in body must be of type uuid\`

\`\`\`
RuntimeError: Weaviate upsert failed for chunk_id='c-d8cb85a69c92d7ef' in 'Chunk_vv20260514_1841':
  replace=UnexpectedStatusCodeError("'id in body must be of type uuid: \"c-d8cb85a69c92d7ef\"'"),
  insert=UnexpectedStatusCodeError("'id in body must be of type uuid: \"c-d8cb85a69c92d7ef\"'")
\`\`\`

The chunker emits chunk_ids in the format \`c-<16 hex>\` ([scripts/etl/chunker.py:_derive_chunk_id](https://github.com/Meng-V/chatbot/blob/main/ai-core/scripts/etl/chunker.py)). Weaviate v4 strictly validates the object id is a UUID — arbitrary strings get rejected with HTTP 422. PR #44's adapter sent the chunk_id verbatim, so the first \`upsert_chunk\` call crashed the apply phase.

**Fix**: hash \`chunk_id\` → UUID5 at the Weaviate boundary via \`_chunk_uuid(chunk_id)\`. Deterministic, so the same chunk_id maps to the same UUID across runs (idempotency preserved — dedup-by-chunk-id still works after rerun).

The original chunk_id is also written as a property (\`chunk_id\` in the \`Chunk\` schema) so:
- Callers can still filter on chunk_id at query time
- \`Message.citedChunkIds\` (Postgres) joins back to chunks correctly — Postgres keeps the original \`c-...\` format in \`ChunkProvenance.chunkId\`

### 2. Embed errors logged with no actual error text

47 of 52 batches returned HTTP 400 from OpenAI during the apply. The error was logged as \`embed batch failed\` with the actual exception in an \`extra={}\` dict — which the default Python logging formatter doesn't print. So I couldn't tell why the batches were failing.

**Fix**: include the exception in the log message string + log the longest input's char length (the most common 400 cause is a chunk exceeding the 8192-token cap). Doesn't change behavior, just makes the next run's 400 root cause visible.

## State of the failed apply

- Collection \`Chunk_vv20260514_1841\` was created on the server's Weaviate
- **It's empty** — the crash happened before any successful upsert
- \`UrlSeen\` is still 0 rows
- The \`.applied\` marker was NOT written, so the same diff can be retried

Cleanup is a single \`collection.delete()\` call once the retry succeeds. The next apply will pick a new timestamp-based collection name anyway.

## Tests

| Suite | Result |
|---|---|
| \`src/weaviate/test_etl_adapter.py\` | **18/18** (4 new tests for the UUID conversion) |
| \`scripts/etl/test_upsert.py\` | **20/20** (regression) |

### New tests

- \`test_chunk_uuid_is_deterministic\` — same chunk_id → same UUID across calls
- \`test_chunk_uuid_distinguishes_different_ids\` — collision-free for different inputs
- \`test_chunk_uuid_returns_valid_uuid_string\` — output parses as a real UUID (the contract Weaviate validates)
- \`test_upsert_then_get_chunk_roundtrip_via_chunk_id\` — public API uses chunk_id; internal UUID conversion is transparent

Updated 2 existing tests (\`upsert_chunk_writes_via_replace\`, \`soft_delete_by_url_tombstones_non_seen_only\`) to look up by the converted UUID instead of the raw chunk_id in the in-memory stub.

## Test plan for the next apply

After this merges:

1. Re-run \`python -m scripts.etl.run_etl --phase apply --diff 2026-05-14_1835.md\` (same diff, same approval — both are still valid)
2. Expect: ~5,091 chunks embedded successfully, written to a new \`Chunk_v<timestamp>\` collection
3. If the OpenAI 400 errors recur, the new log line will show the actual error message — likely a chunk-too-long issue that needs a separate chunker fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)