### PR TITLE
etl: hard-cap oversized chunks + token-budgeted embed batching

### DIFF
--- a/ai-core/scripts/etl/chunker.py
+++ b/ai-core/scripts/etl/chunker.py
@@ -159,15 +159,33 @@ def chunk_document(
         tail_chars = overlap_tokens * 4
         prev_tail = body[-tail_chars:] if tail_chars > 0 else ""
 
+    # Hard cap on any single emitted chunk: prevents the
+    # oversize-sentence path below from producing chunks larger than
+    # OpenAI's 8192-token embedding input limit. Same approximation
+    # (~4 chars / token) as _approximate_tokens, kept in sync.
+    hard_max_chars = config.CHUNK_HARD_MAX_TOKENS * 4
+
     for sent in sentences:
         sent_tokens = _approximate_tokens(sent)
         # If a single sentence exceeds the target, emit it on its own --
-        # better a too-long chunk than to drop content.
+        # better a too-long chunk than to drop content. But CAP its size
+        # at CHUNK_HARD_MAX_TOKENS: library pages routinely produce
+        # monster "sentences" (long lists, JS dumps, unparagraphed
+        # blocks) that exceed the 8192-token embedding cap, which
+        # causes the whole embed batch to silently fail (see
+        # scripts/etl/upsert.py::embed_chunks).
         if sent_tokens >= target:
             if buf:
                 emit(buf)
                 buf, buf_tokens = [], 0
-            emit([sent])
+            if sent_tokens <= config.CHUNK_HARD_MAX_TOKENS:
+                emit([sent])
+            else:
+                # Hard-split by character window. Slight token bleed
+                # at boundaries is acceptable -- the alternative is
+                # losing the chunk's content entirely to a 400.
+                for start in range(0, len(sent), hard_max_chars):
+                    emit([sent[start : start + hard_max_chars]])
             continue
         if buf_tokens + sent_tokens > target:
             emit(buf)

--- a/ai-core/scripts/etl/config.py
+++ b/ai-core/scripts/etl/config.py
@@ -215,6 +215,14 @@ LIBRARY_BY_URL_SUBSTRING: Final[tuple[tuple[str, str], ...]] = (
 CHUNK_TARGET_TOKENS: Final[int] = 400
 CHUNK_OVERLAP_TOKENS: Final[int] = 50
 CHUNK_MIN_TOKENS: Final[int] = 50  # drop chunks shorter than this (boilerplate)
+# Hard upper bound on a single chunk's token count. Enforced by the chunker
+# when a "sentence" (post sentence-splitter) is itself larger than the target:
+# such sentences are hard-split into character windows of this size. The cap
+# exists because OpenAI's text-embedding-3-large rejects inputs above 8192
+# tokens with a 400, which causes the whole embed batch to fail silently
+# (see scripts/etl/upsert.py::embed_chunks). 1000 leaves a 7x safety margin
+# vs. the model limit and accommodates the ~50-token overlap prepend.
+CHUNK_HARD_MAX_TOKENS: Final[int] = 1000
 
 
 # --- Extraction quality gates -----------------------------------------------

--- a/ai-core/scripts/etl/test_chunker.py
+++ b/ai-core/scripts/etl/test_chunker.py
@@ -232,11 +232,35 @@ def test_long_doc_splits_into_multiple_chunks() -> None:
 
 def test_oversized_single_sentence_still_emits() -> None:
     """A pathological single sentence longer than CHUNK_TARGET_TOKENS
-    still emits as one chunk -- better a fat chunk than to drop content."""
-    huge_sentence = "Word " * 1500  # ~1500 tokens, all one "sentence"
+    still emits chunks -- better a fat chunk than to drop content."""
+    huge_sentence = "Word " * 1500  # ~1875 approx-tokens, all one "sentence"
     chunks = chunk_document(_doc(body_text=huge_sentence), _meta())
     # Got something back even though it's larger than the target.
     assert len(chunks) >= 1
+
+
+def test_oversized_single_sentence_is_capped_at_hard_max() -> None:
+    """Regression: a pathological "sentence" (e.g. a JS dump or
+    unparagraphed list on a library page) MUST NOT produce a chunk
+    larger than CHUNK_HARD_MAX_TOKENS, because OpenAI's
+    text-embedding-3-large rejects inputs above 8192 tokens with a
+    400, which silently kills the whole embed batch.
+
+    Without the hard-split, a single 15k-token sentence would emit
+    one 15k-token chunk. We require it to be split into pieces, each
+    under the hard cap (with ~4 chars/token + small overlap slack)."""
+    # ~15000 approx-tokens (~60000 chars), well over the 8192 limit.
+    huge_sentence = "x" * 60_000
+    chunks = chunk_document(_doc(body_text=huge_sentence), _meta())
+    assert len(chunks) >= 2, "expected hard-split into multiple chunks"
+    # Each emitted chunk's approx-token count must be at-or-below the
+    # hard cap, plus a small slack for the prepended overlap prefix.
+    slack_tokens = config.CHUNK_OVERLAP_TOKENS + 10
+    cap = config.CHUNK_HARD_MAX_TOKENS + slack_tokens
+    for ch in chunks:
+        assert _approximate_tokens(ch.text) <= cap, (
+            f"chunk exceeds hard cap: {_approximate_tokens(ch.text)} > {cap}"
+        )
 
 
 def test_position_resets_per_document() -> None:
@@ -350,6 +374,7 @@ def main() -> int:
         test_short_doc_emits_one_chunk,
         test_long_doc_splits_into_multiple_chunks,
         test_oversized_single_sentence_still_emits,
+        test_oversized_single_sentence_is_capped_at_hard_max,
         test_position_resets_per_document,
         test_overlap_carries_text_across_boundary,
         test_content_hash_stable_for_stable_text,

--- a/ai-core/scripts/etl/test_upsert.py
+++ b/ai-core/scripts/etl/test_upsert.py
@@ -192,6 +192,30 @@ def test_embed_chunks_failure_pads_with_empty_vectors() -> None:
     assert out[4] and out[5]  # third batch succeeded
 
 
+def test_embed_chunks_truncates_oversized_input() -> None:
+    """Regression: if a chunk's text exceeds the embedding model's
+    input limit (~32k chars / 8192 tokens), embed_chunks MUST truncate
+    rather than send it as-is. The previous behavior caused OpenAI to
+    400 the whole batch, silently dropping up to 100 chunks per
+    oversized input. This is a second-layer defense; the chunker's
+    CHUNK_HARD_MAX_TOKENS is the primary guard."""
+    # 100k chars -> well above the 32k-ish embedding input cap.
+    huge_text = "x" * 100_000
+    chunks = [
+        _chunk(chunk_id="c-small", text="hello"),
+        _chunk(chunk_id="c-huge", text=huge_text),
+    ]
+    client = StubEmbedClient()
+    out = embed_chunks(chunks, client, model="text-embedding-3-large", batch_size=10)
+    # Batch succeeded (no padding-with-empties): both got real vectors.
+    assert len(out) == 2
+    assert out[0] and out[1]
+    # The client saw a truncated string for the huge input, not 100k chars.
+    sent_huge = client.calls[0]["input"][1]
+    assert len(sent_huge) < 100_000
+    assert len(sent_huge) <= 8192 * 4  # under the model's char-equivalent cap
+
+
 # --- upsert step -------------------------------------------------------
 
 
@@ -412,6 +436,7 @@ def main() -> int:
         test_embed_chunks_returns_one_vector_per_chunk,
         test_embed_chunks_batches,
         test_embed_chunks_failure_pads_with_empty_vectors,
+        test_embed_chunks_truncates_oversized_input,
         test_upsert_new_chunk_records_new,
         test_upsert_dedupes_unchanged_content_hash,
         test_upsert_records_change_when_content_hash_differs,

--- a/ai-core/scripts/etl/upsert.py
+++ b/ai-core/scripts/etl/upsert.py
@@ -104,6 +104,67 @@ class UrlSeenStore(Protocol):
 # --- Step 7: Embed -----------------------------------------------------------
 
 
+# Per-input cap. OpenAI text-embedding-3-large rejects single inputs
+# > 8192 tokens with a 400. ~4 chars/token, minus 1k chars slack for
+# multibyte / dense content. The chunker's CHUNK_HARD_MAX_TOKENS is
+# the primary guard; this is the second layer.
+_EMBED_MAX_INPUT_CHARS = 8192 * 4 - 1000
+
+# Per-REQUEST cap. text-embedding-3-large accepts up to 300_000 tokens
+# per request. We target a much lower budget because:
+#   1. tiktoken (cl100k_base) isn't always available, and our char/4
+#      estimate is wildly optimistic on dense text (URLs, code) where
+#      real tokens can be ~1.5x our estimate.
+#   2. The TPM (tokens-per-minute) rate limit is 5M; a few back-to-back
+#      300K-token requests trigger 429s. Smaller requests pace better.
+# 200_000 leaves 33% headroom against the 300K hard limit.
+_EMBED_MAX_BATCH_TOKENS = 200_000
+
+
+def _count_tokens(text: str, encoder: Any) -> int:
+    """Tokens for `text`, using tiktoken if available, else chars/4.
+
+    The chunker uses the same fallback (`_approximate_tokens`) so this
+    is consistent with chunk-size decisions when tiktoken isn't loaded.
+    """
+    if encoder is not None:
+        try:
+            return len(encoder.encode(text))
+        except Exception:  # noqa: BLE001 -- never let counting kill the run
+            pass
+    return max(1, len(text) // 4)
+
+
+def _iter_token_budgeted_batches(
+    texts: list[str],
+    *,
+    max_count: int,
+    max_tokens: int,
+    encoder: Any,
+) -> Iterable[tuple[int, list[str]]]:
+    """Yield `(batch_start, batch_texts)` such that each batch has
+    `len(batch) <= max_count` AND sum(tokens) <= max_tokens.
+
+    Single inputs already above `max_tokens` are yielded alone (caller
+    has already truncated to the per-input cap, so this is safe).
+    """
+    cur: list[str] = []
+    cur_tokens = 0
+    cur_start = 0
+    for i, t in enumerate(texts):
+        n = _count_tokens(t, encoder)
+        # Flush before adding if adding would exceed either cap.
+        if cur and (len(cur) >= max_count or cur_tokens + n > max_tokens):
+            yield cur_start, cur
+            cur = []
+            cur_tokens = 0
+            cur_start = i
+        cur.append(t)
+        cur_tokens += n
+    if cur:
+        yield cur_start, cur
+
+
 def embed_chunks(
     chunks: list[Chunk],
     client: EmbeddingClient,
@@ -113,11 +174,19 @@ def embed_chunks(
 ) -> list[list[float]]:
     """Compute embeddings for a list of chunks.
 
-    Batched per `batch_size` (OpenAI text-embedding-3-large allows up
-    to 2048; we default lower for headroom). Per-batch failure logs and
-    skips that batch with zero-vectors -- the upsert step tolerates
-    zero-vector rows by leaving them out of the index, so a partial
-    failure doesn't poison the whole run.
+    Batches are dynamically sized to satisfy BOTH:
+      - `len(batch) <= batch_size` (the count cap), AND
+      - sum(tokens(batch)) <= _EMBED_MAX_BATCH_TOKENS (the request cap).
+
+    The request-cap guard exists because OpenAI's embeddings API
+    rejects requests above 300_000 tokens, and our previous
+    fixed-count batching of 100 chunks could exceed that on
+    token-dense content even when each chunk was under the per-input
+    cap. See git history / PR #45 follow-up for the failure mode.
+
+    Per-batch failures log and pad with zero-vectors; the upsert step
+    tolerates zero-vector rows by leaving them out of the index, so a
+    partial failure doesn't poison the whole run.
 
     `model` MUST come from src/config/models.py::EMBEDDING_MODEL -- never
     hard-code a string here. The freshness rule applies: confirm the
@@ -125,12 +194,39 @@ def embed_chunks(
     """
     if not chunks:
         return []
+    # tiktoken is optional. If absent, fall back to chars/4 (same shape
+    # as the chunker's _approximate_tokens). The pipeline runs either
+    # way; tiktoken just makes the batching tighter.
+    encoder: Any = None
+    try:
+        import tiktoken  # type: ignore
+
+        encoder = tiktoken.get_encoding("cl100k_base")
+    except Exception:  # noqa: BLE001
+        encoder = None
+
+    # First pass: per-input truncation to keep any single chunk under
+    # the model's 8192-token-per-input cap.
+    texts: list[str] = []
+    for c in chunks:
+        t = c.text
+        if len(t) > _EMBED_MAX_INPUT_CHARS:
+            logger.warning(
+                "embed input truncated [chunk_id=%s orig_chars=%d -> %d]",
+                c.chunk_id, len(t), _EMBED_MAX_INPUT_CHARS,
+            )
+            t = t[:_EMBED_MAX_INPUT_CHARS]
+        texts.append(t)
+
     out: list[list[float]] = []
-    for i in range(0, len(chunks), batch_size):
-        batch = chunks[i : i + batch_size]
-        texts = [c.text for c in batch]
+    for batch_start, batch_texts in _iter_token_budgeted_batches(
+        texts,
+        max_count=batch_size,
+        max_tokens=_EMBED_MAX_BATCH_TOKENS,
+        encoder=encoder,
+    ):
         try:
-            resp = client.create(model=model, input=texts)
+            resp = client.create(model=model, input=batch_texts)
             # OpenAI SDK shape: resp.data is a list of objects with .embedding
             for item in resp.data:
                 out.append(list(item.embedding))
@@ -140,13 +236,13 @@ def embed_chunks(
             # default). Also log batch position + the longest input's
             # length -- OpenAI's most common 400 cause is a single
             # chunk exceeding the 8192-token cap.
-            max_chars = max((len(t) for t in texts), default=0)
+            max_chars = max((len(t) for t in batch_texts), default=0)
             logger.error(
                 "embed batch failed [batch_start=%d size=%d max_chars=%d]: %s",
-                i, len(batch), max_chars, e,
+                batch_start, len(batch_texts), max_chars, e,
             )
             # Pad with empty vectors so positions line up; upsert drops these.
-            out.extend([[]] * len(batch))
+            out.extend([[]] * len(batch_texts))
     return out
 
 


### PR DESCRIPTION
## Summary

Two distinct bugs were blocking the embed step from completing. Both surfaced during real \`--phase apply\` runs against \`ulblwebt04\` + the server's Weaviate. Fixed in this PR. **Verified end-to-end: 20,255 chunks written to \`Chunk_vv20260514_1929\` with 0 failures.**

Follow-up to PR #45 (which fixed the UUID-format bug + made these embed errors visible in the logs — that visibility is what let us diagnose these next two layers).

## Bug 1 — oversized single chunks → OpenAI 400

The chunker's sentence splitter occasionally emits sentences larger than text-embedding-3-large's 8192-token per-input cap. The embed step then sends a 100-chunk batch with one giant input, OpenAI 400s the whole batch, \`embed_chunks\` pads all 100 with empty vectors, and the upsert step silently drops them.

**Effect**: first retry of the apply went from 47 failed batches (~470 chunks lost) to 0 failures on individual chunks, but turned into bug #2 below at batch level.

**Fix**:
- \`config.CHUNK_HARD_MAX_TOKENS = 1000\` — absolute upper bound. 7× headroom under the 8192 model limit, with room for the 50-token overlap prepend.
- Chunker hard-splits any \"sentence\" above this into character windows. Content preserved (not dropped), just sliced.

## Bug 2 — per-REQUEST token cap → OpenAI 400

After bug #1's fix, **71 of 132 batches still 400'd**:

\`\`\`
Invalid 'input': maximum request size is 300000 tokens per request
\`\`\`

The per-input cap stops 8192-overruns on a single chunk, but stuffing 100 chunks of ~1000 tokens each can still exceed the 300K-token per-REQUEST limit on dense content (URLs, code, lists) where real tokenization runs ~1.5× our \`chars/4\` estimate.

**Fix**:
- \`_EMBED_MAX_BATCH_TOKENS = 200_000\` — per-request token budget. 33% headroom under the 300K hard limit (because the chars/4 heuristic underestimates on dense content).
- \`_iter_token_budgeted_batches()\` — dynamic bin-packing. Each batch satisfies BOTH \`len(batch) <= 100\` AND \`sum(tokens) <= 200_000\`. Uses \`tiktoken\` (cl100k_base) when available, falls back to chars/4 when not — same shape as the chunker's \`_approximate_tokens\`.
- \`_count_tokens()\` helper — never lets counting kill the run.

## Belt-and-suspenders: per-input truncation

\`embed_chunks\` now also truncates any input above \`_EMBED_MAX_INPUT_CHARS\` (≈31.7K chars, accounting for the chars/4 estimate) and warns. The chunker's hard-cap is the primary guard; this is the safety net for any chunk that slips through — e.g. a future bug in the chunker's sentence detection, or a non-English doc where the encoder is wrong.

## Verified

| Metric | Pre-PR-#45 | Post-#45, pre-this | Post-this |
|---|---|---|---|
| Chunks written | 0 (UUID crash) | 13,155 | **20,255** |
| Embed batch failures | n/a (crashed) | 71 | **0** |
| Truncation warnings | n/a | n/a | **0** |

Final apply: \`ETL apply finished in 820s, 20255 new chunks written to Chunk_vv20260514_1929\`.

## Tests

- \`scripts/etl/test_chunker.py\` — **+1** \`test_oversized_single_sentence_is_capped_at_hard_max\`
- \`scripts/etl/test_upsert.py\` — **+1** \`test_embed_chunks_truncates_oversized_input\`
- All existing tests: regression-clean (47/47 total in the affected suites)

## Files

| File | Change |
|---|---|
| \`scripts/etl/config.py\` | +8 — \`CHUNK_HARD_MAX_TOKENS = 1000\` constant |
| \`scripts/etl/chunker.py\` | +22 — hard-split oversized sentences into char windows |
| \`scripts/etl/upsert.py\` | +120 — \`tiktoken\` import + \`_count_tokens\` + \`_iter_token_budgeted_batches\` + per-input truncation |
| \`scripts/etl/test_chunker.py\` | +29 — new test |
| \`scripts/etl/test_upsert.py\` | +25 — new test |

## What this unblocks

This is the **final embed-pipeline blocker**. With this merged, the full rebuild is operationally green:

- Server's Weaviate has 20,255 real Miami library chunks ✓
- \`UrlSeen\` populated ✓
- URL validator can validate against a real allowlist ✓
- Synthesizer has real evidence to ground on ✓
- LLM-as-judge can score real bot answers ✓

The next chunk of work is verification at the bot level: re-run \`scripts/eval_classifier_v38.py\` and \`scripts/sweep_thresholds.py\` against the now-populated index, then \`run_eval.py --with-real-llm --with-judge\` end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)