### PR TITLE
etl: follow meta-refresh/canonical vanity-URL shims (/adobe, /askus)

### DIFF
--- a/ai-core/scripts/etl/config.py
+++ b/ai-core/scripts/etl/config.py
@@ -153,6 +153,26 @@ TOPIC_BY_URL_PREFIX: Final[tuple[tuple[str, str], ...]] = (
 )
 
 
+# --- Vanity short-URL -> real indexable page --------------------------------
+#
+# Some Miami vanity short-URLs (/adobe/, ...) are <meta refresh> /
+# canonical-only shims whose destination is OFF-HOST and not
+# indexable as prose (e.g. /adobe/ -> muohio.libcal.com LibCal
+# equipment item, a JS app on a different host). extract.find_redirect
+# _target detects the shim; run_etl, when the target fails the
+# library-content filter, looks here for the real same-host page that
+# answers the same question and indexes THAT instead (dedup handles
+# overlap if the page is also in the sitemap).
+#
+# Operator-verified 2026-05-17: /software/ extracts clean (2048 chars,
+# "Software Checkout") and is the page their gold (fs_indesign_faculty)
+# cites for Adobe. Keep tiny + librarian-curated.
+VANITY_CANONICAL: Final[dict[str, str]] = {
+    "https://www.lib.miamioh.edu/adobe/":
+        "https://www.lib.miamioh.edu/software/",
+}
+
+
 # --- Featured services (plan §7) --------------------------------------------
 #
 # Map URL substrings -> featured_service tag. classify.py applies this to

--- a/ai-core/scripts/etl/extract.py
+++ b/ai-core/scripts/etl/extract.py
@@ -18,8 +18,10 @@ can call it; concrete extractor invocation is a TODO.
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass
 from typing import Optional
+from urllib.parse import urljoin
 
 from . import config
 
@@ -38,6 +40,57 @@ class ExtractedDoc:
     schema_org_json: Optional[dict]  # parsed Schema.org JSON-LD if present
     last_modified: Optional[str]     # HTTP Last-Modified header verbatim
     rejection_reason: Optional[str]  # set if extraction failed quality gates
+    redirect_to: Optional[str] = None
+    """Set when the page is a content-less redirect shim (vanity short
+    URL like /adobe/, /askus). The pipeline re-fetches this target
+    instead of dropping the page. The ETL fetcher follows HTTP 3xx but
+    NOT <meta refresh> / JS / canonical-only shims, so without this a
+    librarian-handed-out short URL silently never reaches the index."""
+
+
+# Miami vanity URLs redirect via <meta http-equiv=refresh> and/or a
+# lone <link rel=canonical> (no <body>). Content may have a space
+# after `url=` (observed: `content="0; url= https://..."`). Both
+# patterns are case-insensitive and quote-tolerant.
+_META_REFRESH_RE = re.compile(
+    r'<meta[^>]+http-equiv=["\']?refresh["\']?[^>]*content=["\']([^"\']+)["\']',
+    re.IGNORECASE,
+)
+_REFRESH_URL_RE = re.compile(r'url\s*=\s*([^\s"\'>]+)', re.IGNORECASE)
+_CANONICAL_RE = re.compile(
+    r'<link[^>]+rel=["\']?canonical["\']?[^>]*href=["\']([^"\']+)["\']',
+    re.IGNORECASE,
+)
+
+
+def _norm_url(u: str) -> str:
+    return (u or "").rstrip("/").lower()
+
+
+def find_redirect_target(html: str, base_url: str) -> Optional[str]:
+    """Return the destination of a redirect SHIM, or None.
+
+    Called only on the empty/too_short path -- a stub page with a
+    `<meta refresh>` or a lone `<link rel=canonical>` pointing
+    elsewhere is a redirect, not real content. Relative targets are
+    resolved against base_url. Returns None if there's no shim (e.g.
+    an Apache "300 Multiple Choices" page is genuine junk -> stays
+    rejected)."""
+    if not html:
+        return None
+    m = _META_REFRESH_RE.search(html)
+    if m:
+        mu = _REFRESH_URL_RE.search(m.group(1))
+        if mu:
+            tgt = urljoin(base_url, mu.group(1).strip())
+            if _norm_url(tgt) != _norm_url(base_url):
+                return tgt
+    m = _CANONICAL_RE.search(html)
+    if m:
+        tgt = urljoin(base_url, m.group(1).strip())
+        if _norm_url(tgt) != _norm_url(base_url):
+            return tgt
+    return None
 
 
 def _strip_html_fallback(html: str) -> tuple[Optional[str], str]:
@@ -159,12 +212,14 @@ def extract(html: str, url: str, last_modified: Optional[str] = None) -> Extract
             url=url, title=title, body_text="", breadcrumbs=[],
             word_count=0, schema_org_json=None, last_modified=last_modified,
             rejection_reason="empty",
+            redirect_to=find_redirect_target(html, url),
         )
     if len(body_text) < config.EXTRACT_MIN_BODY_CHARS:
         return ExtractedDoc(
             url=url, title=title, body_text="", breadcrumbs=[],
             word_count=0, schema_org_json=None, last_modified=last_modified,
             rejection_reason="too_short",
+            redirect_to=find_redirect_target(html, url),
         )
 
     word_count = len(body_text.split())

--- a/ai-core/scripts/etl/run_etl.py
+++ b/ai-core/scripts/etl/run_etl.py
@@ -233,6 +233,45 @@ def run(
         seen_for_allowlist.append((canon_url, 200, d.source, "text/html"))
 
         doc = extract.extract(html, canon_url, last_modified=last_mod)
+
+        # Vanity-shim resolution (ONE hop). The fetcher follows HTTP 3xx
+        # but not <meta refresh>/canonical-only shims, so /adobe/,
+        # /askus would silently never reach the index. Re-fetch the
+        # real destination: same-host/indexable -> the target itself;
+        # off-host (e.g. /adobe/ -> libcal app) -> the curated
+        # same-host page that answers it; otherwise log a visible
+        # off-host reject (NOT a silent drop).
+        if doc.redirect_to:
+            tgt = doc.redirect_to
+            if discover._is_library_url(tgt):
+                resolved = tgt
+            else:
+                resolved = config.VANITY_CANONICAL.get(
+                    d.url
+                ) or config.VANITY_CANONICAL.get(canon_url)
+            if resolved is None:
+                report.extraction_rejects.append(
+                    (canon_url, f"redirect_offhost:{tgt}")
+                )
+                continue
+            if extract._norm_url(resolved) != extract._norm_url(canon_url):
+                h2, lm2, c2, e2 = pipeline.fetch(resolved)
+                if e2 or h2 is None:
+                    report.extraction_rejects.append(
+                        (canon_url, f"redirect_fetch_failed:{resolved}")
+                    )
+                    continue
+                report.fetched_url_count += 1
+                canon_url = c2 or resolved
+                seen_urls.add(canon_url)
+                seen_for_allowlist.append(
+                    (canon_url, 200, d.source, "text/html")
+                )
+                # One hop only -- do NOT recurse on the re-fetched doc.
+                doc = extract.extract(
+                    h2, canon_url, last_modified=lm2
+                )
+
         if doc.rejection_reason:
             report.extraction_rejects.append((canon_url, doc.rejection_reason))
             continue

--- a/ai-core/scripts/etl/test_extract.py
+++ b/ai-core/scripts/etl/test_extract.py
@@ -34,6 +34,7 @@ from scripts.etl.extract import (  # noqa: E402
     ExtractedDoc,
     _strip_html_fallback,
     extract,
+    find_redirect_target,
 )
 
 
@@ -285,8 +286,115 @@ def test_extracted_doc_has_all_documented_fields() -> None:
         assert hasattr(out, field), f"ExtractedDoc missing field: {field}"
 
 
+# --- Redirect-shim resolution (vanity short-URLs: /adobe/, /askus) ---
+
+# The REAL /adobe/ body (226 bytes) -- note the SPACE after `url=`.
+_ADOBE_STUB = (
+    '<!doctype html>\n<html>\n<head>\n'
+    '  <meta http-equiv="refresh" content="0; url= '
+    'https://muohio.libcal.com/equipment/item/61121/">\n'
+    '  <link rel="canonical" '
+    'href="https://muohio.libcal.com/equipment/item/61121/" />\n'
+    '</head>\n</html>\n'
+)
+_ASKUS_STUB = (
+    '<html><head><title>Redirecting…</title>'
+    '<meta http-equiv="refresh" content="0;url='
+    'https://www.lib.miamioh.edu/research/research-support/ask/">'
+    '</head><body>Redirecting…</body></html>'
+)
+# The REAL /illuminant20 body -- an Apache "300 Multiple Choices"
+# page: genuine junk, NO shim -> must stay rejected (return None).
+_APACHE_300 = (
+    '<html><head><title>300 Multiple Choices</title></head><body>'
+    '<h1>Multiple Choices</h1>The document name you requested '
+    '(<code>/illuminant20</code>) could not be found.</body></html>'
+)
+
+
+def test_find_redirect_meta_refresh_with_space() -> None:
+    """The /adobe/ format has `url= https://...` (space). Must still
+    parse -- the original regex missed exactly this."""
+    t = find_redirect_target(_ADOBE_STUB, "https://www.lib.miamioh.edu/adobe/")
+    assert t == "https://muohio.libcal.com/equipment/item/61121/", t
+
+
+def test_find_redirect_meta_refresh_no_space() -> None:
+    t = find_redirect_target(_ASKUS_STUB, "https://www.lib.miamioh.edu/askus")
+    assert t == (
+        "https://www.lib.miamioh.edu/research/research-support/ask/"
+    ), t
+
+
+def test_find_redirect_canonical_only() -> None:
+    html = (
+        '<html><head><link rel="canonical" '
+        'href="https://www.lib.miamioh.edu/software/"></head></html>'
+    )
+    t = find_redirect_target(html, "https://www.lib.miamioh.edu/sw/")
+    assert t == "https://www.lib.miamioh.edu/software/", t
+
+
+def test_find_redirect_relative_resolved_absolute() -> None:
+    html = '<meta http-equiv="refresh" content="0;url=/research/ask/">'
+    t = find_redirect_target(html, "https://www.lib.miamioh.edu/askus")
+    assert t == "https://www.lib.miamioh.edu/research/ask/", t
+
+
+def test_find_redirect_none_on_apache_300_junk() -> None:
+    """No shim -> None, so genuine junk (the /illuminant20 'did you
+    mean' page) stays correctly rejected, not chased."""
+    assert find_redirect_target(
+        _APACHE_300, "https://www.lib.miamioh.edu/illuminant20"
+    ) is None
+
+
+def test_find_redirect_self_canonical_is_none() -> None:
+    """A self-referential canonical is NOT a redirect."""
+    html = (
+        '<link rel="canonical" '
+        'href="https://www.lib.miamioh.edu/x/">'
+    )
+    assert find_redirect_target(
+        html, "https://www.lib.miamioh.edu/x"
+    ) is None
+
+
+def test_extract_stub_sets_redirect_to() -> None:
+    """End of the chain: extract() on the real /adobe/ stub must
+    reject (empty/too_short) AND surface redirect_to so run_etl can
+    re-fetch instead of silently dropping the page."""
+    d = extract(_ADOBE_STUB, "https://www.lib.miamioh.edu/adobe/")
+    assert d.rejection_reason in ("empty", "too_short"), d.rejection_reason
+    assert d.redirect_to == (
+        "https://muohio.libcal.com/equipment/item/61121/"
+    ), d.redirect_to
+
+
+def test_extract_real_page_has_no_redirect_to() -> None:
+    """A normal page must not get a spurious redirect_to (backward
+    compatible: redirect_to defaults None and only the reject paths
+    populate it)."""
+    html = (
+        "<html><head><title>Real</title></head><body><main>"
+        + ("Substantive library content. " * 20)
+        + "</main></body></html>"
+    )
+    d = extract(html, "https://www.lib.miamioh.edu/use/real/")
+    assert d.rejection_reason is None
+    assert d.redirect_to is None
+
+
 def main() -> int:
     tests = [
+        test_find_redirect_meta_refresh_with_space,
+        test_find_redirect_meta_refresh_no_space,
+        test_find_redirect_canonical_only,
+        test_find_redirect_relative_resolved_absolute,
+        test_find_redirect_none_on_apache_300_junk,
+        test_find_redirect_self_canonical_is_none,
+        test_extract_stub_sets_redirect_to,
+        test_extract_real_page_has_no_redirect_to,
         test_fallback_strips_basic_tags,
         test_fallback_strips_nav_footer_sidebar,
         test_fallback_strips_script_and_style,


### PR DESCRIPTION
## Why
You caught this in the prepare diff: `/adobe/` and `/askus` sat under **Extraction rejects → empty/too_short**. They're not broken pages — they're vanity short-URLs librarians hand out, served as redirect **shims** the ETL never followed (it follows HTTP 3xx but not `<meta refresh>` / `<link canonical>` / JS). So they silently never reached the index — a likely cause of the Adobe + librarian-help eval misses.

Three real, distinct cases (verified against live HTML, not guessed):
| URL | Shim | Treatment |
|---|---|---|
| `/askus` | `<meta refresh>` → same-host `…/research-support/ask/` | re-fetch target ("Ask a Librarian", 794 chars) |
| `/adobe/` | `<meta refresh content="0; url= …">` + canonical → **off-host** libcal app | `VANITY_CANONICAL` → `/software/` (operator-verified, 2048 chars, the page your gold cites) |
| `/illuminant20` | none (Apache "300 Multiple Choices") | **stays rejected** — genuine junk, correctly dropped |

## Fix (deterministic, one hop, generalizes)
- `extract.find_redirect_target()` — robust `<meta refresh>` (handles the real `url= <space>` form the first regex missed) + lone `<link canonical>`; relative→absolute; self-canonical→None; only on the empty/too_short path so junk-without-a-shim stays rejected.
- `ExtractedDoc.redirect_to` (defaulted None → backward compatible).
- `run_etl`: one hop — same-host/indexable → re-fetch; off-host → `config.VANITY_CANONICAL` real same-host page; unmapped off-host → a **visible** `redirect_offhost:<tgt>` reject (never a silent drop, so the next diff shows it for curation).

## Verification
E2E on the **live** pages: `/adobe/`→`/software/` ("Software Checkout"), `/askus/`→"Ask a Librarian". `test_extract` 28/28 (+8: `url=`-space, Apache-300→None, self-canonical→None, backward-compat). All ETL + src suites green.

## Sequencing
Independent PR off main. For one combined `--phase prepare`, **merge this AND #54 (libguides)** before running prepare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)