### PR TITLE
env: run on Python 3.14.5 + silence verified-harmless prisma import warning

### DIFF
--- a/ai-core/src/__init__.py
+++ b/ai-core/src/__init__.py
@@ -1,0 +1,37 @@
+"""ai-core package root.
+
+Side effect on import: silence ONE specific, verified-harmless
+third-party warning.
+
+`prisma-client-py` 0.15.0 emits a `UserWarning` from `prisma._compat`
+on import under Python 3.14+: "Core Pydantic V1 functionality isn't
+compatible with Python 3.14 or greater." We pin prisma 0.15.0 (it is
+the version compatible with our Prisma engine / JS toolchain) and run
+on Python 3.14.5 deliberately. The warning fires because prisma keeps
+a `pydantic.v1` shim it does not exercise on our code paths: this was
+empirically verified — `connect()`, `count()`, and the
+`UrlSeen`/`ChunkProvenance` CRUD the app actually uses all work at
+runtime on 3.14.5 (UrlSeen round-trips 396 rows against the shared
+Postgres). The warning is therefore cosmetic, but it prints on EVERY
+process start (tests, eval, ETL, API) and that log noise is exactly
+the alert-fatigue the observability plan (Op 3) warns against.
+
+The filter is intentionally narrow — exact message prefix + category
++ originating module — so it cannot mask any other pydantic/prisma
+warning. Installed here because `src/__init__` runs before any
+`src.*` submodule executes its top-level `from prisma import Prisma`.
+
+Revisit when prisma-client-py ships a release that drops the
+pydantic-v1 shim (or supports py3.14 cleanly) — then delete this.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+warnings.filterwarnings(
+    "ignore",
+    message=r"Core Pydantic V1 functionality isn't compatible with Python 3\.14",
+    category=UserWarning,
+    module=r"prisma\._compat",
+)


### PR DESCRIPTION
## Summary
- Project now runs on **Python 3.14.5** (deliberate choice). Recreated the venv on 3.14.5 with the same behavior-critical dependency pins (prisma 0.15.0, weaviate-client 4.19.2, openai 2.8.1, langchain 1.0.7, langgraph 1.0.3, pydantic 2.12.5, tiktoken 0.12.0, numpy 2.4.4) and let transitive deps resolve fresh for 3.14 (the old freeze was internally inconsistent — `packaging==26.0` violated `langchain-core 1.0.5`).
- `prisma-client-py` 0.15.0 emits a `UserWarning` on import under py3.14+ (`prisma._compat`: pydantic-v1 shim). **Verified cosmetic, not a runtime break.** This PR adds a *narrow* filter (exact message prefix + `UserWarning` + `module=prisma._compat`) in the empty `src/__init__.py`, which runs before any `src.*` submodule's top-level `from prisma import Prisma`.
- Independent of PR #50 (strict-mode tool schemas) — touches a different file; either merge order is safe.

## Verification on 3.14.5
- [x] **26/26** test modules pass
- [x] Prisma runtime verified against the shared Postgres: `connect()` + `UrlSeen.count()` → 396 rows (the pydantic-v1 path prisma warns about is never exercised by app CRUD)
- [x] Real retrieval + real-LLM + judge eval byte-equivalent to the 3.13 run: 0 crashes / 0 400s, tokens ~12,03k, cache hit 57.4%, correct_rate 100%
- [x] Filter confirmed to suppress the warning across `import src` and a representative test module; cleaned the stray prisma client wrongly generated into Homebrew global site-packages

## Note for prod/other devs
`pyproject.toml` deps are unpinned. A committed lockfile (the critical pins above) would make the 3.14 environment reproducible on the server — recommend as a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)