### PR TITLE
etl: close the libguides corpus gap (curated, campus-correct seed)

### DIFF
--- a/ai-core/scripts/etl/classify.py
+++ b/ai-core/scripts/etl/classify.py
@@ -104,11 +104,34 @@ def _infer_audience(url: str, body_text: str) -> list[str]:
     return sorted(audiences) if audiences else ["all"]
 
 
+# Curated LibGuide registry -> explicit (campus, library,
+# featured_service). libguides.lib.miamioh.edu host-defaults to
+# 'oxford' in _infer_campus, which would mis-tag the Middletown TEC
+# Lab guide as Oxford and make the cross-campus guard BLOCK it for
+# Middletown queries. So for these URLs we use the registry's
+# operator/canonical-confirmed values VERBATIM, never host inference.
+_LIBGUIDE_OVERRIDE: dict[str, tuple[str, str, Optional[str]]] = {
+    url: (campus, library, fs)
+    for url, campus, library, fs in config.LIBGUIDE_SEED
+}
+
+
 def classify(url: str, body_text: str) -> DocMetadata:
     """Apply all rule-based metadata inference to a document.
 
     Pure function: same inputs -> same outputs. No I/O. Easy to test.
     """
+    override = _LIBGUIDE_OVERRIDE.get(url)
+    if override is not None:
+        campus, library, featured_service = override
+        return DocMetadata(
+            topic=_infer_topic(url),
+            campus=campus,
+            library=library,
+            audience=_infer_audience(url, body_text),
+            featured_service=featured_service,
+        )
+
     return DocMetadata(
         topic=_infer_topic(url),
         campus=_infer_campus(url),

--- a/ai-core/scripts/etl/config.py
+++ b/ai-core/scripts/etl/config.py
@@ -13,7 +13,7 @@ See plan: Data preparation playbook §4 (pipeline) and §7 (featured services).
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Final
+from typing import Final, Optional
 
 
 # --- Path anchor ------------------------------------------------------------
@@ -126,8 +126,10 @@ EXCLUDE_URL_SUBSTRINGS: Final[tuple[str, ...]] = (
 # To allow a new domain or path shape, add to one of the patterns below.
 
 LIBRARY_HOST_PREFIXES: Final[tuple[str, ...]] = (
-    "lib.",      # lib.miamioh.edu
-    "www.lib.",  # www.lib.miamioh.edu
+    "lib.",        # lib.miamioh.edu
+    "www.lib.",    # www.lib.miamioh.edu
+    "libguides.",  # libguides.lib.miamioh.edu -- curated LIBGUIDE_SEED
+                   # only; discover never bulk-crawls this host.
 )
 
 LIBRARY_PATH_SUBSTRINGS: Final[tuple[str, ...]] = (
@@ -174,6 +176,44 @@ FEATURED_SERVICE_PATTERNS: Final[tuple[tuple[str, str], ...]] = (
     ("/research/databases/newspapers", "newspapers"),
     ("/databases/nyt", "newspapers"),
     ("/databases/wsj", "newspapers"),
+)
+
+
+# --- Curated LibGuide registry (plan §1/§7) ---------------------------------
+#
+# libguides.lib.miamioh.edu is NOT in any campus sitemap, and the eval
+# proved this is a MEASURED blocker: fs_makerspace_middletown_refusal
+# can't answer ("couldn't verify my sources") because the Middletown
+# TEC Lab guide isn't in the index.
+#
+# We seed a SMALL, canonical-doc/operator-confirmed set rather than
+# bulk-crawl the libguides sitemap, for TWO reasons:
+#   1. The plan prefers curated > bulk (signal/noise; pollution is the
+#      exact failure this whole project fights).
+#   2. classify._infer_campus host-defaults libguides -> 'oxford', so a
+#      bulk crawl would tag the Middletown TEC Lab guide as Oxford and
+#      the load-bearing cross-campus guard would then BLOCK it for
+#      Middletown queries. Each entry below carries EXPLICIT campus /
+#      library / featured_service; classify.py honors these verbatim
+#      (does NOT re-infer from host).
+#
+# Every URL HEAD-verified 200, no redirect, 2026-05-17. campus/library
+# "all" = university-wide (cross-campus guard passes "all").
+#
+# (url, campus, library, featured_service|None)
+LIBGUIDE_SEED: Final[tuple[tuple[str, str, str, Optional[str]], ...]] = (
+    ("https://libguides.lib.miamioh.edu/middletown_tec_lab/home",
+     "middletown", "gardner_harvey", "makerspace"),
+    ("https://libguides.lib.miamioh.edu/create/makerspace",
+     "oxford", "king", "makerspace"),
+    ("https://libguides.lib.miamioh.edu/newspapers",
+     "all", "all", "newspapers"),
+    ("https://libguides.lib.miamioh.edu/citation",
+     "all", "all", None),
+    ("https://libguides.lib.miamioh.edu/mul-circulation-policies",
+     "all", "all", None),
+    ("https://libguides.lib.miamioh.edu/reserves-textbooks/",
+     "all", "all", None),
 )
 
 

--- a/ai-core/scripts/etl/discover.py
+++ b/ai-core/scripts/etl/discover.py
@@ -170,6 +170,30 @@ def discover() -> list[DiscoveredUrl]:
                             url=url, campus=campus, source="seed",
                         )
 
+    # --- Curated LibGuide seeds (config.LIBGUIDE_SEED) ---
+    # libguides.lib.miamioh.edu is in NO campus sitemap. We add a
+    # small, canonical-confirmed set here (NOT a bulk libguides crawl
+    # -- see config.LIBGUIDE_SEED for why). The DiscoveredUrl.campus
+    # is the registry's explicit value; classify.py honors the
+    # registry verbatim so the Middletown TEC Lab guide is NOT
+    # host-defaulted to Oxford.
+    libguide_kept = 0
+    for lg_url, lg_campus, _lib, _fs in config.LIBGUIDE_SEED:
+        excluded, reason = _is_excluded(lg_url)
+        if excluded:
+            rejected.append((lg_url, reason or "unknown"))
+            continue
+        if lg_url not in seen:
+            seen[lg_url] = DiscoveredUrl(
+                url=lg_url, campus=lg_campus, source="libguide_seed",
+            )
+            libguide_kept += 1
+    if libguide_kept:
+        logger.info(
+            "added curated LibGuide seeds",
+            extra={"libguide_kept": libguide_kept},
+        )
+
     logger.info(
         "discovery complete",
         extra={

--- a/ai-core/scripts/etl/test_classify.py
+++ b/ai-core/scripts/etl/test_classify.py
@@ -49,10 +49,51 @@ def test_middletown_host_resolves_to_middletown() -> None:
 
 
 def test_unknown_host_falls_back_to_oxford() -> None:
-    """Conservative default: a third-party LibGuide URL we forgot to
-    tag falls into Oxford rather than crashing or being campus-less."""
+    """Conservative default: a NON-seed LibGuide URL we forgot to tag
+    falls into Oxford rather than crashing or being campus-less. (The
+    registry override only applies to LIBGUIDE_SEED URLs, so this
+    stays valid.)"""
     out = classify("https://libguides.lib.miamioh.edu/research/", "body")
     assert out.campus == "oxford"
+
+
+# --- Curated LibGuide registry override (the cross-campus landmine) ---
+
+
+def test_libguide_tec_lab_is_middletown_not_host_default_oxford() -> None:
+    """LOAD-BEARING: the Middletown TEC Lab guide MUST tag
+    campus=middletown. Host inference would default it to 'oxford',
+    and the cross-campus guard would then BLOCK it for Middletown
+    queries (the exact reason fs_makerspace_middletown_refusal could
+    not be answered)."""
+    out = classify(
+        "https://libguides.lib.miamioh.edu/middletown_tec_lab/home", ""
+    )
+    assert out.campus == "middletown"
+    assert out.library == "gardner_harvey"
+    assert out.featured_service == "makerspace"
+
+
+def test_libguide_citation_is_university_wide() -> None:
+    out = classify("https://libguides.lib.miamioh.edu/citation", "")
+    assert out.campus == "all"
+    assert out.library == "all"
+    assert out.featured_service is None
+
+
+def test_libguide_create_makerspace_is_oxford_king() -> None:
+    out = classify(
+        "https://libguides.lib.miamioh.edu/create/makerspace", ""
+    )
+    assert out.campus == "oxford"
+    assert out.library == "king"
+    assert out.featured_service == "makerspace"
+
+
+def test_libguide_newspapers_featured_service() -> None:
+    out = classify("https://libguides.lib.miamioh.edu/newspapers", "")
+    assert out.campus == "all"
+    assert out.featured_service == "newspapers"
 
 
 # --- Library inference (URL substring) ---------------------------------
@@ -396,6 +437,10 @@ def main() -> int:
         test_makerspace_full_classification,
         test_rentschler_about_page_full_classification,
         test_special_collections_full_classification,
+        test_libguide_tec_lab_is_middletown_not_host_default_oxford,
+        test_libguide_citation_is_university_wide,
+        test_libguide_create_makerspace_is_oxford_king,
+        test_libguide_newspapers_featured_service,
     ]
     failed = 0
     for t in tests:

--- a/ai-core/scripts/etl/test_discover.py
+++ b/ai-core/scripts/etl/test_discover.py
@@ -29,6 +29,7 @@ from scripts.etl import config, discover as discover_mod  # noqa: E402
 from scripts.etl.discover import (  # noqa: E402
     DiscoveredUrl,
     _is_excluded,
+    _is_library_url,
     discover,
 )
 
@@ -392,8 +393,51 @@ class _Monkeypatch:
         self._undo.clear()
 
 
+def test_libguide_seed_passes_library_filter() -> None:
+    """Pre-fix, _is_library_url rejected libguides.* (host wasn't
+    lib./www.lib., path had no /library/), so seeds would be dropped.
+    The host-prefix add must let every seed through."""
+    for url, *_ in config.LIBGUIDE_SEED:
+        assert _is_library_url(url), f"seed rejected by filter: {url}"
+        excluded, reason = _is_excluded(url)
+        assert not excluded, f"seed excluded ({reason}): {url}"
+
+
+def test_libguide_seed_registry_well_formed() -> None:
+    """Anti-fabrication guard: every seed is a 4-tuple, https, on the
+    libguides host, with a sane campus. Catches a typo'd/garbage URL
+    before it becomes an indexed, citable source."""
+    valid_campus = {"oxford", "hamilton", "middletown", "all"}
+    seen: set[str] = set()
+    for entry in config.LIBGUIDE_SEED:
+        assert len(entry) == 4, entry
+        url, campus, library, fs = entry
+        assert url.startswith("https://libguides.lib.miamioh.edu/"), url
+        assert url not in seen, f"duplicate seed: {url}"
+        seen.add(url)
+        assert campus in valid_campus, (url, campus)
+        assert library, (url, library)
+        assert fs is None or isinstance(fs, str)
+
+
+def test_libguide_seed_emitted_by_discover(monkeypatch) -> None:
+    """discover() must include the curated seeds with
+    source='libguide_seed' and the registry's explicit campus, even
+    when every campus sitemap is empty (network stubbed via the
+    runner's monkeypatch shim -> auto-undone)."""
+    monkeypatch.setattr(discover_mod, "_fetch_sitemap", lambda _u: [])
+    out = {d.url: d for d in discover()}
+    for url, campus, *_ in config.LIBGUIDE_SEED:
+        assert url in out, f"seed missing from discover(): {url}"
+        assert out[url].source == "libguide_seed"
+        assert out[url].campus == campus
+
+
 def main() -> int:
     tests = [
+        test_libguide_seed_passes_library_filter,
+        test_libguide_seed_registry_well_formed,
+        test_libguide_seed_emitted_by_discover,
         test_news_events_path_excluded,
         test_news_path_excluded,
         test_events_path_excluded,


### PR DESCRIPTION
## Why
The single highest-value content lever. `libguides.lib.miamioh.edu` is in **no** campus sitemap, so the eval has a *measured* blocker: `fs_makerspace_middletown_refusal` cannot answer ("couldn't verify my sources") because the Middletown TEC Lab guide isn't in the index. Flagged across 6+ audits; now a quantified miss.

## Two barriers (verified in code, not guessed)
1. `_is_library_url` **rejects** the libguides host (`libguides.`, not `lib.`/`www.lib.`; paths lack `/library/`).
2. `classify._infer_campus` host-defaults libguides → `oxford`. A blind sitemap bulk-crawl would tag the **Middletown** TEC Lab guide as **Oxford**, and the load-bearing cross-campus guard would then *block* it for Middletown queries.

## Fix — curated, campus-correct registry (plan's "curated > bulk")
- `config.LIBGUIDE_SEED`: 6 canonical-doc/operator-confirmed guides, each with **explicit** `(campus, library, featured_service)`. Every URL HEAD-verified 200, no redirect. `all` = university-wide (guard passes "all").
- `+ "libguides."` host prefix (curated seed only; discover never bulk-crawls this host).
- `discover.py` emits them (`source="libguide_seed"`); `classify.py` honors the registry **verbatim** (never host inference for seeds). Non-seed libguides URLs still host-default (backward compatible).

## Verification
- Unit: `test_classify` 40/40 (+4; TEC Lab→middletown is load-bearing), `test_discover` 34/34 (+3; incl. anti-fabrication well-formedness guard). All ETL modules + full src suite green.
- **End-to-end** (real fetch + trafilatura extract + classify, no tunnel/embeddings/Weaviate): **6/6 extract clean** (≥200 chars, 0 rejections) with correct tags — TEC Lab → `middletown/gardner_harvey/makerspace`, newspapers → `all/all/newspapers`, etc.

## Operator handoff (gated by design)
Indexing requires `run_etl.py --phase prepare` → diff → librarian sign-off → `--phase apply` (needs the Weaviate tunnel + approval token; deliberately gated like the DB hotfix). Code is ready + proven offline; the apply is the operator's environment + sign-off loop.

Minor follow-up (non-blocking): LibGuides pages carry a short "Skip to Main Content / chat loading…" nav prefix; a LibGuides-specific extract rule could trim it for marginally cleaner chunks. Bulk is real content; well under the boilerplate-rejection threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)