### PR TITLE
synthesizer: nav/menu mention != service exists here (no cross-campus half-affirm)

### DIFF
--- a/ai-core/src/prompts/synthesizer_v1.py
+++ b/ai-core/src/prompts/synthesizer_v1.py
@@ -65,6 +65,15 @@ refusal handoff card is more useful to the user than a wrong answer.
 context. Do not include information about other campuses unless the user \
 explicitly asked for a comparison. If your only relevant evidence is from \
 another campus, return REFUSAL.
+   A passing or NAVIGATION/menu/link mention of a service is NOT \
+evidence that the service exists at the asked campus. (A "Special \
+Collections" link in another campus's site nav usually points to the \
+Oxford one.) To say campus X has service Y you need a SUBSTANTIVE \
+statement that X provides Y -- not a label, breadcrumb, or link. If \
+you cannot substantively confirm Y at X, return REFUSAL. Do NOT \
+half-affirm ("X is listed as having Y, but I don't have the \
+location") -- that affirms a possibly-false premise and is exactly \
+the failure mode rule 4 forbids.
 
 7. Keep answers short. 2-4 sentences for most questions. The user came for \
 the answer, not for prose.


### PR DESCRIPTION
## Why
Operator flagged `xc_special_collections_at_hamilton` as a real hallucination ("there is no Special Collections at Hamilton; bot was hallucination"). For *"Where are special collections at Hamilton?"* (scope=hamilton) the bot replied: *"Special Collections are listed from the Rentschler Library homepage on the Hamilton campus [2]. I don't have a source … for the exact location."* — it treated a **nav-link label** (the Rentschler site's "Special Collections" menu link → actually the Oxford SCUA) as proof Hamilton *has* the service, then hedged. Judge: `wrong`. This is exactly the failure the project exists to kill.

## Fix
The *deterministic* fix is the `LibrarySpace.services_offered` guard — but that's **Gap 3**, operator-blocked (needs librarian seed data). This PR is the **code-only synthesis-discipline backstop**, folded into the existing **rule 6** (scope discipline) rather than a new numbered rule (avoids cached-prefix bloat):

- A passing/navigation/menu/link mention is **not** evidence a service exists at the asked campus.
- Affirming "campus X has Y" requires a **substantive** statement, not a label/breadcrumb/link.
- If it can't be substantively confirmed for the asked campus → **REFUSAL**.
- Explicitly forbids the "X is listed as having Y, but I don't have the location" half-affirm (rule 4 already bans partial-but-confident; now named for this case).

## Tests
`test_builder` 9/9 (stable prefix byte-stable), `test_synthesizer` 16/16, `test_post_processor` 22/22, full src suite **27/27**. Prompt-level because "nav-mention vs substantive statement" is semantic; the deterministic services_offered guard remains the eventual load-bearing fix.

Independent of PR #54 (libguides ETL) — different file, either merge order is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)