### PR TITLE
agent: enforce OpenAI strict-mode tool schemas (fixes v2 agent 400 crash)

### DIFF
--- a/ai-core/src/agent/test_tool_registry.py
+++ b/ai-core/src/agent/test_tool_registry.py
@@ -31,12 +31,16 @@ _HERE = Path(__file__).resolve().parent
 _AI_CORE = _HERE.parent.parent
 sys.path.insert(0, str(_AI_CORE))
 
+import json  # noqa: E402
+
 from src.agent.tool_registry import (  # noqa: E402
     Tool,
     ToolCall,
     ToolError,
     ToolRegistry,
     ToolResult,
+    _make_nullable,
+    _strictify_schema,
 )
 
 
@@ -200,6 +204,138 @@ def test_tool_result_is_error_property() -> None:
     assert err.is_error
 
 
+# --- strict-mode schema normalization ---
+#
+# Regression coverage for the production OpenAI 400:
+#   "Invalid schema for function 'search_kb': 'required' ... must be an
+#    array including every key in properties. Missing 'k'."
+
+
+def _search_kb_like_params() -> dict:
+    """The exact shape of search_kb's _PARAMETERS that triggered the
+    400: `k` present in properties but absent from `required`."""
+    return {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "the query"},
+            "k": {"type": "integer", "description": "top-k", "default": 10},
+        },
+        "required": ["query"],
+        "additionalProperties": False,
+    }
+
+
+def test_strictify_adds_every_property_to_required() -> None:
+    """Rule 1: the exact 400 regression. Every key in properties must
+    appear in required after serialization."""
+    reg = ToolRegistry()
+    reg.register(Tool(
+        name="search_kb", description="kb",
+        parameters=_search_kb_like_params(), handler=lambda _: {},
+    ))
+    params = reg.as_responses_tools()[0]["parameters"]
+    assert set(params["required"]) == {"query", "k"}
+    # Deterministic order = properties insertion order (cache stability).
+    assert params["required"] == ["query", "k"]
+
+
+def test_strictify_makes_optional_param_nullable() -> None:
+    """Rule 2: a param that was NOT in the author's `required` stays
+    answerable-as-absent by becoming a `null` union; a param that WAS
+    required keeps its single type."""
+    out = _strictify_schema(_search_kb_like_params())
+    assert out["properties"]["k"]["type"] == ["integer", "null"]
+    assert out["properties"]["query"]["type"] == "string"  # untouched
+
+
+def test_strictify_sets_additional_properties_false() -> None:
+    """Rule 3."""
+    out = _strictify_schema({
+        "type": "object",
+        "properties": {"a": {"type": "string"}},
+        "required": ["a"],
+    })
+    assert out["additionalProperties"] is False
+
+
+def test_strictify_is_pure_does_not_mutate_input() -> None:
+    """The registry's stored Tool.parameters must be untouched -- it is
+    part of the cached prompt prefix; mutation would corrupt later
+    calls."""
+    original = _search_kb_like_params()
+    snapshot = json.dumps(original, sort_keys=True)
+    _strictify_schema(original)
+    assert json.dumps(original, sort_keys=True) == snapshot
+    assert original["required"] == ["query"]  # unchanged
+
+
+def test_strictify_is_byte_stable_across_calls() -> None:
+    """OpenAI prompt caching needs the serialized tool block to be
+    byte-identical call-to-call. Two serializations must match exactly."""
+    reg = ToolRegistry()
+    reg.register(Tool(
+        name="search_kb", description="kb",
+        parameters=_search_kb_like_params(), handler=lambda _: {},
+    ))
+    a = json.dumps(reg.as_responses_tools())
+    b = json.dumps(reg.as_responses_tools())
+    assert a == b
+
+
+def test_strictify_recurses_into_nested_objects_and_arrays() -> None:
+    """Nested objects and array item schemas must also satisfy strict
+    mode (every nested property required + additionalProperties:false)."""
+    out = _strictify_schema({
+        "type": "object",
+        "properties": {
+            "filters": {
+                "type": "object",
+                "properties": {
+                    "campus": {"type": "string"},
+                    "library": {"type": "string"},
+                },
+                "required": ["campus"],
+            },
+            "tags": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}},
+                },
+            },
+        },
+        "required": ["filters"],
+    })
+    nested = out["properties"]["filters"]
+    assert set(nested["required"]) == {"campus", "library"}
+    assert nested["additionalProperties"] is False
+    # `library` was not author-required -> nullable.
+    assert nested["properties"]["library"]["type"] == ["string", "null"]
+    item = out["properties"]["tags"]["items"]
+    assert item["required"] == ["name"]
+    assert item["additionalProperties"] is False
+    # `tags` itself was optional at the top level -> nullable union.
+    assert "null" in out["properties"]["tags"]["type"]
+
+
+def test_make_nullable_handles_str_list_and_anyof() -> None:
+    assert _make_nullable({"type": "string"})["type"] == ["string", "null"]
+    # Already a list: append null, don't duplicate.
+    assert _make_nullable({"type": ["a", "b"]})["type"] == ["a", "b", "null"]
+    assert _make_nullable({"type": ["a", "null"]})["type"] == ["a", "null"]
+    # anyOf branch gets a null option added.
+    out = _make_nullable({"anyOf": [{"type": "string"}]})
+    assert {"type": "null"} in out["anyOf"]
+    # No type/anyOf: wrapped.
+    out2 = _make_nullable({"enum": ["x", "y"]})
+    assert out2["anyOf"] == [{"enum": ["x", "y"]}, {"type": "null"}]
+
+
+def test_strictify_non_dict_passthrough() -> None:
+    assert _strictify_schema("nope") == "nope"
+    assert _strictify_schema(None) is None
+
+
 def main() -> int:
     tests = [
         test_register_and_get,
@@ -215,6 +351,14 @@ def main() -> int:
         test_tool_is_read_only_defaults_true,
         test_tool_is_read_only_overridable,
         test_tool_result_is_error_property,
+        test_strictify_adds_every_property_to_required,
+        test_strictify_makes_optional_param_nullable,
+        test_strictify_sets_additional_properties_false,
+        test_strictify_is_pure_does_not_mutate_input,
+        test_strictify_is_byte_stable_across_calls,
+        test_strictify_recurses_into_nested_objects_and_arrays,
+        test_make_nullable_handles_str_list_and_anyof,
+        test_strictify_non_dict_passthrough,
     ]
     failed = 0
     for t in tests:

--- a/ai-core/src/agent/tool_registry.py
+++ b/ai-core/src/agent/tool_registry.py
@@ -100,6 +100,89 @@ class ToolError(Exception):
         self.message = message
 
 
+# --- Strict-mode schema normalization -------------------------------------
+#
+# OpenAI's Responses API runs function tools with strict=True (set in
+# as_responses_tools()). Strict mode constrains decoding to the JSON
+# schema and imposes three rules the OpenAI docs spell out (verified
+# against the function-calling guide + developer-community guidance,
+# 2026-05 -- see the plan's model/API freshness rule):
+#
+#   1. EVERY key in `properties` must appear in `required`. (This is
+#      the exact 400 the agent hit: "'required' ... must be an array
+#      including every key in properties. Missing 'k'.")
+#   2. A logically-optional parameter stays in `required`, but its
+#      type becomes a union with "null" -- the model emits null to
+#      mean "not supplied".
+#   3. Every object must set `additionalProperties: false`.
+#
+# `default` is NOT honored under strict decoding, so a tool HANDLER
+# must treat a null/absent value as the default itself.
+#
+# Tool authors write natural JSON Schema (optional params simply
+# omitted from `required`). This transformer applies rules 1-3 at the
+# serialization boundary so no tool author has to remember them and
+# every tool is consistent. It is PURE -- returns new structures and
+# never mutates the registry's stored Tool.parameters -- and
+# DETERMINISTIC (`required` emitted in properties insertion order), so
+# the serialized tool block stays byte-identical call-to-call, a hard
+# requirement for OpenAI prompt caching.
+
+
+def _make_nullable(prop_schema: dict) -> dict:
+    """Copy `prop_schema` so its value space includes null. Lets a
+    property be `required` (per strict mode) yet still 'optional' by
+    the model emitting null."""
+    out = dict(prop_schema)
+    t = out.get("type")
+    if isinstance(t, str):
+        out["type"] = [t, "null"] if t != "null" else t
+        return out
+    if isinstance(t, list):
+        out["type"] = list(t) + ([] if "null" in t else ["null"])
+        return out
+    if isinstance(out.get("anyOf"), list):
+        has_null = any(
+            isinstance(s, dict) and s.get("type") == "null"
+            for s in out["anyOf"]
+        )
+        out["anyOf"] = list(out["anyOf"]) + (
+            [] if has_null else [{"type": "null"}]
+        )
+        return out
+    # No `type`/`anyOf` (enum-only, $ref, ...): wrap in anyOf-null.
+    return {"anyOf": [out, {"type": "null"}]}
+
+
+def _strictify_schema(schema: Any) -> Any:
+    """Recursively rewrite a JSON Schema to satisfy OpenAI strict mode.
+
+    Pure + deterministic (see the section comment above).
+    """
+    if not isinstance(schema, dict):
+        return schema
+
+    out = dict(schema)
+
+    if "items" in out:  # array element schema
+        out["items"] = _strictify_schema(out["items"])
+
+    props = out.get("properties")
+    if isinstance(props, dict):
+        original_required = set(out.get("required") or [])
+        new_props: dict = {}
+        for key, sub in props.items():
+            sub_strict = _strictify_schema(sub)
+            if key not in original_required:
+                sub_strict = _make_nullable(sub_strict)
+            new_props[key] = sub_strict
+        out["properties"] = new_props
+        out["required"] = list(props.keys())  # insertion order = stable
+        out["additionalProperties"] = False
+
+    return out
+
+
 # --- Registry -------------------------------------------------------------
 
 
@@ -166,7 +249,7 @@ class ToolRegistry:
                 "type": "function",
                 "name": t.name,
                 "description": t.description,
-                "parameters": t.parameters,
+                "parameters": _strictify_schema(t.parameters),
                 "strict": True,
             }
             for t in self.tools.values()

--- a/ai-core/src/eval/run_eval.py
+++ b/ai-core/src/eval/run_eval.py
@@ -473,7 +473,26 @@ def _run_bot(q: GoldQuestion, deps: OrchestratorDeps) -> dict:
     try:
         resp = run_turn(request, deps)
     except Exception as e:  # noqa: BLE001
-        logger.warning("turn crashed", extra={"id": q.id, "error": str(e)})
+        # Surface the full exception (incl. OpenAI 400 body) in the
+        # message itself -- extra={} is dropped by the default formatter,
+        # which is why "turn crashed" was previously opaque.
+        body = ""
+        for attr in ("response", "body"):
+            obj = getattr(e, attr, None)
+            if obj is not None:
+                try:
+                    body = f" | {attr}={obj.text if hasattr(obj, 'text') else obj}"
+                except Exception:  # noqa: BLE001
+                    body = f" | {attr}=<unreadable>"
+                break
+        logger.warning(
+            "turn crashed id=%s %s: %s%s",
+            q.id,
+            type(e).__name__,
+            str(e),
+            body,
+            exc_info=True,
+        )
         return {
             "actual_intent": None,
             "intent_match": False,

--- a/ai-core/src/tools/search_kb_tool.py
+++ b/ai-core/src/tools/search_kb_tool.py
@@ -176,7 +176,13 @@ def make_search_kb_tool(
         query = args.get("query")
         if not isinstance(query, str) or not query.strip():
             raise ToolError("search_kb requires a non-empty `query` string.")
-        k = int(args.get("k", 10))
+        # Strict-mode tools force `k` into `required` as an int|null
+        # union, so the model emits null (not absence) to mean
+        # "default". `default` in the schema is ignored under strict
+        # decoding -- the handler owns the default. (See
+        # tool_registry._strictify_schema.)
+        k_raw = args.get("k")
+        k = 10 if k_raw is None else int(k_raw)
         if k < 1 or k > 50:
             # Bound the requested k -- defends against the LLM passing
             # k=10000 because of a bad chain-of-thought.


### PR DESCRIPTION
## Summary
- **Fixes the bug that made every real v2 agent turn crash with HTTP 400.** OpenAI's Responses API runs function tools with `strict=True`; strict mode requires every `properties` key to be in `required`. All ~10 production tools wrote natural JSON Schema with optional params omitted from `required`, so each had the same latent 400 — the eval only surfaced `search_kb` because the agent crashed before reaching the others.
- Central, pure, deterministic `_strictify_schema` transformer applied in `ToolRegistry.as_responses_tools()` (the one serialization boundary `tools_v2/registry.py` also routes through). Recurses nested objects/arrays; deterministic `required` ordering keeps the serialized tool block byte-stable for OpenAI prompt caching.
- `search_kb` handler now treats `k=null` as the default (strict mode makes the model emit `null`, not absence; schema `default` is ignored under constrained decoding).
- `run_eval` crash handler now surfaces the full exception + response body + traceback instead of swallowing it in `extra={}` — this is why earlier real-LLM runs looked like "tokens sum=0".

Strict-mode rules were verified against the live OpenAI function-calling docs + developer-community guidance, per the plan's model/API freshness rule (not training memory).

## Test plan
- [x] `tool_registry` 21/21 (8 new: required-completeness regression, nullable-union, additionalProperties, **purity/no-mutation**, **byte-stability for prompt cache**, nested recursion, `_make_nullable` edge cases, non-dict passthrough)
- [x] `search_kb_tool` 13/13, `search_adapter` 12/12, `agent` 14/14, `new_orchestrator` 18/18, `llm.client` 11/11, `smoke_e2e` 24/24, `judge` 16/16, `inspect_turn` 19/19 — **148/148**
- [x] Real-LLM + judge eval (`--filter capability_refuse --with-real-llm --with-judge`): **0 crashes / 0 400s** (was 2 crashes), tokens **sum=12,036** (was 0), **6/6 judged** (was 4/6), cache hit 57.4%

🤖 Generated with [Claude Code](https://claude.com/claude-code)