### PR TITLE
eval: wire REAL Weaviate retrieval; delete _REALISTIC_EVIDENCE

### DIFF
--- a/ai-core/docs/canonical/makerspaces.md
+++ b/ai-core/docs/canonical/makerspaces.md
@@ -1,0 +1,275 @@
+# Canonical truth: Makerspaces across Miami University Libraries
+
+**Date captured**: 2026-05-14
+**Sources** (verbatim verified):
+  - <https://libguides.lib.miamioh.edu/create/makerspace/home> (King)
+  - <https://libguides.lib.miamioh.edu/middletown_tec_lab/home> (Middletown)
+  - <https://www.ham.miamioh.edu/library/> (Hamilton — confirmed absent)
+
+**Why this doc exists**: an earlier draft of the gold eval set and
+the plan's §7 featured-services section both assumed there is only
+ONE makerspace at Miami (King Library, Oxford), and that "Middletown
+does not have a MakerSpace." **This is wrong.** Middletown has its
+own makerspace under a different name — the TEC Lab ("Tinker, Envision,
+Create"), founded Fall 2014, located inside Gardner-Harvey Library.
+
+A user asking "is there a makerspace at Middletown?" should receive
+"yes — the TEC Lab" with the LibGuide URL, NOT a refusal that points
+them to Oxford.
+
+---
+
+## TL;DR
+
+| Campus / Library | Makerspace? | Name | URL |
+|---|---|---|---|
+| **Oxford / King Library** | **Yes** | The Makerspace | <https://libguides.lib.miamioh.edu/create/makerspace/home> |
+| **Middletown / Gardner-Harvey Library** | **Yes** | TEC Lab Makerspace (Tinker, Envision, Create) | <https://libguides.lib.miamioh.edu/middletown_tec_lab/home> |
+| **Hamilton / Rentschler Library** | No | — | — |
+| **Oxford / Wertz Art & Architecture** | No (but is the Art library, not a fabrication space) | — | — |
+| **Oxford / Special Collections** | No (archival; not a creation space) | — | — |
+| **Middletown / SWORD** | No (depository) | — | — |
+
+---
+
+## King Makerspace (Oxford)
+
+URL: <https://libguides.lib.miamioh.edu/create/makerspace/home>
+
+- **Location**: King Library, **3rd floor, room 303**.
+- **Equipment** (per the official "What's Available" list referenced
+  on the page):
+  - 3D printers
+  - Laser cutter/engravers
+  - Sewing/embroidery machines
+  - Digital cutters
+  - Additional maker equipment (full list lives on the LibGuide)
+- **Hours** (verbatim):
+  - **Regular semester**: Mon-Fri 9am-5pm; Wed-Thu until 7pm; Sun noon-4pm
+  - **Finals week**: Mon-Fri 9am-5pm
+  - **Summer**: Mon-Fri 9am-4pm
+- **Who can use it** (verbatim): "Everyone at Miami can use the
+  Makerspace" — students, faculty, staff. Public access not addressed.
+- **Access requirements** (verbatim, two-step):
+  1. "Fill out and sign the Makerspace Liability Waiver"
+  2. "Make an appointment to use a machine" via the reservation system
+- **Cost**: no fees mentioned for equipment use.
+- **Contact**:
+  - Email: `create@miamioh.edu`
+  - Phone: (513) 529-2871
+  - Faculty inquiries: Sarah Nagle (Creation and Innovation Services Librarian)
+- **Out-of-stock note** (verbatim, captured 2026-05-14, may rotate):
+  "Currently out of button supplies of all sizes; restocking begins
+  Fall Semester."
+
+---
+
+## Middletown TEC Lab Makerspace
+
+URL: <https://libguides.lib.miamioh.edu/middletown_tec_lab/home>
+
+- **Name decoded**: "TEC" stands for **Tinker, Envision, Create**.
+  Described verbatim as: "The TEC Lab Makerspace was founded as a
+  place for you to Tinker, Envision, and Create!"
+- **Founded**: Fall 2014. Currently celebrating its 10th anniversary
+  per the page.
+- **Location**: Inside **Gardner-Harvey Library**, 4200 N. University
+  Blvd., Middletown, OH 45042. Two rooms across two levels:
+  - **TEC Lab** — Room **125**, **upper level**
+  - **TEC SPACE** — Room **014**, **lower level**
+- **Equipment in the TEC Lab (upper level)** (verbatim list):
+  - Laser engraver/cutter
+  - Glowforge laser
+  - 3D printers (**staff use only**)
+  - Button maker
+  - Wood burning pens
+  - Craft supplies
+  - 3D pens
+- **Equipment in the TEC SPACE (lower level)** (verbatim list):
+  - Heat press
+  - Sublimation printing
+  - Perler beads
+  - Sewing machine
+  - Vinyl cutter — Silhouette
+- **Hours**: not directly listed; defers to "the library's open hours"
+  (i.e. Gardner-Harvey's hours).
+- **Who can use it**: page does not restrict by user category. Anyone
+  who signs the user agreement gets access.
+- **Access paths** (four, verbatim):
+  - Independent use: "Sign our user agreement" to work independently
+    "during the library's open hours"
+  - Reservations: "Use our online reservation system to book the TEC
+    Lab or TEC SPACE for up to 2 hours"
+  - Workshops: "Attend one of our workshops"
+  - Tours: "Ask us for a tour"
+- **Cost** (verbatim): "Equipment in the TEC Lab and TEC SPACE is
+  free to use. There may be costs associated with materials used
+  with the equipment." Specific material costs are documented on a
+  "TEC Lab Charges" subpage.
+- **Contact**:
+  - Jennifer Hicks — `hicksjl2@miamioh.edu`
+  - John Burke — `burkejj@miamioh.edu`
+  - Phone: 513-727-3222
+  - Chat: AskGHL (Ask Gardner-Harvey Library)
+  - Text: 513-273-5360
+  - Training: online form to "Schedule a time to learn how to use
+    equipment"
+- **Mission statement**: <https://www.mid.miamioh.edu/library/TECmission.htm>
+
+### TEC Lab subpages worth indexing
+
+The LibGuide has dedicated pages for each major equipment / service:
+Workshops • 3D Printing • 3D Pens • Button Maker • Heat
+Press/Sublimation/Vinyl • Glowforge & Full Spectrum Laser
+Cutter/Engravers • Graphic Design Software • Poster Printing •
+Silhouette Cameo Cutter • TEC Lab Charges.
+
+When the ETL re-runs against a broader URL set including
+`libguides.lib.miamioh.edu/middletown_tec_lab/*`, each of these
+becomes its own chunk and the bot can answer equipment-specific
+questions ("can I sublimate at Middletown?") directly.
+
+---
+
+## Hamilton (Rentschler Library) — explicitly NO makerspace
+
+Confirmed from <https://www.ham.miamioh.edu/library/>. The Rentschler
+Library page lists "Audiovisual Resources" as a service but no maker,
+fabrication, TEC Lab, design studio, or equivalent creation space.
+
+**The bot's `service_not_at_building` refusal for "MakerSpace at
+Hamilton" remains correct.** Just point the user to either King
+(Oxford) or Middletown (TEC Lab) as alternatives, depending on
+which campus is closer to where they're already standing.
+
+---
+
+## What the bot is allowed to say about makerspaces
+
+Synthesizer prompt should treat the following as facts:
+
+1. **Two makerspaces exist** in the Miami library system, with
+   **different names and inventories**:
+   - King's "Makerspace" (Oxford, room 303)
+   - Middletown's "TEC Lab" (Gardner-Harvey, rooms 125 + 014)
+2. **Both are free to use** with appropriate sign-up / agreement.
+   Material costs may apply at both.
+3. **Hamilton (Rentschler) has neither.** Refer Hamilton users to
+   the closer of the two (depending on travel preference).
+4. **Equipment is different at each location** — the canonical doc
+   above is the truth table. The bot should not claim King-specific
+   equipment exists at Middletown or vice versa.
+5. **King has a 3D printer for student use; Middletown's 3D printers
+   are staff-use only.** This is the most common easily-conflated
+   detail.
+6. Both have **online reservation systems** and **liability
+   waivers / user agreements**.
+
+What the bot must **refuse** to claim without checking:
+
+- Specific real-time equipment availability ("is the Glowforge free
+  right now?" — requires live calendar query)
+- Current workshop schedule ("what workshops are running next week?"
+  — depends on the LibGuide subpages, refresh frequency)
+- Specific material costs ("how much for a sheet of acrylic?" —
+  links to TEC Lab Charges or King-equivalent page)
+
+---
+
+## URL canonicalization note
+
+The URL `https://www.lib.miamioh.edu/use/spaces/makerspace/` is a
+**redirect**, not a content page. It forwards to the LibGuide
+canonical: `https://libguides.lib.miamioh.edu/create/makerspace/home`.
+
+The post-processor's URL validator should treat both as valid when
+appearing in citations, since clicking either lands the user on the
+same canonical content. The gold set currently lists the redirect URL
+in some `allowed_urls` fields; bot answers citing the LibGuide URL
+are functionally equivalent.
+
+Either:
+- (a) treat the two URLs as aliases in the URL validator's allowlist
+  (read both into `UrlSeen.url` rows with the same `canonical_url`
+  via the ETL's redirect-following), OR
+- (b) update the gold set's `allowed_urls` to include both forms
+
+Recommended: (a). The ETL's `fetch()` step already captures the
+canonical post-redirect URL; we just need `UrlSeen` to store both
+the requested URL and the canonical, and the validator to accept
+either.
+
+## Gold-set corrections to file
+
+When updating `ai-core/src/eval/golden_set.jsonl` against this truth:
+
+| Gold case | Current state | Bug + correction |
+|---|---|---|
+| `xc_makerspace_hamilton_refusal` | Expects refusal | **Correct.** Hamilton has no makerspace. But refusal *copy* should mention BOTH King and TEC Lab as alternatives (not just King). |
+| `xc_makerspace_middletown_refusal` | Expects REFUSAL on "Is there a 3D printer at the Middletown library?" | **Wrong.** Middletown DOES have 3D printers (TEC Lab, staff-use only). Change `expected_outcome` to `answer`; bot should point to TEC Lab + note 3D printers are staff-use; update `allowed_urls` to include `https://libguides.lib.miamioh.edu/middletown_tec_lab/home`. |
+| `fs_makerspace_hours` | `allowed_urls` is `lib.miamioh.edu/use/spaces/makerspace/` (redirect) | Add `libguides.lib.miamioh.edu/create/makerspace/home` to `allowed_urls`. Both forms reach the same content. |
+| Any other case asserting "Middletown does not have a MakerSpace" | Wrong | Bot should answer YES (TEC Lab) with the LibGuide URL |
+| Any `cross_campus_comparison` case listing makerspace as "Oxford-only" | Wrong | Correct list: Oxford (King) + Middletown (TEC Lab). Hamilton lacks one. |
+| Cases referencing "MakerSpace at every Miami library" | Still wrong, just not as wrong | Two of three campuses; Hamilton doesn't |
+| The plan §7 statement "If asked about a MakerSpace at Hamilton or Middletown, refuse" | **Wrong for Middletown** | Refuse only for Hamilton + Wertz + Special Collections + SWORD. Answer with TEC Lab for Middletown. |
+
+---
+
+## Refusal-trigger impact
+
+In `src/synthesis/refusal_templates.py`, the `service_not_at_building`
+refusal template currently reads (verbatim):
+
+```
+There isn't a {service_name} at the {campus_display} campus
+library. {service_name} is at {service_available_at}. For help
+at {campus_display}, ask the library staff through Ask Us.
+```
+
+The `service_available_at` field for "makerspace" is now:
+**"King Library on the Oxford campus OR the TEC Lab at Gardner-Harvey
+Library on the Middletown campus."**
+
+When the user resolves to Hamilton scope and asks about MakerSpace,
+both alternatives should be offered. Implementation note: this is a
+single-string field in `RefusalContext`; we can either:
+- (a) write the disjunction into the string at refusal-render time
+- (b) extend `RefusalContext` to support multiple alternatives — overkill
+
+(a) is fine for now.
+
+---
+
+## `LibrarySpace.services_offered` impact
+
+When the librarian provides the truth table for the
+`services_offered` column (currently empty — blocker for the
+cross-campus refusal guard to fire correctly), the makerspace
+column must include:
+
+- **king** (Oxford): `makerspace` ✓
+- **gardner_harvey** (Middletown): `makerspace` ✓
+- **rentschler** (Hamilton): NOT `makerspace`
+- **wertz** (Oxford, art & arch): NOT `makerspace`
+- **special** (Oxford, archives): NOT `makerspace`
+- **sword** (Middletown, depository): NOT `makerspace`
+
+---
+
+## ETL coverage gap
+
+`libguides.lib.miamioh.edu/*` URLs are **not currently in the ETL
+sitemap** (per the 396-URL discover snapshot from 2026-05-14). That
+means neither makerspace page is indexed in Weaviate today, even
+though they're the canonical truth for these questions.
+
+Action: discover.py needs to add `libguides.lib.miamioh.edu` (or at
+minimum the two makerspace pages plus their subpages) as a separate
+discoverable sitemap or seed list. This is a separate small PR; track
+as a follow-up.
+
+Until that lands, the bot would have to either (a) get the chunks via
+a manual upsert, (b) refuse with "I can't find that in my index — try
+[URL]," or (c) hard-code these two URLs as featured-service pinned
+chunks. Option (c) via `ManualCorrection` (action: `pin`) is the
+cheapest immediate workaround.

--- a/ai-core/docs/canonical/newspapers.md
+++ b/ai-core/docs/canonical/newspapers.md
@@ -1,0 +1,158 @@
+# Canonical truth: Newspaper access at Miami University Libraries
+
+**Date captured**: 2026-05-15
+**Source** (verbatim verified): <https://libguides.lib.miamioh.edu/newspapers>
+and its subpages.
+
+**Why this doc exists**: the deleted `_REALISTIC_EVIDENCE["newspapers"]`
+stopgap (and likely several gold-set `newspapers` cases) contained
+real factual errors:
+  - It claimed a direct "Cincinnati Enquirer" subscription. The
+    newspapers page does NOT list that as a named direct
+    subscription.
+  - It said to "activate your NYT/WSJ pass through the library's
+    databases page." **Wrong.** NYT and WSJ each have their OWN
+    distinct activation URL + distinct rules (NYT must be done
+    on-campus; WSJ can be done anywhere). Sending a user to "the
+    databases page" would fail them.
+
+This is the source of truth for newspaper questions until the ETL
+crawls `libguides.lib.miamioh.edu/newspapers*` (currently not in the
+discover set -- see "ETL coverage gap" below).
+
+---
+
+## TL;DR
+
+Miami provides newspaper access via **three distinct mechanisms**.
+The bot must not conflate them:
+
+| Mechanism | Examples | How the user gets in |
+|---|---|---|
+| **Direct sponsored subscriptions** (per-user account) | New York Times, Wall Street Journal | Each has its OWN activation URL + rules (below) |
+| **Newspaper databases** (full-text search across many papers) | NewsBank Access World News, Factiva, Newspaper Source, Ethnic NewsWatch, Alternative Press Index | Library database links; proxy login off-campus |
+| **Local Oxford papers** (free, public web) | Oxford Free Press, The Miami Student, Oxford Observer | Just public websites; not a library subscription |
+
+---
+
+## New York Times — sponsored group pass
+
+- **Activation URL**: `nytimes.com/grouppass`
+  (proxied: `https://proxy.lib.miamioh.edu/login?url=https://ezmyaccount.nytimes.com/grouppass/redir`)
+- **Method**: go to the group-pass URL, create a NYTimes.com account
+  **using your @miamioh.edu university email address**.
+- **Eligibility**: Miami University students, faculty, AND staff.
+- **CRITICAL caveat (verbatim)**: "You need to be on campus when
+  registering or renewing your account." AND "Faculty, staff, and
+  students will need to renew their access every 6 months from an
+  on-campus location."
+  - The bot MUST surface the on-campus + 6-month-renewal
+    requirement. Omitting it is the single highest-value mistake
+    to avoid here -- a user who registers off-campus silently
+    fails and blames the library.
+
+## Wall Street Journal — sponsored partner account
+
+- **Activation URL**: `https://partner.wsj.com/partner/miamiuniversity`
+- **Method** (verbatim steps):
+  1. Enter first and last name
+  2. Select an Account Type from the dropdown: **Student, Professor,
+     or Staff**
+  3. Enter your email address and create a password
+  4. Click Create to complete registration
+  5. Afterward, go directly to `https://www.wsj.com/`
+- **Eligibility**: current faculty, staff, and students.
+- **Key difference from NYT**: WSJ activation works **from any
+  location, on OR off campus**. (NYT requires on-campus; WSJ does
+  NOT.) The bot must not copy the NYT on-campus rule onto WSJ.
+- **Coverage note**: "Wall Street Journal (4 years ago - present)".
+
+## Newspaper databases (full-text, many sources)
+
+| Database | Covers | Access caveat | Library link |
+|---|---|---|---|
+| **NewsBank Access World News** | 7,500+ U.S. + global news sources, full-text | — | <https://libguides.lib.miamioh.edu/worldnews> |
+| **Factiva** | Washington Post, LA Times, Chicago Tribune; TV/radio transcripts; business/trade journals | **Limited to 4 simultaneous users** | <https://libguides.lib.miamioh.edu/factiva> |
+| **Newspaper Source** | USA Today, Times of London; CBS/CNN/FOX/NPR broadcast transcripts; some older content | — | <https://libguides.lib.miamioh.edu/newspaper-source> |
+| **Ethnic NewsWatch** | African American, Caribbean, African, Arab/Middle Eastern, Asian/Pacific Islander, European/Eastern European, Hispanic, Native peoples press; full-text | — | <https://libguides.lib.miamioh.edu/ethnic-newswatch> |
+| **Alternative Press Index** | 700+ international alternative/radical/left periodicals; 1969+ | **Oxford campus users only** | <https://libguides.lib.miamioh.edu/alternative-press-index> |
+
+So Washington Post / LA Times / Chicago Tribune are reachable
+**via Factiva**, not as standalone subscriptions. USA Today /
+Times of London via Newspaper Source. The bot should answer "yes,
+through [database]" -- not "yes, we subscribe to it directly."
+
+## Historical / back-issue newspapers
+
+The home page doesn't detail dedicated historical archives, but the
+LibGuide has dedicated subpages for them. When asked about old /
+archived issues, point to the relevant subpage:
+
+- U.S. Newspapers, Historical: `https://libguides.lib.miamioh.edu/newspapers/Archives`
+- International Newspapers, Historical: `https://libguides.lib.miamioh.edu/c.php?g=22080&p=11156343`
+- Ohio Newspapers: `https://libguides.lib.miamioh.edu/newspapers/ohio`
+- African American Newspapers: (subpage tab; URL not captured -- crawl will surface it)
+- Newspapers in Print: (subpage tab)
+
+## Local Oxford papers (free public web -- NOT a library subscription)
+
+- Oxford Free Press: <https://www.oxfreepress.com/>
+- The Miami Student: <https://miamistudent.net>
+- Oxford Observer: <https://oxfordobserver.org>
+
+The bot can mention these for hyper-local Oxford news but must not
+imply the library "subscribes" to them -- they're free public sites.
+
+---
+
+## What the bot is allowed to say about newspapers
+
+1. **NYT and WSJ are sponsored per-user accounts**, each with a
+   DISTINCT activation flow. Never give one's URL/rules for the
+   other.
+2. **NYT requires on-campus registration + 6-month on-campus
+   renewal.** Always surface this. WSJ does NOT (any location).
+3. **Many major papers (WaPo, LA Times, Chicago Tribune, USA Today,
+   Times of London) are reached via databases**, not direct
+   subscriptions. Answer "via [Factiva / Newspaper Source]" with
+   the database link.
+4. **Factiva caps 4 simultaneous users**; **Alternative Press Index
+   is Oxford-only.** Surface these access limits when relevant.
+5. **Local Oxford papers are free public sites**, not subscriptions.
+
+What the bot must **refuse / not invent**:
+- A direct "Cincinnati Enquirer" subscription -- not listed on the
+  page. (May exist via a database; do not assert a direct sub.)
+- Any newspaper not named here as a direct sub or database-covered
+  title. If unsure, point to NewsBank Access World News (the
+  broadest, 7,500+ sources) and let the user search.
+- Step-by-step that mixes NYT and WSJ flows.
+
+---
+
+## Gold-set corrections to file
+
+| Pattern | Bug | Correction |
+|---|---|---|
+| Any `newspapers` case whose expected answer says "activate via the databases page" | Wrong | NYT -> `nytimes.com/grouppass` (on-campus); WSJ -> `partner.wsj.com/partner/miamiuniversity` (any location) |
+| Any case asserting a direct Cincinnati Enquirer subscription | Wrong | Not a named direct sub; reachable (if at all) only via a database |
+| NYT cases missing the on-campus + 6-month-renewal caveat | Incomplete | The caveat is load-bearing; expected answer must require it |
+| WSJ cases that copy NYT's on-campus rule | Wrong | WSJ activates from ANY location |
+| `allowed_urls` listing a generic "/databases/" page for NYT/WSJ | Wrong | Use the specific activation URLs above |
+
+---
+
+## ETL coverage gap (same as makerspaces.md)
+
+`libguides.lib.miamioh.edu/newspapers*` is **not currently in the
+ETL discover set** (the 396-URL crawl is `lib.miamioh.edu` +
+`ham`/`mid` + regional). So none of these newspaper pages are in
+Weaviate yet, and the bot can't ground newspaper answers on real
+retrieved chunks until that's fixed.
+
+Action (one follow-up PR, shared with the makerspaces gap): add
+`libguides.lib.miamioh.edu` to `scripts/etl/discover.py` -- at
+minimum the newspapers + makerspace LibGuides and their subpages.
+Until then, `ManualCorrection` (action: `pin`) on these canonical
+URLs is the cheapest interim workaround so the URL validator
+doesn't reject legitimate LibGuide citations.

--- a/ai-core/docs/canonical/room_reservations.md
+++ b/ai-core/docs/canonical/room_reservations.md
@@ -1,0 +1,194 @@
+# Canonical truth: Room reservations across Miami University Libraries
+
+**Date captured**: 2026-05-14
+**Source**: <https://www.lib.miamioh.edu/use/spaces/room-reservations/> + each per-building LibCal page linked from there.
+**Why this doc exists**: an earlier draft of the gold eval set
+(`ai-core/src/eval/golden_set.jsonl`) carried incorrect "expected answers"
+about room booking that didn't match what the Miami library website
+actually says. This document is the source-of-truth captured directly
+from `lib.miamioh.edu` so future evals, prompts, `LibrarySpace.services_offered`
+seeds, and synthetic evidence can be grounded on real facts.
+
+When the bot's eventual LibCal API integration lands, this doc gets
+*verified* against the live API but stays as a human-readable summary.
+
+---
+
+## TL;DR
+
+| Building | Campus | Bookable rooms? | LibCal URL |
+|---|---|---|---|
+| **King Library** | Oxford | Yes — most extensive inventory | <https://muohio.libcal.com/reserve/king> |
+| **Wertz Art & Architecture Library** | Oxford | Yes — smaller inventory | <https://muohio.libcal.com/reserve/ArtArch> |
+| **Armstrong Student Center** | Oxford | Yes — via libraries' LibCal | <https://muohio.libcal.com/spaces?lid=4757&gid=8174> |
+| **Rentschler Library (Hamilton)** | Hamilton | Yes — small inventory (≤8 capacity) | <https://muohio.libcal.com/reserve/hamilton> |
+| **Gardner-Harvey Library (Middletown)** | Middletown | Yes — full capacity range | <https://muohio.libcal.com/reserve/middletown> |
+| **Special Collections & University Archives (King)** | Oxford | No — appointment-only access for archival research | not via room reservation system |
+| **SWORD (Middletown depository)** | Middletown | No — not a study space | n/a |
+
+**Universal rules across every bookable location** (per the
+`/use/spaces/room-reservations/` page):
+
+- **Max 2 hours per day per user**.
+- **May reserve up to 2 weeks in advance**.
+- Reservations require a Miami login through LibCal.
+- Walk-ins are allowed if a room is currently free, but no walk-in
+  guarantee of any specific room.
+
+---
+
+## Per-building detail
+
+### King Library (Oxford)
+
+LibCal URL: <https://muohio.libcal.com/reserve/king>
+
+Room categories visible on the booking page:
+
+| Category | Notes |
+|---|---|
+| **King Study Rooms (Key Access Only)** | Pick up key at service desk |
+| **King Study Rooms (Swipe Accessible)** | Card swipe entry, no desk pickup |
+| **Sensory-Friendly Study Rooms (Key Access Only)** | Rooms **022 + 023** (lower level, rear of Instructional Media Center) and **242 + 243** (second floor, behind main staircase) |
+| **Large Group Study Rooms** | 9-12 and 13+ capacity tiers |
+| **Makerspace Study Room** | Located adjacent to / in the King MakerSpace |
+
+Zoom-equipped rooms (named):
+- **112A, 112B, 112C** — equipped with Zoom Room capabilities. Operator
+  instruction (verbatim from the page): "Set the TV to HDMI1 and use
+  the iPad in the room to control your zoom meeting."
+
+Capacity buckets supported (LibCal filter):
+- 1-4 people
+- 5-8 people
+- 9-12 people
+- 13+ people
+
+### Wertz Art & Architecture Library (Oxford)
+
+LibCal URL: <https://muohio.libcal.com/reserve/ArtArch>
+
+Category visible: "Art & Architecture Study Rooms".
+
+Capacity buckets advertised on the booking page: **at least 9-12**
+(this filter appears explicitly). Other capacity tiers likely exist
+but the static page doesn't enumerate them; the LibCal calendar UI
+shows the actual inventory at request time.
+
+**Gold-set correction**: an earlier draft (`rb_wertz_no_bookable`)
+asserted Wertz has "no bookable rooms." That is **incorrect**.
+Wertz has at least one bookable room in the 9-12 capacity tier and
+likely additional smaller rooms.
+
+### Armstrong Student Center (Oxford — NOT a library building)
+
+LibCal URL: <https://muohio.libcal.com/spaces?lid=4757&gid=8174>
+
+Listed on the libraries' room-reservation page because the libraries
+manage some Armstrong study space reservations through the same
+LibCal instance. Building is NOT operated by the libraries — note
+the `lid=4757` (different location id from library buildings).
+
+When users ask about "study rooms on campus" generally, Armstrong is
+a valid answer; when they ask about "study rooms at the library,"
+it is NOT.
+
+### Rentschler Library (Hamilton campus)
+
+LibCal URL: <https://muohio.libcal.com/reserve/hamilton>
+
+Marked on the page as a **private category** (`Rentschler Study
+Rooms is a private category and can only be viewed at this URL`).
+
+Capacity buckets advertised: 1-4 and 5-8 people. **No 9-12 or 13+
+tiers visible** — Rentschler does not have large-group rooms.
+
+**Gold-set correction**: any case implying Hamilton has the same
+inventory as King is wrong. Hamilton has the smallest bookable
+inventory.
+
+### Gardner-Harvey Library (Middletown campus)
+
+LibCal URL: <https://muohio.libcal.com/reserve/middletown>
+
+Category visible: "Gardner-Harvey Study Rooms".
+
+Capacity buckets advertised: 1-4, 5-8, 9-12, 13+ — the **full range**,
+unlike Hamilton's restricted set. Gardner-Harvey appears to have a
+fuller bookable inventory than Hamilton.
+
+### Special Collections & University Archives (Oxford, in King)
+
+**Not in the room-reservation system.** Access is by **appointment
+with the Special Collections staff**, not by self-service booking.
+Confirms the `LibrarySpace.services_offered` truth-table for the
+`special` building: does NOT include `study_rooms` as a self-service
+offering.
+
+### SWORD (Southwest Ohio Regional Depository, Middletown)
+
+**Not a study space.** SWORD is a closed-stack depository for
+shared OhioLINK storage. Not in the room reservation system. Should
+never appear in a "where can I study?" answer.
+
+---
+
+## What the bot is allowed to say about room booking
+
+Synthesizer prompt should treat the following as facts:
+
+1. **There are 5 building locations** with bookable rooms (King,
+   Wertz, Armstrong, Rentschler, Gardner-Harvey). Special Collections
+   and SWORD are NOT bookable spaces.
+2. **All booking goes through LibCal** — Miami login required.
+   `https://muohio.libcal.com/reserve/{building}` is the canonical
+   per-building URL.
+3. **Universal rules**: 2 hours/day, 2 weeks ahead.
+4. **Inventory varies by building**: King has the most; Hamilton has
+   the smallest (only ≤8 capacity); Wertz is small; Middletown is
+   medium; Armstrong is non-library.
+5. **Specific room numbers** (King 022/023/242/243 sensory-friendly,
+   King 112A/B/C Zoom rooms) are real and citable.
+
+What the bot must **refuse** to claim without live LibCal data:
+
+- "Room X is available right now" — requires live API call
+- "There's a room with capacity exactly N free at time T" — same
+- "This room has whiteboard / monitor / Mac / PC" — equipment details
+  are not surfaced on the static room-reservation page; only via
+  the LibCal calendar UI per-room. Until the API integration lands,
+  the bot can say "many King study rooms have whiteboards and screens"
+  in general but cannot promise specific equipment in a specific room.
+
+---
+
+## Gold-set corrections to file
+
+When updating `ai-core/src/eval/golden_set.jsonl` against this truth:
+
+| Gold case ID | Current state | Correction |
+|---|---|---|
+| `rb_king_4_people_whiteboard` | `allowed_urls` includes `/use/spaces/study-rooms/` (404) | Replace with `https://www.lib.miamioh.edu/use/spaces/room-reservations/` AND `https://muohio.libcal.com/reserve/king` |
+| `rb_wertz_no_bookable` | `expected_answer` says Wertz has "limited bookable rooms" | True but expand: Wertz HAS bookable rooms; cite `https://muohio.libcal.com/reserve/ArtArch` |
+| `rb_rentschler_tomorrow` | (verify URL field) | Should cite `https://muohio.libcal.com/reserve/hamilton` + the universal 2-hour / 2-week rules |
+| `rb_gardner_harvey` | (verify URL field) | Should cite `https://muohio.libcal.com/reserve/middletown` |
+| Any case claiming "no rooms at X" | Verify | Special Collections + SWORD are correct refusals; **all other library buildings have rooms** |
+
+---
+
+## What's still unknown (parked for LibCal API integration)
+
+When the user provides write access to LibCal, this section becomes
+the integration checklist:
+
+1. **Per-room metadata** — current equipment lists per room, capacity
+   per room (not per filter bucket), accessibility notes.
+2. **Live availability** — "is room X free now?" requires LibCal's
+   availability endpoint.
+3. **Reservation submission** — letting the bot book on the user's
+   behalf is an Op-2 / capability-scope decision the librarians have
+   to sign off on. Plan §7 notes the action-vs-guidance distinction:
+   the bot should POINT users to LibCal, not submit reservations.
+
+Until then, the bot should answer at the granularity captured above
+and let users complete the actual booking on LibCal.

--- a/ai-core/scripts/inspect_eval_case.py
+++ b/ai-core/scripts/inspect_eval_case.py
@@ -94,6 +94,22 @@ def _show(q: GoldQuestion, *, live: bool, k: int) -> None:
     print(f"  intent:    {q.intent}")
     print(f"  outcome:   {q.expected_outcome}")
     print(f"  scope:     campus={q.scope_campus}, library={q.scope_library}")
+    # session_origin is the field that EXPLAINS a non-Oxford scope on
+    # a generic question. Surface it next to scope so "why is this
+    # Hamilton when King is the default?" is answered inline, not a
+    # mystery. Default scope = Oxford/King; session_origin OVERRIDES
+    # that default when the chat widget is embedded on a regional
+    # campus site (ham.miamioh.edu / mid.miamioh.edu).
+    if q.needs_session_origin:
+        print(f"  session_origin: {q.needs_session_origin}  "
+              f"<-- OVERRIDES the Oxford/King default; scope is "
+              f"{q.scope_campus} because the chat is simulated as "
+              f"originating from the {q.needs_session_origin} campus site")
+    else:
+        print("  session_origin: (none)  -- scope came from the "
+              "question text or the Oxford/King default")
+    if q.notes:
+        print(f"  notes:     {q.notes}")
     print(bar)
 
     print("\n  QUESTION (what the user asked):")

--- a/ai-core/scripts/inspect_eval_case.py
+++ b/ai-core/scripts/inspect_eval_case.py
@@ -1,0 +1,214 @@
+"""
+Gold-set audit tool: read each gold case against the live Miami site.
+
+The gold set (`ai-core/src/eval/golden_set.jsonl`) is the answer key
+the eval scores the bot against. It's hand-written, so it has bugs
+(e.g. the makerspace / room-booking errors found 2026-05-14/15). This
+tool surfaces one or more gold cases so a human can verify the
+`expected_answer` + `allowed_urls` actually match what
+lib.miamioh.edu / libguides.* / ham.* / mid.* say today.
+
+Two modes:
+  - default: prints the gold case only. No LLM, no Weaviate, ~$0,
+    instant. Use this to eyeball expected-answer correctness.
+  - `--live`: also runs REAL Weaviate retrieval for the question and
+    prints the top-k chunks the bot would actually see. Requires the
+    SSH tunnel + a populated index. Distinguishes a gold-set bug
+    (wrong expected answer) from a corpus gap (right gold, the ETL
+    just didn't crawl the page).
+
+When the gold is wrong: capture the truth in
+`ai-core/docs/canonical/` and file the correction.
+
+Usage:
+    python -m scripts.inspect_eval_case --id svc_print_color
+    python -m scripts.inspect_eval_case --category cross_campus --limit 5
+    python -m scripts.inspect_eval_case --intent makerspace_3d --live
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import textwrap
+from pathlib import Path
+from typing import Optional
+
+# Allow running as `python -m scripts.inspect_eval_case` from ai-core/.
+_HERE = Path(__file__).resolve().parent
+_AI_CORE = _HERE.parent
+sys.path.insert(0, str(_AI_CORE))
+
+from src.eval.golden_set import GoldQuestion, load_golden_set  # noqa: E402
+
+
+def _wrap(text: str, indent: str = "  ") -> str:
+    return textwrap.fill(
+        text, width=86,
+        initial_indent=indent, subsequent_indent=indent,
+    )
+
+
+def _live_chunks(q: GoldQuestion, k: int) -> list[dict]:
+    """Run REAL Weaviate retrieval for this gold question (requires the
+    SSH tunnel + a populated index). Returns the top-k hit dicts so a
+    human can eyeball whether the corpus actually has the content the
+    gold expects. Empty list on any failure."""
+    try:
+        from src.retrieval.scope_filter import ScopeFilter
+        from src.retrieval.search import RetrievalRequest, search_kb
+        from src.scope.resolver import resolve_scope
+        from src.weaviate.search_adapter import WeaviateSearchAdapter
+
+        s = resolve_scope(
+            q.question,
+            session_origin_campus=q.needs_session_origin,  # type: ignore[arg-type]
+        )
+        scope = ScopeFilter(campus=s.campus, library=s.library)
+        result = search_kb(
+            RetrievalRequest(query=q.question, scope=scope, k=k),
+            weaviate=WeaviateSearchAdapter(),
+            collection=None,  # WEAVIATE_CHUNK_COLLECTION env var
+        )
+        return [
+            {
+                "source_url": c.source_url,
+                "score": round(c.score, 3),
+                "text": (c.text[:300] + "...") if len(c.text) > 300 else c.text,
+            }
+            for c in result.chunks
+        ]
+    except Exception as e:  # noqa: BLE001
+        print(f"  (live retrieval unavailable: {type(e).__name__}: {e})")
+        return []
+
+
+def _show(q: GoldQuestion, *, live: bool, k: int) -> None:
+    """Pretty-print one gold case for human audit against the live
+    Miami website. With `live=True`, also shows what real Weaviate
+    retrieval returns so you can spot corpus gaps vs gold-set bugs."""
+    bar = "─" * 90
+    print(f"\n{bar}")
+    print(f"  ID:        {q.id}")
+    print(f"  category:  {q.category}")
+    print(f"  intent:    {q.intent}")
+    print(f"  outcome:   {q.expected_outcome}")
+    print(f"  scope:     campus={q.scope_campus}, library={q.scope_library}")
+    print(bar)
+
+    print("\n  QUESTION (what the user asked):")
+    print(_wrap(q.question))
+
+    print("\n  GOLD EXPECTED ANSWER (what a librarian wrote -- audit THIS "
+          "against the live site):")
+    print(_wrap(q.expected_answer or "(none)"))
+
+    if q.allowed_urls:
+        print("\n  ALLOWED URLS (gold says these are the only URLs the bot "
+              "may cite -- verify they're live + canonical, not redirects):")
+        for u in q.allowed_urls:
+            print(f"    - {u}")
+
+    if live:
+        print(f"\n  LIVE RETRIEVAL (top-{k} real chunks the bot would "
+              f"actually see):")
+        chunks = _live_chunks(q, k)
+        if not chunks:
+            print("    (no chunks returned -- corpus gap OR scope filter "
+                  "too strict OR tunnel down)")
+        for i, c in enumerate(chunks, 1):
+            print(f"    [{i}] score={c['score']}  {c['source_url']}")
+            print(_wrap(c["text"], indent="        "))
+    else:
+        print("\n  (run with --live to see the real retrieved chunks; "
+              "requires the SSH tunnel + populated Weaviate)")
+
+    if q.expected_outcome == "refusal":
+        print("\n  NOTE: gold expects a refusal here -- confirm the question "
+              "is genuinely unanswerable (out-of-scope / no corpus content / "
+              "service-not-at-this-building), NOT just thin retrieval.")
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n")[1])
+    p.add_argument(
+        "--id", nargs="*", default=None,
+        help="One or more gold case ids to inspect (e.g. svc_print_color).",
+    )
+    p.add_argument(
+        "--category", default=None,
+        help="Filter to a single gold category (e.g. service, featured_service).",
+    )
+    p.add_argument(
+        "--intent", default=None,
+        help="Filter to gold cases with this expected intent (e.g. hours).",
+    )
+    p.add_argument(
+        "--outcome", choices=["answer", "refusal", "clarify"], default=None,
+        help="Filter to gold cases with this expected outcome.",
+    )
+    p.add_argument(
+        "--limit", type=int, default=None,
+        help="Stop after N cases (handy with --category for a quick scan).",
+    )
+    p.add_argument(
+        "--live", action="store_true",
+        help=(
+            "Also run REAL Weaviate retrieval per case to show the "
+            "actual chunks the bot would see. Requires the SSH tunnel "
+            "+ a populated index. Without this flag, only the gold "
+            "case is shown (always works, no deps)."
+        ),
+    )
+    p.add_argument(
+        "-k", type=int, default=5,
+        help="With --live: how many retrieved chunks to show (default 5).",
+    )
+    args = p.parse_args()
+
+    questions = load_golden_set()
+
+    if args.id:
+        wanted = set(args.id)
+        questions = [q for q in questions if q.id in wanted]
+        missing = wanted - {q.id for q in questions}
+        if missing:
+            print(f"warning: ids not found in gold set: {sorted(missing)}",
+                  file=sys.stderr)
+    if args.category:
+        questions = [q for q in questions if q.category == args.category]
+    if args.intent:
+        questions = [q for q in questions if q.intent == args.intent]
+    if args.outcome:
+        questions = [q for q in questions if q.expected_outcome == args.outcome]
+
+    if not questions:
+        print("no gold cases matched the filters", file=sys.stderr)
+        return 1
+
+    if args.limit:
+        questions = questions[: args.limit]
+
+    print(f"Inspecting {len(questions)} gold case(s)"
+          f"{' [LIVE retrieval]' if args.live else ''}:")
+    for q in questions:
+        _show(q, live=args.live, k=args.k)
+
+    print(f"\n{'─' * 90}")
+    print(f"  Inspected: {len(questions)} case(s).")
+    print(
+        "  This is a GOLD-SET AUDIT tool. Read each case's expected "
+        "answer + allowed URLs\n  against the live Miami website "
+        "(lib.miamioh.edu / libguides.* / ham.* / mid.*).\n"
+        "  When the gold is wrong, capture the truth in "
+        "ai-core/docs/canonical/ and file the\n  correction. With "
+        "--live you also see the real retrieved chunks, which "
+        "distinguishes\n  a gold-set bug (wrong expected answer) from "
+        "a corpus gap (right gold, missing crawl)."
+    )
+    print(f"{'─' * 90}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ai-core/src/eval/run_eval.py
+++ b/ai-core/src/eval/run_eval.py
@@ -90,6 +90,7 @@ from src.router.intent_knn import (  # noqa: E402
     IntentKNN,
     load_exemplars_from_disk,
 )
+from src.retrieval.scope_filter import ScopeFilter  # noqa: E402
 from src.scope.resolver import resolve_scope  # noqa: E402
 
 logger = logging.getLogger("eval")
@@ -366,275 +367,65 @@ def _is_stub_answer(answer: Optional[str]) -> bool:
     return bool(answer) and _STUB_ANSWER_MARKER in answer
 
 
-# --- Real-LLM deps + realistic-fake search_kb ----------------------------
+# --- Real-LLM deps: real OpenAI + real Weaviate retrieval ---------------
 #
 # When --with-real-llm is set, the eval uses the production agent +
-# synthesizer LLM defaults (which call OpenAI via src/llm/client) but
-# still uses a FAKE search_kb tool because no real Weaviate is
-# populated. The fake returns intent-keyed plausible evidence so the
-# synth has something to ground on. Pairs cleanly with --with-judge
-# for end-to-end scoring.
+# synthesizer LLM defaults AND `WeaviateSearchAdapter` against the
+# real indexed corpus. There is NO canned/synthetic evidence anymore
+# (the old `_REALISTIC_EVIDENCE` map was deleted once real retrieval
+# was wired -- it caused more confusion than it was worth: the synth
+# was grounding on hand-written approximations instead of the actual
+# crawled Miami content).
+#
+# Requires the server's Weaviate reachable. From a laptop, run with
+# the SSH tunnel up (see ai-core/docs/canonical/ for the workflow).
 #
 # Cost when --with-real-llm:
 #   ~$0.005 agent + ~$0.005 synth per turn = ~$1.80 for 184 cases
 #   plus ~$0.02 per judge call if --with-judge = ~$3.70 total
-# In practice you'll usually filter to a smaller category for
-# iteration cost.
-
-# Intent -> (canonical_url, plausible_evidence_text). One chunk per
-# intent. Text is short on purpose -- enough for the synth to
-# generate a grounded one-paragraph answer, but not so verbose that
-# we're effectively writing the bot's answer ourselves.
-_REALISTIC_EVIDENCE: dict[str, tuple[str, str]] = {
-    "hours": (
-        "https://www.lib.miamioh.edu/about/locations/king-library/",
-        "King Library hours: Mon-Thu 7am-2am, Fri 7am-10pm, "
-        "Sat 9am-10pm, Sun 10am-2am. Check the LibCal widget for "
-        "today's actual hours including holidays.",
-    ),
-    "location_directions": (
-        "https://www.lib.miamioh.edu/about/locations/",
-        "Miami's main library is the Edward King Library, located on "
-        "the Oxford campus at 151 South Campus Avenue. The Wertz Art "
-        "and Architecture Library is in Alumni Hall. Regional "
-        "libraries: Rentschler at Hamilton, Gardner-Harvey at "
-        "Middletown.",
-    ),
-    "staff_lookup": (
-        "https://www.lib.miamioh.edu/about/organization/",
-        "Find any librarian via the staff directory. For department "
-        "leadership (deans, associate deans), see the Organization "
-        "page.",
-    ),
-    "subject_librarian": (
-        "https://www.lib.miamioh.edu/about/organization/liaisons/",
-        "Each subject area has a designated liaison librarian. The "
-        "liaisons page lists them by department + email.",
-    ),
-    "room_booking": (
-        "https://miamioh.libcal.com/spaces",
-        "Group study rooms at King and Wertz are reservable via "
-        "LibCal. Reservations open 14 days in advance. Walk-ins are "
-        "OK if a room is free.",
-    ),
-    "space_info": (
-        "https://www.lib.miamioh.edu/use/spaces/",
-        "King has quiet (silent) study on the 3rd floor; group "
-        "study on the 1st-2nd floors. Lockers are available near "
-        "the main entrance. Food and drinks are allowed except in "
-        "the silent area.",
-    ),
-    "makerspace_3d": (
-        "https://www.lib.miamioh.edu/use/spaces/makerspace/",
-        "The MakerSpace is located in King Library, ground floor. "
-        "Equipment includes 3D printers (Prusa), a vinyl cutter, "
-        "sewing machines, and an embroidery machine. Open during "
-        "King's regular hours.",
-    ),
-    "printing_wifi": (
-        "https://www.lib.miamioh.edu/use/technology/printing/",
-        "Print from any campus computer or your laptop via the "
-        "wireless print queue. Scanning is free from the multi-"
-        "function devices on each floor. Color printing is "
-        "available at a per-page charge.",
-    ),
-    "tech_checkout": (
-        "https://www.lib.miamioh.edu/use/technology/",
-        "Laptops, chargers, calculators, and cameras are available "
-        "for checkout at the circulation desk. Check the equipment "
-        "list for current availability.",
-    ),
-    "circulation_basic": (
-        "https://www.lib.miamioh.edu/use/borrow/",
-        "Place a hold on any item via Primo. Pickup is at the King "
-        "circulation desk; you'll get an email when it's ready. "
-        "Holds are held for 7 days.",
-    ),
-    "renewal": (
-        "https://www.lib.miamioh.edu/use/borrow/",
-        "Books can be renewed online via MyAccount up to 5 times "
-        "unless someone else has placed a hold. Late fees apply "
-        "after the due date.",
-    ),
-    "loan_policy": (
-        "https://www.lib.miamioh.edu/use/borrow/",
-        "Standard loan period for undergraduates is 28 days; "
-        "graduate students 90 days; faculty 180 days. Late fees "
-        "are $0.25/day for general circulation.",
-    ),
-    "course_reserves": (
-        "https://www.lib.miamioh.edu/use/borrow/course-reserves/",
-        "Course reserves are textbooks and supplemental readings "
-        "instructors have placed at the circulation desk for "
-        "in-library use. Search by course number on the reserves "
-        "page.",
-    ),
-    "interlibrary_loan": (
-        "https://www.lib.miamioh.edu/use/borrow/ill/",
-        "Request items Miami doesn't own via OhioLINK or ILLiad. "
-        "OhioLINK items typically arrive in 3-5 business days; "
-        "ILLiad takes 1-2 weeks.",
-    ),
-    "citation_help": (
-        "https://libguides.lib.miamioh.edu/cite/",
-        "The citation guide covers APA, MLA, and Chicago. Examples "
-        "for books, journal articles, and websites. Miami also "
-        "subscribes to Zotero training.",
-    ),
-    "research_consultation": (
-        "https://www.lib.miamioh.edu/research/research-support/",
-        "Schedule a 30-60 minute research consultation with a "
-        "subject librarian. Bring your topic, any sources you've "
-        "found, and questions about research strategy.",
-    ),
-    "data_services": (
-        "https://www.lib.miamioh.edu/research/data-services/",
-        "Data services support includes GIS, statistical software "
-        "(R, SPSS, Stata), and data management plans. Consultations "
-        "by appointment.",
-    ),
-    "newspapers": (
-        "https://libguides.lib.miamioh.edu/news/",
-        "Miami subscribes to the New York Times, Wall Street "
-        "Journal, and Cincinnati Enquirer. Activate your NYT/WSJ "
-        "pass through the library's databases page.",
-    ),
-    "remote_access": (
-        "https://www.lib.miamioh.edu/use/technology/proxy/",
-        "Access databases from off campus using the library's "
-        "proxy. Sign in with your Miami credentials when prompted. "
-        "If a link gives a 401/403, prepend the proxy URL.",
-    ),
-    "av_production": (
-        "https://www.lib.miamioh.edu/use/spaces/",
-        "Podcast and video production spaces are available in King "
-        "Library. Reserve via LibCal. Equipment includes a "
-        "professional mic, camera, and editing software.",
-    ),
-    "scholarly_publishing": (
-        "https://www.lib.miamioh.edu/research/scholarly-publishing/",
-        "Scholarly Commons hosts Miami-authored works for open "
-        "access. The library provides author-rights guidance and "
-        "ETD (thesis/dissertation) deposit support.",
-    ),
-    "instruction_request": (
-        "https://www.lib.miamioh.edu/research/research-support/",
-        "Faculty can request a librarian-led instruction session "
-        "for their course. Submit through the instruction request "
-        "form at least 2 weeks before the desired session date.",
-    ),
-    "accessibility_services": (
-        "https://www.lib.miamioh.edu/use/accessibility/",
-        "Library accessibility services include alternative format "
-        "materials, accessible workstations, and ADA-compliant "
-        "study spaces. Coordinate via Miller Center for Disability.",
-    ),
-    "copyright_permissions": (
-        "https://libguides.lib.miamioh.edu/copyright/",
-        "Fair use, TEACH Act, and permissions guidance for "
-        "instructors and students. Includes the four-factor fair "
-        "use analysis worksheet.",
-    ),
-    "software_access": (
-        "https://www.lib.miamioh.edu/use/technology/software/",
-        "Library computers have Microsoft Office, SPSS, Stata, "
-        "MATLAB, and Adobe Creative Cloud. Some software is "
-        "available for personal-device install via the IT services "
-        "portal.",
-    ),
-    "adobe_access": (
-        "https://www.lib.miamioh.edu/use/technology/software/adobe/",
-        "Adobe Creative Cloud is available on library computers. "
-        "Students can also install Adobe on personal devices via "
-        "the Miami University Adobe license through IT services.",
-    ),
-    "human_handoff": (
-        "https://www.lib.miamioh.edu/research/research-support/ask/",
-        "Ask Us via chat, email, or phone for help from a librarian. "
-        "Chat hours align with King service desk hours; email gets "
-        "a same-day reply on business days.",
-    ),
-    "special_collections": (
-        "https://www.lib.miamioh.edu/about/locations/special-collections-archives/",
-        "Special Collections and University Archives is on the 3rd "
-        "floor of King. Appointments preferred. Holdings include "
-        "rare books, university records, and Western College "
-        "Memorial Library collections.",
-    ),
-    "digital_collections": (
-        "https://digital.lib.miamioh.edu/",
-        "Miami's digital collections include historical photos, "
-        "Miamian yearbooks, oral histories, and the Western College "
-        "for Women archive. Browse by collection or full-text search.",
-    ),
-    "cross_campus_comparison": (
-        "https://www.lib.miamioh.edu/about/locations/",
-        "Services vary by campus: King (Oxford) has the MakerSpace "
-        "and Special Collections; Rentschler (Hamilton) and "
-        "Gardner-Harvey (Middletown) offer printing, study rooms, "
-        "and research help. All campuses share electronic resources.",
-    ),
-    "service_howto": (
-        "https://www.lib.miamioh.edu/use/",
-        "Browse the library's services page for an index of how to "
-        "use each service: borrowing, spaces, technology, research "
-        "support.",
-    ),
-    # find_resource, databases, library_employment, events_news,
-    # account, website_feedback are all POINT_TO_URL / REFUSE; agent
-    # never runs for them. No evidence needed.
-}
+# Filter to a category for cheaper iteration.
 
 
-def _build_real_deps(classifier: IntentKNN, intent_for_evidence: str):
-    """Build OrchestratorDeps that use REAL OpenAI LLMs (no stubs).
+def _build_real_deps(
+    classifier: IntentKNN,
+    *,
+    scope: "ScopeFilter",
+    intent: str,
+):
+    """Build OrchestratorDeps that use REAL OpenAI LLMs AND real
+    Weaviate retrieval (no stubs, no canned evidence).
 
-    The agent + synthesizer modules already default to real Responses
-    API calls when no `llm=` override is passed. We just have to not
-    pass the stubs that `_build_stub_deps` does.
+    `search_kb` is wired to `WeaviateSearchAdapter` -> the same
+    `Chunk_v*` collection the production bot reads (selected via the
+    WEAVIATE_CHUNK_COLLECTION env var, defaulting to Chunk_current).
+    Requires the server's Weaviate to be reachable -- run the eval
+    with the SSH tunnel up if you're on a laptop.
 
-    `search_kb` is still a fake (no real Weaviate), but returns
-    realistic intent-keyed evidence from `_REALISTIC_EVIDENCE` so the
-    synthesizer has something plausible to ground on. The intent is
-    determined by the classifier upstream; we pass it through so the
-    tool's fake-evidence pick matches the resolved intent.
+    `scope` and `intent` are pre-resolved by the caller (same pattern
+    the eval already uses for scope-match checking). The orchestrator
+    re-resolves both internally and arrives at the same values
+    (deterministic); we pass them here only so the search tool's
+    scope filter + featured-service boost match the resolved turn.
+
+    `load_url_allowlist` returns an empty set deliberately: the
+    post-processor's URL validator accepts any URL that appears in
+    the retrieval bundle's source_urls (see
+    test_url_cited_not_in_allowlist_is_ok). Real retrieved chunks
+    carry their real source_url, so citing them passes validation
+    without needing UrlSeen populated on the eval host. Only
+    *fabricated* URLs (not in any retrieved chunk) get rejected --
+    exactly the behavior we want to measure.
     """
-    url, snippet = _REALISTIC_EVIDENCE.get(
-        intent_for_evidence,
-        (
-            "https://www.lib.miamioh.edu/",
-            "General library landing page; specific service info is "
-            "linked from the navigation.",
-        ),
-    )
-    fake_evidence = {
-        "n": 1,
-        "chunk_id": f"eval-realistic-{intent_for_evidence}",
-        "source_url": url,
-        "snippet": snippet,
-        "campus": "all",
-        "library": "all",
-        "topic": "service",
-        "featured_service": None,
-        "score": 0.85,
-    }
+    from src.tools.search_kb_tool import make_search_kb_tool
+    from src.weaviate.search_adapter import WeaviateSearchAdapter
 
+    weav = WeaviateSearchAdapter()  # real v4 client via get_weaviate_client()
     registry = ToolRegistry()
-    registry.register(Tool(
-        name="search_kb",
-        description=(
-            "Search the library knowledge base. Returns evidence "
-            "chunks the synthesizer can cite."
-        ),
-        parameters={
-            "type": "object",
-            "additionalProperties": False,
-            "properties": {
-                "query": {"type": "string"},
-            },
-            "required": ["query"],
-        },
-        handler=lambda args: {"evidence": [fake_evidence]},
+    registry.register(make_search_kb_tool(
+        weaviate=weav,
+        scope=scope,
+        intent=intent,
+        collection=None,  # resolves WEAVIATE_CHUNK_COLLECTION at request time
     ))
 
     return OrchestratorDeps(
@@ -643,7 +434,7 @@ def _build_real_deps(classifier: IntentKNN, intent_for_evidence: str):
         agent_llm=None,         # use _default_llm_call -> real OpenAI
         synthesizer_llm=None,   # ditto
         load_corrections=lambda: [],
-        load_url_allowlist=lambda: {url},
+        load_url_allowlist=lambda: set(),
         lookup_service_availability=lambda intent, campus: None,
     )
 
@@ -800,15 +591,24 @@ def run_eval(
             # Per-turn construction is cheap (no I/O, no embeddings)
             # so this is the right shape.
             if with_real_llm:
-                # Pre-classify to pick intent-keyed evidence for the
-                # realistic-fake search_kb. The orchestrator will
-                # re-classify with the same exemplars + cache hit,
-                # arriving at the same intent. One redundant cosine
-                # matmul; negligible vs the LLM cost about to happen.
+                # Pre-resolve scope + intent so the real search_kb
+                # tool filters/boosts to the right campus/library/
+                # featured-service for this turn. The orchestrator
+                # re-resolves both internally (deterministic) and
+                # arrives at the same values -- the pre-resolution
+                # here only configures the tool, which is built once
+                # per turn in deps. One redundant classify + scope
+                # resolve; negligible vs the LLM cost.
                 pre_classification = classifier.classify(q.question)
+                _s = resolve_scope(
+                    q.question,
+                    session_origin_campus=q.needs_session_origin,  # type: ignore[arg-type]
+                )
+                _scope = ScopeFilter(campus=_s.campus, library=_s.library)
                 deps = _build_real_deps(
                     classifier,
-                    intent_for_evidence=pre_classification.intent,
+                    scope=_scope,
+                    intent=pre_classification.intent,
                 )
             else:
                 deps = _build_stub_deps(classifier)

--- a/ai-core/src/weaviate/search_adapter.py
+++ b/ai-core/src/weaviate/search_adapter.py
@@ -1,0 +1,207 @@
+"""
+WeaviateSearchAdapter: read-side v4 client wrapper for retrieval.
+
+Implements `src/retrieval/search.py::WeaviateLike` (the `hybrid_search`
+Protocol). This is the production wire that lets `search_kb` query the
+real indexed corpus instead of the hand-written `_REALISTIC_EVIDENCE`
+map the eval used as a stopgap.
+
+Separate module from `etl_adapter.py` on purpose:
+  - ETL adapter = WRITE side (upsert / tombstone / gc). Destructive.
+  - Search adapter = READ side (hybrid query). Idempotent, hot path.
+Different consistency + performance concerns; keeping them apart keeps
+each adapter's surface minimal and auditable.
+
+The scope-filter dict shape (`build_where_clause` /
+`build_should_match` in `src/retrieval/scope_filter.py`) is a nested
+{operator, operands, path, valueText/valueBoolean} structure. This
+adapter recursively translates it into v4 typed `Filter` objects.
+
+See plan: Layer 2 (Retrieval and grounding).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _translate_filter(clause: dict) -> Any:
+    """Recursively convert a scope_filter dict into a v4 `Filter`.
+
+    Input shapes (from src/retrieval/scope_filter.py):
+        {"operator": "And", "operands": [ ... ]}
+        {"operator": "Or",  "operands": [ ... ]}
+        {"path": ["campus"], "operator": "Equal", "valueText": "oxford"}
+        {"path": ["deleted"], "operator": "Equal", "valueBoolean": False}
+
+    Lazy-imports `weaviate.classes.query.Filter` so this module is
+    importable in environments without the SDK (the translator itself
+    is unit-tested with a fake Filter; see test_search_adapter.py).
+    """
+    from weaviate.classes.query import Filter
+
+    op = clause.get("operator")
+
+    if op == "And":
+        operands = [_translate_filter(o) for o in clause["operands"]]
+        return Filter.all_of(operands)
+    if op == "Or":
+        operands = [_translate_filter(o) for o in clause["operands"]]
+        return Filter.any_of(operands)
+    if op == "Equal":
+        path = clause["path"][0]
+        if "valueText" in clause:
+            return Filter.by_property(path).equal(clause["valueText"])
+        if "valueBoolean" in clause:
+            return Filter.by_property(path).equal(clause["valueBoolean"])
+        raise ValueError(
+            f"Equal clause for path={path!r} has no valueText/valueBoolean: "
+            f"{clause!r}"
+        )
+    raise ValueError(f"unsupported filter clause: {clause!r}")
+
+
+# Exposed for unit testing with an injected fake `Filter` so the
+# recursive translation can be exercised without the weaviate SDK.
+def _translate_filter_with(clause: dict, filter_cls: Any) -> Any:
+    """Same as _translate_filter but uses an injected Filter class.
+    Used by tests; prod calls _translate_filter (lazy real import)."""
+    op = clause.get("operator")
+    if op == "And":
+        return filter_cls.all_of(
+            [_translate_filter_with(o, filter_cls) for o in clause["operands"]]
+        )
+    if op == "Or":
+        return filter_cls.any_of(
+            [_translate_filter_with(o, filter_cls) for o in clause["operands"]]
+        )
+    if op == "Equal":
+        path = clause["path"][0]
+        if "valueText" in clause:
+            return filter_cls.by_property(path).equal(clause["valueText"])
+        if "valueBoolean" in clause:
+            return filter_cls.by_property(path).equal(clause["valueBoolean"])
+        raise ValueError(f"Equal clause missing value: {clause!r}")
+    raise ValueError(f"unsupported filter clause: {clause!r}")
+
+
+@dataclass
+class WeaviateSearchAdapter:
+    """Implements `WeaviateLike.hybrid_search` against a real v4 client.
+
+    Construct with `client=None` to auto-resolve from
+    `src.utils.weaviate_client.get_weaviate_client()`. Tests inject a
+    fake client exposing `.collections.get(name).query.hybrid(...)`.
+    """
+
+    client: Any = None
+
+    def __post_init__(self) -> None:
+        if self.client is None:
+            from src.utils.weaviate_client import get_weaviate_client
+            c = get_weaviate_client()
+            if c is None:
+                raise RuntimeError(
+                    "Weaviate client unavailable. Check WEAVIATE_HOST/PORT "
+                    "in .env and that the server's Weaviate is reachable "
+                    "(SSH tunnel if running the eval from a laptop). See "
+                    "src/utils/weaviate_client.py."
+                )
+            self.client = c
+
+    def hybrid_search(
+        self,
+        *,
+        collection: str,
+        query: str,
+        where: dict,
+        alpha: float,
+        limit: int,
+        should_match: Optional[dict] = None,
+    ) -> list[dict]:
+        """Run a v4 hybrid (BM25 + vector) query.
+
+        `should_match` is accepted for Protocol conformance but NOT
+        applied here -- src/retrieval/search.py does featured-service
+        soft-boost reordering on the returned hits AFTER this call, so
+        applying it again here would double-count. The contract is:
+        this method does the hard-filtered hybrid query; the caller
+        does the soft rank-nudge.
+
+        Returns hit dicts in the shape WeaviateLike documents:
+            {chunk_id, source_url, text, campus, library, topic,
+             featured_service, score}
+
+        On any error returns [] (the caller treats empty as NO_RESULTS
+        and the agent refuses via that trigger -- never crash the turn
+        on a retrieval hiccup).
+        """
+        # Build optional v4 query helpers. If the SDK isn't importable
+        # (sandbox / unit tests with a fake client), degrade: no typed
+        # filter, no metadata request. A fake client ignores both; a
+        # real Weaviate server always has the SDK. Only an actual query
+        # EXECUTION error returns [] -- an SDK-absent environment is a
+        # test path, not a turn failure.
+        filters = None
+        return_metadata = None
+        try:
+            from weaviate.classes.query import Filter as _F  # noqa: F401
+            from weaviate.classes.query import MetadataQuery
+
+            return_metadata = MetadataQuery(score=True)
+            if where:
+                filters = _translate_filter(where)
+        except ImportError:
+            logger.debug(
+                "weaviate SDK not importable; querying without typed "
+                "filter / metadata (test or sandbox path)"
+            )
+
+        try:
+            coll = self.client.collections.get(collection)
+            resp = coll.query.hybrid(
+                query=query,
+                alpha=alpha,
+                limit=limit,
+                filters=filters,
+                return_metadata=return_metadata,
+            )
+        except Exception as e:  # noqa: BLE001 -- never crash the turn
+            logger.warning(
+                "hybrid_search failed for collection=%s query=%r: %s",
+                collection, query[:80], e,
+            )
+            return []
+
+        hits: list[dict] = []
+        for obj in getattr(resp, "objects", []) or []:
+            props = dict(getattr(obj, "properties", {}) or {})
+            meta = getattr(obj, "metadata", None)
+            score = 0.0
+            if meta is not None and getattr(meta, "score", None) is not None:
+                try:
+                    score = float(meta.score)
+                except (TypeError, ValueError):
+                    score = 0.0
+            hits.append({
+                # The ETL stored the original chunk_id as a property
+                # (the Weaviate object id is a uuid5 of it -- see
+                # etl_adapter._chunk_uuid). Prefer the property; fall
+                # back to the object uuid if somehow absent.
+                "chunk_id": props.get("chunk_id") or str(getattr(obj, "uuid", "")),
+                "source_url": props.get("source_url", ""),
+                "text": props.get("text", ""),
+                "campus": props.get("campus"),
+                "library": props.get("library") or None,
+                "topic": props.get("topic"),
+                "featured_service": props.get("featured_service") or None,
+                "score": score,
+            })
+        return hits
+
+
+__all__ = ["WeaviateSearchAdapter", "_translate_filter", "_translate_filter_with"]

--- a/ai-core/src/weaviate/test_search_adapter.py
+++ b/ai-core/src/weaviate/test_search_adapter.py
@@ -1,0 +1,325 @@
+"""
+Unit tests for WeaviateSearchAdapter.
+
+Run: `python -m src.weaviate.test_search_adapter` from ai-core/.
+
+The risky logic is the recursive scope-filter-dict -> v4 Filter
+translation and the response-shape mapping. Both are tested with
+fakes so no live Weaviate is needed.
+
+Coverage:
+  1. Translate a flat Equal(text) clause
+  2. Translate a flat Equal(bool) clause
+  3. Translate a nested And/Or tree (the real build_where_clause shape)
+  4. Reject an Equal clause with no value
+  5. Reject an unknown operator
+  6. hybrid_search maps v4 response objects to the documented hit shape
+  7. hybrid_search prefers the chunk_id PROPERTY over the object uuid
+  8. hybrid_search returns [] on client error (never crashes the turn)
+  9. hybrid_search tolerates missing metadata / missing properties
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+_HERE = Path(__file__).resolve().parent
+_AI_CORE = _HERE.parent.parent
+sys.path.insert(0, str(_AI_CORE))
+
+from src.weaviate.search_adapter import (  # noqa: E402
+    WeaviateSearchAdapter,
+    _translate_filter_with,
+)
+from src.retrieval.scope_filter import (  # noqa: E402
+    ScopeFilter,
+    build_where_clause,
+)
+
+
+# --- Fake v4 Filter -----------------------------------------------------
+
+
+class _FakeFilterExpr:
+    """Records what filter expression got built so tests can assert."""
+    def __init__(self, kind: str, **kw: Any):
+        self.kind = kind
+        self.kw = kw
+
+    def __repr__(self) -> str:
+        return f"Filter({self.kind}, {self.kw})"
+
+
+class _FakeProp:
+    def __init__(self, name: str):
+        self.name = name
+
+    def equal(self, value: Any) -> _FakeFilterExpr:
+        return _FakeFilterExpr("equal", path=self.name, value=value)
+
+
+class FakeFilter:
+    @staticmethod
+    def by_property(name: str) -> _FakeProp:
+        return _FakeProp(name)
+
+    @staticmethod
+    def all_of(operands: list) -> _FakeFilterExpr:
+        return _FakeFilterExpr("all_of", operands=operands)
+
+    @staticmethod
+    def any_of(operands: list) -> _FakeFilterExpr:
+        return _FakeFilterExpr("any_of", operands=operands)
+
+
+# --- Fake v4 query client -----------------------------------------------
+
+
+class _FakeMeta:
+    def __init__(self, score: Any):
+        self.score = score
+
+
+class _FakeObj:
+    def __init__(self, uuid: str, properties: dict, score: Any = 0.5):
+        self.uuid = uuid
+        self.properties = properties
+        self.metadata = _FakeMeta(score)
+
+
+class _FakeResp:
+    def __init__(self, objects: list):
+        self.objects = objects
+
+
+class _FakeQuery:
+    def __init__(self, resp: _FakeResp, raises: bool = False):
+        self._resp = resp
+        self._raises = raises
+        self.last_call: dict = {}
+
+    def hybrid(self, **kw: Any) -> _FakeResp:
+        self.last_call = kw
+        if self._raises:
+            raise RuntimeError("simulated weaviate error")
+        return self._resp
+
+
+class _FakeCollection:
+    def __init__(self, query: _FakeQuery):
+        self.query = query
+
+
+class _FakeCollections:
+    def __init__(self, collection: _FakeCollection):
+        self._c = collection
+
+    def get(self, name: str) -> _FakeCollection:
+        return self._c
+
+
+class _FakeClient:
+    def __init__(self, resp: _FakeResp, raises: bool = False):
+        q = _FakeQuery(resp, raises=raises)
+        self._q = q
+        self.collections = _FakeCollections(_FakeCollection(q))
+
+
+# --- Filter translation tests -------------------------------------------
+
+
+def test_translate_equal_text() -> None:
+    out = _translate_filter_with(
+        {"path": ["campus"], "operator": "Equal", "valueText": "oxford"},
+        FakeFilter,
+    )
+    assert out.kind == "equal"
+    assert out.kw == {"path": "campus", "value": "oxford"}
+
+
+def test_translate_equal_bool() -> None:
+    out = _translate_filter_with(
+        {"path": ["deleted"], "operator": "Equal", "valueBoolean": False},
+        FakeFilter,
+    )
+    assert out.kind == "equal"
+    assert out.kw == {"path": "deleted", "value": False}
+
+
+def test_translate_real_where_clause_shape() -> None:
+    """The actual build_where_clause output for a scoped query:
+    And(deleted=false, Or(campus=oxford, campus=all),
+        Or(library=king, library=all))."""
+    where = build_where_clause(
+        ScopeFilter(campus="oxford", library="king")
+    )
+    out = _translate_filter_with(where, FakeFilter)
+    # Top level is an And (all_of).
+    assert out.kind == "all_of"
+    operands = out.kw["operands"]
+    # deleted=false + 2 Or-groups (campus, library)
+    assert len(operands) == 3
+    assert operands[0].kind == "equal"
+    assert operands[0].kw == {"path": "deleted", "value": False}
+    assert operands[1].kind == "any_of"  # campus Or
+    assert operands[2].kind == "any_of"  # library Or
+
+
+def test_translate_no_library_clause_when_library_none() -> None:
+    where = build_where_clause(ScopeFilter(campus="hamilton"))
+    out = _translate_filter_with(where, FakeFilter)
+    assert out.kind == "all_of"
+    # deleted + campus-Or only; no library clause
+    assert len(out.kw["operands"]) == 2
+
+
+def test_translate_rejects_equal_without_value() -> None:
+    try:
+        _translate_filter_with(
+            {"path": ["x"], "operator": "Equal"}, FakeFilter,
+        )
+    except ValueError as e:
+        assert "value" in str(e).lower()
+        return
+    raise AssertionError("expected ValueError")
+
+
+def test_translate_rejects_unknown_operator() -> None:
+    try:
+        _translate_filter_with(
+            {"operator": "NotARealOp", "operands": []}, FakeFilter,
+        )
+    except ValueError as e:
+        assert "unsupported" in str(e).lower()
+        return
+    raise AssertionError("expected ValueError")
+
+
+# --- hybrid_search response mapping -------------------------------------
+
+
+def _adapter_with(objects: list, raises: bool = False) -> WeaviateSearchAdapter:
+    return WeaviateSearchAdapter(client=_FakeClient(_FakeResp(objects), raises=raises))
+
+
+def test_hybrid_search_maps_documented_shape() -> None:
+    obj = _FakeObj(
+        uuid="00000000-0000-0000-0000-000000000001",
+        properties={
+            "chunk_id": "c-abc123",
+            "source_url": "https://lib.miamioh.edu/use/technology/printing/",
+            "text": "Printing how-to.",
+            "campus": "oxford",
+            "library": "king",
+            "topic": "technology",
+            "featured_service": "",
+        },
+        score=0.87,
+    )
+    a = _adapter_with([obj])
+    hits = a.hybrid_search(
+        collection="Chunk_v1", query="how do I print",
+        where=build_where_clause(ScopeFilter(campus="oxford")),
+        alpha=0.5, limit=5,
+    )
+    assert len(hits) == 1
+    h = hits[0]
+    assert h["chunk_id"] == "c-abc123"
+    assert h["source_url"].endswith("/printing/")
+    assert h["text"] == "Printing how-to."
+    assert h["campus"] == "oxford"
+    assert h["library"] == "king"
+    assert h["topic"] == "technology"
+    assert h["featured_service"] is None  # "" coerced to None
+    assert h["score"] == 0.87
+
+
+def test_hybrid_search_prefers_chunk_id_property_over_uuid() -> None:
+    """The ETL stores the real chunk_id as a property; the object uuid
+    is a uuid5 hash. Retrieval must surface the property so citations
+    join back to ChunkProvenance."""
+    obj = _FakeObj(
+        uuid="ffffffff-1111-2222-3333-444444444444",
+        properties={"chunk_id": "c-real-id", "source_url": "u", "text": "t"},
+    )
+    hits = _adapter_with([obj]).hybrid_search(
+        collection="C", query="q", where={}, alpha=0.5, limit=1,
+    )
+    assert hits[0]["chunk_id"] == "c-real-id"
+
+
+def test_hybrid_search_falls_back_to_uuid_if_no_chunk_id_prop() -> None:
+    obj = _FakeObj(uuid="the-uuid", properties={"source_url": "u", "text": "t"})
+    hits = _adapter_with([obj]).hybrid_search(
+        collection="C", query="q", where={}, alpha=0.5, limit=1,
+    )
+    assert hits[0]["chunk_id"] == "the-uuid"
+
+
+def test_hybrid_search_returns_empty_on_client_error() -> None:
+    """Retrieval hiccup must NOT crash the turn -- empty list, the
+    agent refuses via NO_RESULTS."""
+    hits = _adapter_with([], raises=True).hybrid_search(
+        collection="C", query="q", where={}, alpha=0.5, limit=5,
+    )
+    assert hits == []
+
+
+def test_hybrid_search_tolerates_missing_metadata_and_props() -> None:
+    class _Bare:
+        uuid = "u1"
+        properties = {}
+        metadata = None
+    hits = _adapter_with([_Bare()]).hybrid_search(
+        collection="C", query="q", where={}, alpha=0.5, limit=1,
+    )
+    assert hits[0]["chunk_id"] == "u1"
+    assert hits[0]["score"] == 0.0
+    assert hits[0]["source_url"] == ""
+
+
+def test_hybrid_search_passes_alpha_and_limit_through() -> None:
+    a = _adapter_with([])
+    a.hybrid_search(
+        collection="C", query="q", where={}, alpha=0.25, limit=7,
+    )
+    call = a.client._q.last_call
+    assert call["alpha"] == 0.25
+    assert call["limit"] == 7
+    assert call["query"] == "q"
+
+
+def main() -> int:
+    tests = [
+        test_translate_equal_text,
+        test_translate_equal_bool,
+        test_translate_real_where_clause_shape,
+        test_translate_no_library_clause_when_library_none,
+        test_translate_rejects_equal_without_value,
+        test_translate_rejects_unknown_operator,
+        test_hybrid_search_maps_documented_shape,
+        test_hybrid_search_prefers_chunk_id_property_over_uuid,
+        test_hybrid_search_falls_back_to_uuid_if_no_chunk_id_prop,
+        test_hybrid_search_returns_empty_on_client_error,
+        test_hybrid_search_tolerates_missing_metadata_and_props,
+        test_hybrid_search_passes_alpha_and_limit_through,
+    ]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:
+            failed += 1
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

The `--with-real-llm` eval was grounding the synthesizer on a hand-written `_REALISTIC_EVIDENCE` map (one short paragraph per intent) instead of the real 20,255-chunk indexed corpus. That made the eval **lie**: the synth correctly self-flagged `confidence: low` because one canned paragraph genuinely isn't enough to answer a detailed Miami library question. The headline numbers looked far worse than the bot actually is, and gold-set bugs were invisible under the noise.

This is the move that **collapses the "too many truths" confusion**: after this, there is ONE runtime truth (Weaviate, refreshed from the live site by the ETL) and the eval tests the bot against exactly that.

## Changes

### New: `src/weaviate/search_adapter.py`
`WeaviateSearchAdapter` implements `WeaviateLike.hybrid_search` against the real v4 client — recursive scope-filter→v4 `Filter` translation, `collection.query.hybrid(...)`, response mapping that prefers the `chunk_id` property over the uuid5 object id. SDK-absent degradation so unit tests need no live Weaviate. **12 unit tests.**

### Changed: `_build_real_deps` (`run_eval.py`)
- `search_kb` → `make_search_kb_tool(weaviate=WeaviateSearchAdapter(), ...)`, queries the same `Chunk_v*` collection production reads (via `WEAVIATE_CHUNK_COLLECTION`, PR #47).
- **`_REALISTIC_EVIDENCE` (235-line dict) deleted entirely.**
- run loop pre-resolves scope alongside the existing pre-classify.
- Stub-mode eval **unaffected** (scope-only still 177/177).

### Changed: `scripts/inspect_eval_case.py`
Repurposed from "show canned evidence vs gold" (now obsolete) into a **gold-set audit tool**. Default mode: print the gold case for human verification against the live site. `--live`: also run real retrieval to distinguish a gold-set bug from a corpus gap.

### New: `ai-core/docs/canonical/`
Truth captured during the content audit:
- `room_reservations.md` — 5 bookable buildings + LibCal URLs + universal rules + gold-correction table
- `makerspaces.md` — **TWO** makerspaces (King + Middletown TEC Lab); Hamilton confirmed absent; corrects the prior "King-only" assumption in the gold set + plan §7; URL-redirect canonicalization note

These are a dev reference + gold-correction checklist, **not** a runtime source. The bot only ever reads Weaviate + Postgres.

## Tests

| Suite | Result |
|---|---|
| `test_search_adapter` (new) | 12/12 |
| `test_etl_adapter` | 18/18 |
| `test_judge` | 16/16 |
| `test_smoke_e2e` | 24/24 |
| `run_eval --scope-only` | 177/177 (stub path intact) |

## Test plan

- [ ] With SSH tunnel up + `WEAVIATE_CHUNK_COLLECTION=Chunk_vv20260514_1929`: `python -m src.eval.run_eval --filter capability_refuse --with-real-llm --with-judge` (cheap, ~$0.10) — confirm real chunks come back
- [ ] Then the full honest run: `python -m src.eval.run_eval --with-real-llm --with-judge` (~$3.70, ~30 min). **This is the first FAIR bot-quality number.**
- [ ] Spot-check with `python -m scripts.inspect_eval_case --intent makerspace_3d --live`

## What this unblocks

The honest end-to-end measurement. Prediction from the canned-evidence run's failure shape: `model_self_flagged` (was 51) drops sharply; `correct` + `partial` rise. The remaining eval noise becomes purely gold-set bugs — which the repurposed inspector + canonical docs are the workflow for fixing.

Follow-up to PR #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)