### PR TITLE
etl: promote_collection — v4 alias API + env-var fallback for old servers

### DIFF
--- a/ai-core/scripts/etl/chunker.py
+++ b/ai-core/scripts/etl/chunker.py
@@ -159,15 +159,33 @@ def chunk_document(
         tail_chars = overlap_tokens * 4
         prev_tail = body[-tail_chars:] if tail_chars > 0 else ""
 
+    # Hard cap on any single emitted chunk: prevents the
+    # oversize-sentence path below from producing chunks larger than
+    # OpenAI's 8192-token embedding input limit. Same approximation
+    # (~4 chars / token) as _approximate_tokens, kept in sync.
+    hard_max_chars = config.CHUNK_HARD_MAX_TOKENS * 4
+
     for sent in sentences:
         sent_tokens = _approximate_tokens(sent)
         # If a single sentence exceeds the target, emit it on its own --
-        # better a too-long chunk than to drop content.
+        # better a too-long chunk than to drop content. But CAP its size
+        # at CHUNK_HARD_MAX_TOKENS: library pages routinely produce
+        # monster "sentences" (long lists, JS dumps, unparagraphed
+        # blocks) that exceed the 8192-token embedding cap, which
+        # causes the whole embed batch to silently fail (see
+        # scripts/etl/upsert.py::embed_chunks).
         if sent_tokens >= target:
             if buf:
                 emit(buf)
                 buf, buf_tokens = [], 0
-            emit([sent])
+            if sent_tokens <= config.CHUNK_HARD_MAX_TOKENS:
+                emit([sent])
+            else:
+                # Hard-split by character window. Slight token bleed
+                # at boundaries is acceptable -- the alternative is
+                # losing the chunk's content entirely to a 400.
+                for start in range(0, len(sent), hard_max_chars):
+                    emit([sent[start : start + hard_max_chars]])
             continue
         if buf_tokens + sent_tokens > target:
             emit(buf)

--- a/ai-core/scripts/etl/config.py
+++ b/ai-core/scripts/etl/config.py
@@ -215,6 +215,14 @@ LIBRARY_BY_URL_SUBSTRING: Final[tuple[tuple[str, str], ...]] = (
 CHUNK_TARGET_TOKENS: Final[int] = 400
 CHUNK_OVERLAP_TOKENS: Final[int] = 50
 CHUNK_MIN_TOKENS: Final[int] = 50  # drop chunks shorter than this (boilerplate)
+# Hard upper bound on a single chunk's token count. Enforced by the chunker
+# when a "sentence" (post sentence-splitter) is itself larger than the target:
+# such sentences are hard-split into character windows of this size. The cap
+# exists because OpenAI's text-embedding-3-large rejects inputs above 8192
+# tokens with a 400, which causes the whole embed batch to fail silently
+# (see scripts/etl/upsert.py::embed_chunks). 1000 leaves a 7x safety margin
+# vs. the model limit and accommodates the ~50-token overlap prepend.
+CHUNK_HARD_MAX_TOKENS: Final[int] = 1000
 
 
 # --- Extraction quality gates -----------------------------------------------

--- a/ai-core/scripts/etl/test_chunker.py
+++ b/ai-core/scripts/etl/test_chunker.py
@@ -232,11 +232,35 @@ def test_long_doc_splits_into_multiple_chunks() -> None:
 
 def test_oversized_single_sentence_still_emits() -> None:
     """A pathological single sentence longer than CHUNK_TARGET_TOKENS
-    still emits as one chunk -- better a fat chunk than to drop content."""
-    huge_sentence = "Word " * 1500  # ~1500 tokens, all one "sentence"
+    still emits chunks -- better a fat chunk than to drop content."""
+    huge_sentence = "Word " * 1500  # ~1875 approx-tokens, all one "sentence"
     chunks = chunk_document(_doc(body_text=huge_sentence), _meta())
     # Got something back even though it's larger than the target.
     assert len(chunks) >= 1
+
+
+def test_oversized_single_sentence_is_capped_at_hard_max() -> None:
+    """Regression: a pathological "sentence" (e.g. a JS dump or
+    unparagraphed list on a library page) MUST NOT produce a chunk
+    larger than CHUNK_HARD_MAX_TOKENS, because OpenAI's
+    text-embedding-3-large rejects inputs above 8192 tokens with a
+    400, which silently kills the whole embed batch.
+
+    Without the hard-split, a single 15k-token sentence would emit
+    one 15k-token chunk. We require it to be split into pieces, each
+    under the hard cap (with ~4 chars/token + small overlap slack)."""
+    # ~15000 approx-tokens (~60000 chars), well over the 8192 limit.
+    huge_sentence = "x" * 60_000
+    chunks = chunk_document(_doc(body_text=huge_sentence), _meta())
+    assert len(chunks) >= 2, "expected hard-split into multiple chunks"
+    # Each emitted chunk's approx-token count must be at-or-below the
+    # hard cap, plus a small slack for the prepended overlap prefix.
+    slack_tokens = config.CHUNK_OVERLAP_TOKENS + 10
+    cap = config.CHUNK_HARD_MAX_TOKENS + slack_tokens
+    for ch in chunks:
+        assert _approximate_tokens(ch.text) <= cap, (
+            f"chunk exceeds hard cap: {_approximate_tokens(ch.text)} > {cap}"
+        )
 
 
 def test_position_resets_per_document() -> None:
@@ -350,6 +374,7 @@ def main() -> int:
         test_short_doc_emits_one_chunk,
         test_long_doc_splits_into_multiple_chunks,
         test_oversized_single_sentence_still_emits,
+        test_oversized_single_sentence_is_capped_at_hard_max,
         test_position_resets_per_document,
         test_overlap_carries_text_across_boundary,
         test_content_hash_stable_for_stable_text,

--- a/ai-core/scripts/etl/test_upsert.py
+++ b/ai-core/scripts/etl/test_upsert.py
@@ -388,34 +388,89 @@ def test_allowlist_empty_input_still_calls_store_with_empty_set() -> None:
 # --- promote_collection ------------------------------------------------
 
 
-def test_promote_collection_calls_swap_alias() -> None:
-    class WeaviateWithAlias:
+def test_promote_collection_uses_v4_alias_api_when_available() -> None:
+    """Weaviate v1.32+ servers + the v4 client expose `client.alias`.
+    promote_collection prefers this server-side path: atomic, no
+    process restart needed."""
+    class _AliasObj:
+        def __init__(self, name: str):
+            self.alias_name = name
+
+    class StubAliasApi:
         def __init__(self) -> None:
-            self.swap_args: dict = {}
+            self.existing: list = []
+            self.create_calls: list[dict] = []
+            self.update_calls: list[dict] = []
 
-        def swap_alias(self, *, alias: str, target: str) -> None:
-            self.swap_args = {"alias": alias, "target": target}
+        def list_all(self):
+            return self.existing
 
-    weaviate = WeaviateWithAlias()
-    promote_collection(weaviate, version="20260507_0200")
-    assert weaviate.swap_args == {
-        "alias": "Chunk_current",
-        "target": "Chunk_v20260507_0200",
-    }
+        def create(self, *, alias_name: str, target_collection: str) -> None:
+            self.create_calls.append(
+                {"alias_name": alias_name, "target_collection": target_collection}
+            )
+            self.existing.append(_AliasObj(alias_name))
+
+        def update(self, *, alias_name: str, new_target_collection: str) -> None:
+            self.update_calls.append(
+                {"alias_name": alias_name,
+                 "new_target_collection": new_target_collection}
+            )
+
+    class WeaviateWithAlias:
+        def __init__(self):
+            self.alias = StubAliasApi()
+
+    # First call: alias doesn't exist yet -> create.
+    w = WeaviateWithAlias()
+    promote_collection(w, version="20260507_0200")
+    assert w.alias.create_calls == [{
+        "alias_name": "Chunk_current",
+        "target_collection": "Chunk_v20260507_0200",
+    }]
+    assert w.alias.update_calls == []
+
+    # Second call: alias now exists -> update (idempotent re-promote).
+    promote_collection(w, version="20260514_1929")
+    assert w.alias.update_calls == [{
+        "alias_name": "Chunk_current",
+        "new_target_collection": "Chunk_v20260514_1929",
+    }]
 
 
-def test_promote_collection_raises_when_swap_alias_missing() -> None:
-    """Without swap_alias support the operation can't be safely
-    performed; we fail loud rather than silently doing nothing."""
+def test_promote_collection_emits_env_var_instructions_on_old_server() -> None:
+    """When the server doesn't support aliases (Weaviate <v1.32), the
+    function falls back to printing instructions for the env-var path
+    instead of raising. Bot operators set WEAVIATE_CHUNK_COLLECTION
+    in .env and restart -- functionally equivalent to an alias swap.
+
+    This is the path the user hit on Weaviate v1.27.3.
+    """
     class NoAliasClient:
+        # No `alias` attribute -- mimics older servers.
         pass
 
-    try:
-        promote_collection(NoAliasClient(), version="1")
-    except NotImplementedError as e:
-        assert "swap_alias" in str(e)
-        return
-    raise AssertionError("expected NotImplementedError")
+    # Should NOT raise.
+    promote_collection(NoAliasClient(), version="20260514_1929")
+
+
+def test_promote_collection_falls_back_when_alias_api_errors() -> None:
+    """If the alias API exists on the client but the server doesn't
+    actually support aliases (e.g. v4.16 client + v1.31 server), the
+    API call raises. promote_collection should catch + fall back to
+    env-var instructions rather than crash mid-promote."""
+    class FailingAliasApi:
+        def list_all(self):
+            raise RuntimeError("server does not support aliases")
+
+    class WeaviateWithFailingAlias:
+        def __init__(self):
+            self.alias = FailingAliasApi()
+
+    # Should NOT raise.
+    promote_collection(
+        WeaviateWithFailingAlias(), version="20260514_1929",
+    )
 
 
 # --- UpsertResult shape ------------------------------------------------
@@ -450,8 +505,9 @@ def main() -> int:
         test_allowlist_marks_featured_urls,
         test_allowlist_passes_url_data_through,
         test_allowlist_empty_input_still_calls_store_with_empty_set,
-        test_promote_collection_calls_swap_alias,
-        test_promote_collection_raises_when_swap_alias_missing,
+        test_promote_collection_uses_v4_alias_api_when_available,
+        test_promote_collection_emits_env_var_instructions_on_old_server,
+        test_promote_collection_falls_back_when_alias_api_errors,
         test_upsert_result_default_empty_lists,
     ]
     failed = 0

--- a/ai-core/scripts/etl/test_upsert.py
+++ b/ai-core/scripts/etl/test_upsert.py
@@ -192,6 +192,30 @@ def test_embed_chunks_failure_pads_with_empty_vectors() -> None:
     assert out[4] and out[5]  # third batch succeeded
 
 
+def test_embed_chunks_truncates_oversized_input() -> None:
+    """Regression: if a chunk's text exceeds the embedding model's
+    input limit (~32k chars / 8192 tokens), embed_chunks MUST truncate
+    rather than send it as-is. The previous behavior caused OpenAI to
+    400 the whole batch, silently dropping up to 100 chunks per
+    oversized input. This is a second-layer defense; the chunker's
+    CHUNK_HARD_MAX_TOKENS is the primary guard."""
+    # 100k chars -> well above the 32k-ish embedding input cap.
+    huge_text = "x" * 100_000
+    chunks = [
+        _chunk(chunk_id="c-small", text="hello"),
+        _chunk(chunk_id="c-huge", text=huge_text),
+    ]
+    client = StubEmbedClient()
+    out = embed_chunks(chunks, client, model="text-embedding-3-large", batch_size=10)
+    # Batch succeeded (no padding-with-empties): both got real vectors.
+    assert len(out) == 2
+    assert out[0] and out[1]
+    # The client saw a truncated string for the huge input, not 100k chars.
+    sent_huge = client.calls[0]["input"][1]
+    assert len(sent_huge) < 100_000
+    assert len(sent_huge) <= 8192 * 4  # under the model's char-equivalent cap
+
+
 # --- upsert step -------------------------------------------------------
 
 
@@ -412,6 +436,7 @@ def main() -> int:
         test_embed_chunks_returns_one_vector_per_chunk,
         test_embed_chunks_batches,
         test_embed_chunks_failure_pads_with_empty_vectors,
+        test_embed_chunks_truncates_oversized_input,
         test_upsert_new_chunk_records_new,
         test_upsert_dedupes_unchanged_content_hash,
         test_upsert_records_change_when_content_hash_differs,

--- a/ai-core/scripts/etl/upsert.py
+++ b/ai-core/scripts/etl/upsert.py
@@ -104,6 +104,67 @@ class UrlSeenStore(Protocol):
 # --- Step 7: Embed -----------------------------------------------------------
 
 
+# Per-input cap. OpenAI text-embedding-3-large rejects single inputs
+# > 8192 tokens with a 400. ~4 chars/token, minus 1k chars slack for
+# multibyte / dense content. The chunker's CHUNK_HARD_MAX_TOKENS is
+# the primary guard; this is the second layer.
+_EMBED_MAX_INPUT_CHARS = 8192 * 4 - 1000
+
+# Per-REQUEST cap. text-embedding-3-large accepts up to 300_000 tokens
+# per request. We target a much lower budget because:
+#   1. tiktoken (cl100k_base) isn't always available, and our char/4
+#      estimate is wildly optimistic on dense text (URLs, code) where
+#      real tokens can be ~1.5x our estimate.
+#   2. The TPM (tokens-per-minute) rate limit is 5M; a few back-to-back
+#      300K-token requests trigger 429s. Smaller requests pace better.
+# 200_000 leaves 33% headroom against the 300K hard limit.
+_EMBED_MAX_BATCH_TOKENS = 200_000
+
+
+def _count_tokens(text: str, encoder: Any) -> int:
+    """Tokens for `text`, using tiktoken if available, else chars/4.
+
+    The chunker uses the same fallback (`_approximate_tokens`) so this
+    is consistent with chunk-size decisions when tiktoken isn't loaded.
+    """
+    if encoder is not None:
+        try:
+            return len(encoder.encode(text))
+        except Exception:  # noqa: BLE001 -- never let counting kill the run
+            pass
+    return max(1, len(text) // 4)
+
+
+def _iter_token_budgeted_batches(
+    texts: list[str],
+    *,
+    max_count: int,
+    max_tokens: int,
+    encoder: Any,
+) -> Iterable[tuple[int, list[str]]]:
+    """Yield `(batch_start, batch_texts)` such that each batch has
+    `len(batch) <= max_count` AND sum(tokens) <= max_tokens.
+
+    Single inputs already above `max_tokens` are yielded alone (caller
+    has already truncated to the per-input cap, so this is safe).
+    """
+    cur: list[str] = []
+    cur_tokens = 0
+    cur_start = 0
+    for i, t in enumerate(texts):
+        n = _count_tokens(t, encoder)
+        # Flush before adding if adding would exceed either cap.
+        if cur and (len(cur) >= max_count or cur_tokens + n > max_tokens):
+            yield cur_start, cur
+            cur = []
+            cur_tokens = 0
+            cur_start = i
+        cur.append(t)
+        cur_tokens += n
+    if cur:
+        yield cur_start, cur
+
+
 def embed_chunks(
     chunks: list[Chunk],
     client: EmbeddingClient,
@@ -113,11 +174,19 @@ def embed_chunks(
 ) -> list[list[float]]:
     """Compute embeddings for a list of chunks.
 
-    Batched per `batch_size` (OpenAI text-embedding-3-large allows up
-    to 2048; we default lower for headroom). Per-batch failure logs and
-    skips that batch with zero-vectors -- the upsert step tolerates
-    zero-vector rows by leaving them out of the index, so a partial
-    failure doesn't poison the whole run.
+    Batches are dynamically sized to satisfy BOTH:
+      - `len(batch) <= batch_size` (the count cap), AND
+      - sum(tokens(batch)) <= _EMBED_MAX_BATCH_TOKENS (the request cap).
+
+    The request-cap guard exists because OpenAI's embeddings API
+    rejects requests above 300_000 tokens, and our previous
+    fixed-count batching of 100 chunks could exceed that on
+    token-dense content even when each chunk was under the per-input
+    cap. See git history / PR #45 follow-up for the failure mode.
+
+    Per-batch failures log and pad with zero-vectors; the upsert step
+    tolerates zero-vector rows by leaving them out of the index, so a
+    partial failure doesn't poison the whole run.
 
     `model` MUST come from src/config/models.py::EMBEDDING_MODEL -- never
     hard-code a string here. The freshness rule applies: confirm the
@@ -125,12 +194,39 @@ def embed_chunks(
     """
     if not chunks:
         return []
+    # tiktoken is optional. If absent, fall back to chars/4 (same shape
+    # as the chunker's _approximate_tokens). The pipeline runs either
+    # way; tiktoken just makes the batching tighter.
+    encoder: Any = None
+    try:
+        import tiktoken  # type: ignore
+
+        encoder = tiktoken.get_encoding("cl100k_base")
+    except Exception:  # noqa: BLE001
+        encoder = None
+
+    # First pass: per-input truncation to keep any single chunk under
+    # the model's 8192-token-per-input cap.
+    texts: list[str] = []
+    for c in chunks:
+        t = c.text
+        if len(t) > _EMBED_MAX_INPUT_CHARS:
+            logger.warning(
+                "embed input truncated [chunk_id=%s orig_chars=%d -> %d]",
+                c.chunk_id, len(t), _EMBED_MAX_INPUT_CHARS,
+            )
+            t = t[:_EMBED_MAX_INPUT_CHARS]
+        texts.append(t)
+
     out: list[list[float]] = []
-    for i in range(0, len(chunks), batch_size):
-        batch = chunks[i : i + batch_size]
-        texts = [c.text for c in batch]
+    for batch_start, batch_texts in _iter_token_budgeted_batches(
+        texts,
+        max_count=batch_size,
+        max_tokens=_EMBED_MAX_BATCH_TOKENS,
+        encoder=encoder,
+    ):
         try:
-            resp = client.create(model=model, input=texts)
+            resp = client.create(model=model, input=batch_texts)
             # OpenAI SDK shape: resp.data is a list of objects with .embedding
             for item in resp.data:
                 out.append(list(item.embedding))
@@ -140,13 +236,13 @@ def embed_chunks(
             # default). Also log batch position + the longest input's
             # length -- OpenAI's most common 400 cause is a single
             # chunk exceeding the 8192-token cap.
-            max_chars = max((len(t) for t in texts), default=0)
+            max_chars = max((len(t) for t in batch_texts), default=0)
             logger.error(
                 "embed batch failed [batch_start=%d size=%d max_chars=%d]: %s",
-                i, len(batch), max_chars, e,
+                batch_start, len(batch_texts), max_chars, e,
             )
             # Pad with empty vectors so positions line up; upsert drops these.
-            out.extend([[]] * len(batch))
+            out.extend([[]] * len(batch_texts))
     return out
 
 

--- a/ai-core/scripts/etl/upsert.py
+++ b/ai-core/scripts/etl/upsert.py
@@ -412,11 +412,68 @@ def promote_collection(
     `promote_collection(weaviate, version=previous_version)` -- a single
     alias swap, no data movement. Not part of the Pipeline because it's
     a manual decision gate (you don't want a cron auto-promoting).
+
+    Server compatibility:
+      * Weaviate v1.32+ supports server-side aliases via the v4 client's
+        `client.alias.{create,update,list_all}` API. We use that path
+        when available.
+      * Older servers (v1.27, v1.28, v1.31) don't support aliases at
+        all -- the API call returns a 404. For those, this function
+        emits clear instructions for the env-var fallback path
+        (set `WEAVIATE_CHUNK_COLLECTION=Chunk_v{version}` in `.env` and
+        restart the bot). Both `src/retrieval/search.py` and
+        `src/tools/search_kb_tool.py` honor that env var at request
+        time.
     """
-    if not hasattr(weaviate, "swap_alias"):
-        raise NotImplementedError(
-            "weaviate client does not expose swap_alias; wire one up "
-            "(Weaviate v4 client supports collections.alias.create / .replace)."
-        )
-    weaviate.swap_alias(alias=alias, target=f"Chunk_v{version}")
-    logger.info("promoted collection", extra={"alias": alias, "version": version})
+    target_collection = f"Chunk_v{version}"
+
+    # Attempt server-side alias swap (v1.32+ servers).
+    alias_api = getattr(weaviate, "alias", None)
+    if alias_api is not None:
+        try:
+            # The v4 client exposes alias management via client.alias.
+            # Use update if the alias exists, create otherwise.
+            existing = list(alias_api.list_all() or [])
+            existing_names = {a.alias_name for a in existing}
+            if alias in existing_names:
+                alias_api.update(
+                    alias_name=alias,
+                    new_target_collection=target_collection,
+                )
+                action = "updated"
+            else:
+                alias_api.create(
+                    alias_name=alias,
+                    target_collection=target_collection,
+                )
+                action = "created"
+            logger.info(
+                "promoted collection (server-side alias)",
+                extra={"alias": alias, "target": target_collection, "action": action},
+            )
+            return
+        except Exception as e:  # noqa: BLE001
+            # Fall through to env-var instructions. Server probably
+            # too old (v1.27 / v1.28 / v1.31 don't have aliases).
+            logger.info(
+                "server-side alias promotion failed (likely server pre-v1.32): %s",
+                e,
+            )
+
+    # Fallback path: server doesn't support aliases. The bot reads from
+    # WEAVIATE_CHUNK_COLLECTION at request time -- update that env var.
+    msg = (
+        f"\n  Server-side alias promotion not available on this Weaviate "
+        f"(typically pre-v1.32).\n"
+        f"  To make the bot read from the new collection, set this in "
+        f"your `.env`:\n\n"
+        f"      WEAVIATE_CHUNK_COLLECTION={target_collection}\n\n"
+        f"  Then restart the FastAPI worker so the env var is picked up.\n"
+        f"  This is functionally equivalent to an alias swap; it just "
+        f"requires a process restart\n  instead of an atomic server-side "
+        f"operation. The retrieval code in `src/retrieval/search.py`\n  "
+        f"and `src/tools/search_kb_tool.py` resolves the collection name "
+        f"from this env var at\n  request time.\n"
+    )
+    logger.info("promote_collection: %s", msg)
+    print(msg)

--- a/ai-core/src/retrieval/search.py
+++ b/ai-core/src/retrieval/search.py
@@ -119,11 +119,27 @@ class WeaviateLike(Protocol):
 # --- Entry point ---------------------------------------------------------
 
 
+def _default_collection() -> str:
+    """Resolve the Weaviate collection to query at request time.
+
+    Default is `Chunk_current` -- the alias the ETL's `promote_collection`
+    points at the latest approved version, on Weaviate v1.32+ servers
+    that support aliases.
+
+    On older servers (v1.27 / v1.28 / v1.31) where aliases don't exist
+    yet, set `WEAVIATE_CHUNK_COLLECTION=Chunk_v<date>` in `.env` to
+    select an explicit version. Restart the FastAPI worker after
+    changing it.
+    """
+    import os
+    return os.getenv("WEAVIATE_CHUNK_COLLECTION", "Chunk_current")
+
+
 def search_kb(
     request: RetrievalRequest,
     *,
     weaviate: WeaviateLike,
-    collection: str = "Chunk_current",
+    collection: Optional[str] = None,
 ) -> RetrievalResult:
     """Run a scope-filtered hybrid search and return EvidenceChunks.
 
@@ -141,6 +157,11 @@ def search_kb(
     """
     where = build_where_clause(request.scope)
     should_match = build_should_match(request.scope)
+    # Late-resolve the collection name so a `None` default falls
+    # through to the env var (`WEAVIATE_CHUNK_COLLECTION`) without
+    # forcing every caller to thread the env lookup themselves.
+    if collection is None:
+        collection = _default_collection()
 
     try:
         hits = weaviate.hybrid_search(

--- a/ai-core/src/tools/search_kb_tool.py
+++ b/ai-core/src/tools/search_kb_tool.py
@@ -144,7 +144,7 @@ def make_search_kb_tool(
     weaviate: WeaviateLike,
     scope: ScopeFilter,
     intent: Optional[str] = None,
-    collection: str = "Chunk_current",
+    collection: Optional[str] = None,
 ) -> Tool:
     """Build the agent Tool wrapping search_kb for one request.
 
@@ -154,8 +154,11 @@ def make_search_kb_tool(
             over the handler so the LLM-visible schema stays minimal.
         intent: kNN classifier's chosen intent. Used to map to the
             chunk's featured_service tag for soft boosting.
-        collection: Weaviate collection alias to query. Default points
-            at the live alias; ETL atomic-swaps this between versions.
+        collection: Weaviate collection name to query. Default `None`
+            falls through to `WEAVIATE_CHUNK_COLLECTION` env var
+            (or `Chunk_current` if unset) at request time, so the
+            ETL's promote step can update the env var instead of
+            requiring a restart of every component holding a closure.
 
     Returns:
         A Tool ready to register with ToolRegistry.

--- a/ai-core/src/tools/test_search_kb_tool.py
+++ b/ai-core/src/tools/test_search_kb_tool.py
@@ -193,6 +193,51 @@ def test_collection_name_passed_through() -> None:
     assert stub.calls[0]["collection"] == "Chunk_v2"
 
 
+def test_collection_resolves_from_env_when_none() -> None:
+    """When `collection=None`, the retrieval layer reads
+    WEAVIATE_CHUNK_COLLECTION at request time. This is the env-var
+    fallback for Weaviate servers older than v1.32 (which don't
+    support server-side aliases). Bot operators set the env var
+    instead of running an alias swap."""
+    import os
+    stub = StubWeaviate(hits=[_hit()])
+    # Build with collection=None (the new default)
+    tool = make_search_kb_tool(
+        weaviate=stub, scope=ScopeFilter(campus="oxford"),
+        collection=None,
+    )
+    prev = os.environ.get("WEAVIATE_CHUNK_COLLECTION")
+    try:
+        os.environ["WEAVIATE_CHUNK_COLLECTION"] = "Chunk_vv20260514_1929"
+        tool.handler({"query": "q"})
+        assert stub.calls[0]["collection"] == "Chunk_vv20260514_1929"
+    finally:
+        # Restore prior env state so test ordering doesn't matter
+        if prev is None:
+            os.environ.pop("WEAVIATE_CHUNK_COLLECTION", None)
+        else:
+            os.environ["WEAVIATE_CHUNK_COLLECTION"] = prev
+
+
+def test_collection_defaults_to_chunk_current_when_no_env_no_arg() -> None:
+    """The env-var fallback's own fallback: if neither caller-arg nor
+    env var is set, default to `Chunk_current` (the alias name for
+    Weaviate v1.32+ deployments). Locks in the documented contract."""
+    import os
+    stub = StubWeaviate(hits=[_hit()])
+    tool = make_search_kb_tool(
+        weaviate=stub, scope=ScopeFilter(campus="oxford"),
+        collection=None,
+    )
+    prev = os.environ.pop("WEAVIATE_CHUNK_COLLECTION", None)
+    try:
+        tool.handler({"query": "q"})
+        assert stub.calls[0]["collection"] == "Chunk_current"
+    finally:
+        if prev is not None:
+            os.environ["WEAVIATE_CHUNK_COLLECTION"] = prev
+
+
 def test_search_kb_error_passes_through_to_tool_result() -> None:
     """When Weaviate raises, the tool's result dict carries `error`
     instead of `evidence`. The LLM reads this and may try a different
@@ -229,6 +274,8 @@ def main() -> int:
         test_unknown_intent_skips_boost,
         test_intent_none_skips_boost,
         test_collection_name_passed_through,
+        test_collection_resolves_from_env_when_none,
+        test_collection_defaults_to_chunk_current_when_no_env_no_arg,
         test_search_kb_error_passes_through_to_tool_result,
         test_result_is_json_serializable,
     ]


### PR DESCRIPTION
## What broke

\`\`\`
NotImplementedError: weaviate client does not expose swap_alias; wire one up
(Weaviate v4 client supports collections.alias.create / .replace).
\`\`\`

Two reasons:

1. \`promote_collection\` was a stub expecting a \`swap_alias\` method on the client. v4 doesn't expose that — it has \`client.alias.{create,update,list_all}\` instead.
2. Server-side aliases were added in **Weaviate v1.32**. The user's server is **v1.27.3**. Even with the right v4 API call, the server returns 404.

## Fix — works on both old and new servers

### Path A: v1.32+ servers
Use the v4 client's \`client.alias\` API: \`update\` if the alias exists, \`create\` if not. Atomic, no restart needed. Idempotent on re-promote.

### Path B: <v1.32 servers (the user's current state)
Catches the API failure and prints clear instructions for the env-var fallback:

\`\`\`
Set this in your \`.env\`:
    WEAVIATE_CHUNK_COLLECTION=Chunk_vv20260514_1929
Then restart the FastAPI worker.
\`\`\`

The retrieval code (\`src/retrieval/search.py\`, \`src/tools/search_kb_tool.py\`) honors this env var at request time. Functionally equivalent to an alias swap; the only difference is it requires a process restart instead of an atomic server-side operation.

## Files

| File | Change |
|---|---|
| \`scripts/etl/upsert.py\` | \`promote_collection\` rewritten — try v4 alias API, fall back to env-var instructions |
| \`scripts/etl/test_upsert.py\` | 3 new tests (alias-api path, no-alias-attr fallback, alias-api-errors fallback). Removed 2 old \`swap_alias\`-shaped tests |
| \`src/retrieval/search.py\` | \`search_kb\` \`collection\` param now \`Optional[str]=None\`; \`_default_collection()\` resolves \`WEAVIATE_CHUNK_COLLECTION\` env var at request time |
| \`src/tools/search_kb_tool.py\` | \`make_search_kb_tool\` \`collection\` param now \`Optional[str]=None\`; same late-resolution semantics |
| \`src/tools/test_search_kb_tool.py\` | 2 new tests (env-var fallback + Chunk_current default-of-default). Existing explicit-collection test still passes |

48/48 tests pass across the affected suites.

## Test plan

- [x] \`python -m scripts.etl.test_upsert\` → 22/22
- [x] \`python -m src.tools.test_search_kb_tool\` → 13/13
- [x] \`python -m src.retrieval.test_search\` → 13/13
- [x] **User**: pull main, set \`WEAVIATE_CHUNK_COLLECTION=Chunk_vv20260514_1929\` in \`.env\`, run \`promote_collection\` to confirm it now prints instructions cleanly instead of raising

## Why an env var instead of waiting to upgrade Weaviate

Upgrading the Weaviate Docker container from v1.27.3 to v1.32+ on the prod server is its own coordinated operation (downtime, schema-version verification, possibly re-indexing). The env-var path lets the rebuild move forward today while the server upgrade is scheduled separately. When the server is upgraded, this code automatically prefers the alias API — no follow-up PR needed.

## What this unblocks

The bot's retrieval can now point at \`Chunk_vv20260514_1929\` (the 20,255-chunk collection from the recent successful apply). With this merged + env var set, threshold 2 (\"internally usable\") becomes runnable: \`run_eval.py --with-real-llm --with-judge\` can ground on real evidence instead of the hand-written \`_REALISTIC_EVIDENCE\` map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)