### PR TITLE
fix(etl): pick correct Weaviate verb from known existence in upsert

### DIFF
--- a/ai-core/scripts/etl/test_upsert.py
+++ b/ai-core/scripts/etl/test_upsert.py
@@ -84,7 +84,11 @@ class StubWeaviate:
     def upsert_chunk(
         self, *, collection: str, chunk_id: str,
         properties: dict, vector: list[float],
+        exists: Optional[bool] = None,
     ) -> None:
+        # `exists` is the caller's create-vs-overwrite hint; the
+        # in-memory store doesn't care (dict assignment is upsert),
+        # but the signature must accept it or step() breaks.
         self._data.setdefault(collection, {})[chunk_id] = {
             "properties": dict(properties),
             "vector": list(vector),

--- a/ai-core/scripts/etl/upsert.py
+++ b/ai-core/scripts/etl/upsert.py
@@ -75,7 +75,8 @@ class WeaviateLike(Protocol):
     """
 
     def upsert_chunk(
-        self, *, collection: str, chunk_id: str, properties: dict, vector: list[float]
+        self, *, collection: str, chunk_id: str, properties: dict,
+        vector: list[float], exists: Optional[bool] = None,
     ) -> None: ...
     def get_chunk(
         self, *, collection: str, chunk_id: str
@@ -296,11 +297,17 @@ def make_upsert_step(
                 "deleted": False,
                 "ingested_at": dt.datetime.utcnow().isoformat(),
             }
+            # `existing` came from the get_chunk() probe above, so we
+            # already know whether this is a create or an overwrite.
+            # Pass it through so upsert_chunk leads with the correct
+            # verb instead of a guaranteed-to-fail replace-of-nonexistent
+            # on the fresh `Chunk_v{version}` collection.
             weaviate.upsert_chunk(
                 collection=collection,
                 chunk_id=chunk.chunk_id,
                 properties=properties,
                 vector=vector,
+                exists=existing is not None,
             )
             if existing:
                 result.changed_chunk_ids.append(chunk.chunk_id)

--- a/ai-core/src/weaviate_adapters/etl_adapter.py
+++ b/ai-core/src/weaviate_adapters/etl_adapter.py
@@ -190,6 +190,7 @@ class WeaviateETLAdapter:
         chunk_id: str,
         properties: dict,
         vector: list[float],
+        exists: Optional[bool] = None,
     ) -> None:
         """Insert if new, replace if exists. Idempotent on chunk_id.
 
@@ -200,6 +201,19 @@ class WeaviateETLAdapter:
         chunk_id is stored as a property for callers that need to
         look up by it OR join to `ChunkProvenance.chunkId` (Postgres
         uses the original 'c-...' format).
+
+        `exists` lets a caller that already knows the object's state
+        (the ETL `step()` calls `get_chunk` first) pick the correct
+        verb so we don't fire a request that's guaranteed to fail:
+          - exists is True  -> object present -> `replace` (REST PUT)
+          - exists is False -> object absent  -> `insert`  (REST POST)
+          - exists is None  -> unknown -> historical replace-first order
+        This matters on a FRESH collection (every ETL run writes to a
+        brand-new `Chunk_v{version}`): without it, every chunk does a
+        replace-of-nonexistent that some Weaviate builds answer with a
+        500, then falls back to insert -- one wasted failing PUT and a
+        500-spammed log per chunk. The opposite verb is kept only as a
+        race fallback (stale snapshot / concurrent writer / retry).
         """
         self._ensure_collection(collection)
         coll = self.client.collections.get(collection)
@@ -208,29 +222,47 @@ class WeaviateETLAdapter:
         # identifier survives the UUID conversion. Callers may also
         # have set it; if so we overwrite-with-same-value (no-op).
         props_with_chunk_id = {**properties, "chunk_id": chunk_id}
-        # `replace` is the upsert primitive in v4 if you key on UUID.
-        # It creates if not found, replaces if found. Equivalent to
-        # PUT in REST terms.
-        try:
+
+        def _replace() -> None:
+            # `replace` == PUT: full overwrite, requires the object to
+            # exist on builds that don't treat it as upsert-create.
             coll.data.replace(
                 uuid=obj_uuid,
                 properties=props_with_chunk_id,
                 vector=vector,
             )
+
+        def _insert() -> None:
+            # `insert` == POST: create; conflicts if the object exists.
+            coll.data.insert(
+                uuid=obj_uuid,
+                properties=props_with_chunk_id,
+                vector=vector,
+            )
+
+        if exists is False:
+            primary, fallback = _insert, _replace
+            primary_name, fallback_name = "insert", "replace"
+        else:
+            # exists is True or None -> lead with replace (the v4 upsert
+            # primitive when keying on UUID; also the historical order
+            # so callers that pass nothing are unaffected).
+            primary, fallback = _replace, _insert
+            primary_name, fallback_name = "replace", "insert"
+
+        try:
+            primary()
         except Exception as e:  # noqa: BLE001
-            # Some v4 versions raise on replace-of-nonexistent. Fall
-            # back to insert.
+            # Primary verb failed: either the existence snapshot was
+            # stale, or this build raises on replace-of-nonexistent.
+            # The other verb is the correct one in both those cases.
             try:
-                coll.data.insert(
-                    uuid=obj_uuid,
-                    properties=props_with_chunk_id,
-                    vector=vector,
-                )
+                fallback()
             except Exception as e2:  # noqa: BLE001
                 raise RuntimeError(
                     f"Weaviate upsert failed for chunk_id={chunk_id!r} "
                     f"(uuid={obj_uuid}) in {collection!r}: "
-                    f"replace={e!r}, insert={e2!r}"
+                    f"{primary_name}={e!r}, {fallback_name}={e2!r}"
                 ) from e2
 
     def get_chunk(

--- a/ai-core/src/weaviate_adapters/test_etl_adapter.py
+++ b/ai-core/src/weaviate_adapters/test_etl_adapter.py
@@ -54,16 +54,24 @@ class _StubData:
     """Mimics collection.data.{insert, replace, update, delete_many}."""
     def __init__(self, parent: "_StubCollection"):
         self.parent = parent
-        # Track whether the next replace should fail. Tests can flip
-        # this to exercise the insert fallback.
+        # Track whether the next replace/insert should fail. Tests flip
+        # these to exercise the cross-fallback paths.
         self.fail_replace_with: Optional[Exception] = None
+        self.fail_insert_with: Optional[Exception] = None
+        # Ordered record of verbs the adapter actually invoked, so a
+        # test can assert "insert-first, replace never tried".
+        self.calls: list[str] = []
 
     def insert(self, *, uuid, properties, vector):
+        self.calls.append("insert")
+        if self.fail_insert_with is not None:
+            raise self.fail_insert_with
         self.parent.objects[uuid] = {
             "properties": dict(properties), "vector": list(vector),
         }
 
     def replace(self, *, uuid, properties, vector):
+        self.calls.append("replace")
         if self.fail_replace_with is not None:
             raise self.fail_replace_with
         self.parent.objects[uuid] = {
@@ -346,6 +354,81 @@ def test_upsert_chunk_falls_back_to_insert_when_replace_fails() -> None:
     assert coll.objects[stored_uuid]["properties"]["chunk_id"] == "cid-2"
 
 
+def test_upsert_chunk_exists_false_inserts_without_trying_replace() -> None:
+    """The fix: when the caller knows the object is absent (fresh
+    collection), upsert must go straight to insert and NEVER fire the
+    replace-of-nonexistent that some Weaviate builds 500 on. Replace
+    is rigged to succeed here -- the test still requires it to be
+    untouched, proving verb selection, not luck."""
+    a = _adapter()
+    a._ensure_collection("Chunk_v1")
+    coll = a.client.collections._collections["Chunk_v1"]
+    a.upsert_chunk(
+        collection="Chunk_v1",
+        chunk_id="cid-new",
+        properties={"text": "fresh"},
+        vector=[1.0],
+        exists=False,
+    )
+    assert coll.data.calls == ["insert"]
+    stored_uuid = _chunk_uuid("cid-new")
+    assert coll.objects[stored_uuid]["properties"]["text"] == "fresh"
+
+
+def test_upsert_chunk_exists_true_replaces_without_trying_insert() -> None:
+    """When the caller knows the object is present, lead with replace
+    (full PUT overwrite) and don't waste an insert that would conflict."""
+    a = _adapter()
+    a._ensure_collection("Chunk_v1")
+    coll = a.client.collections._collections["Chunk_v1"]
+    a.upsert_chunk(
+        collection="Chunk_v1",
+        chunk_id="cid-upd",
+        properties={"text": "v2"},
+        vector=[2.0],
+        exists=True,
+    )
+    assert coll.data.calls == ["replace"]
+    stored_uuid = _chunk_uuid("cid-upd")
+    assert coll.objects[stored_uuid]["properties"]["text"] == "v2"
+
+
+def test_upsert_chunk_exists_none_preserves_legacy_replace_first() -> None:
+    """Callers that pass no `exists` (every pre-existing call site +
+    test) must keep the historical replace-first order, so this change
+    is strictly backward-compatible."""
+    a = _adapter()
+    a._ensure_collection("Chunk_v1")
+    coll = a.client.collections._collections["Chunk_v1"]
+    a.upsert_chunk(
+        collection="Chunk_v1",
+        chunk_id="cid-legacy",
+        properties={"text": "legacy"},
+        vector=[3.0],
+    )
+    assert coll.data.calls == ["replace"]
+
+
+def test_upsert_chunk_exists_false_falls_back_to_replace_on_insert_conflict() -> None:
+    """Race safety: caller's snapshot said absent, but a concurrent
+    writer created it first so insert conflicts. The adapter must fall
+    back to replace rather than losing the write."""
+    a = _adapter()
+    a._ensure_collection("Chunk_v1")
+    coll = a.client.collections._collections["Chunk_v1"]
+    coll.data.fail_insert_with = RuntimeError("id already exists")
+    a.upsert_chunk(
+        collection="Chunk_v1",
+        chunk_id="cid-race",
+        properties={"text": "won-the-race"},
+        vector=[4.0],
+        exists=False,
+    )
+    assert coll.data.calls == ["insert", "replace"]
+    stored_uuid = _chunk_uuid("cid-race")
+    assert coll.objects[stored_uuid]["properties"]["text"] == "won-the-race"
+
+
 def test_get_chunk_returns_properties_on_hit() -> None:
     a = _adapter()
     a.upsert_chunk(
@@ -457,6 +540,10 @@ def main() -> int:
         test_chunk_uuid_returns_valid_uuid_string,
         test_upsert_then_get_chunk_roundtrip_via_chunk_id,
         test_upsert_chunk_falls_back_to_insert_when_replace_fails,
+        test_upsert_chunk_exists_false_inserts_without_trying_replace,
+        test_upsert_chunk_exists_true_replaces_without_trying_insert,
+        test_upsert_chunk_exists_none_preserves_legacy_replace_first,
+        test_upsert_chunk_exists_false_falls_back_to_replace_on_insert_conflict,
         test_get_chunk_returns_properties_on_hit,
         test_get_chunk_returns_none_for_missing_object,
         test_get_chunk_returns_none_for_missing_collection,


### PR DESCRIPTION
## Why

`--phase apply` was logging a wall of `PUT /v1/objects/.../{uuid} 500` alternating with `POST /v1/objects 200`, and was slow enough to get Ctrl-C'd mid-run.

**Diagnosed (not guessed) from the code:** the apply was *functionally working* — every `POST 200` was a chunk successfully indexed. ETL writes to a brand-new timestamped `Chunk_v{version}` collection every run, so `upsert_chunk` always tried `coll.data.replace` (REST PUT) first. Replace-of-nonexistent on this Weaviate build returns **500**; the existing `except` then `insert`s (POST) → 200. Result on a fresh collection: one guaranteed-failing PUT + a 500-spammed log + a wasted round trip **per chunk**.

## What

`step()` already calls `get_chunk()` before every write, so it knows whether the object exists. Thread that through:

- `exists is False` → `insert` (POST) directly — the fresh-collection path, no failing PUT
- `exists is True` → `replace` (PUT) directly
- `exists is None` → legacy replace-first (every pre-existing call site/test → **strictly backward compatible**)

The opposite verb stays as a race fallback only (stale snapshot / concurrent writer / retry), so correctness is unchanged. Fresh-collection re-index goes 3 round trips → 2 with **zero 500s**.

## Tests

- `test_etl_adapter` 22/22 (+4 new: insert-only, replace-only, legacy-default preserved, insert→replace race fallback)
- `test_upsert` 22/22, plus `test_extract` 28, `test_classify` 40, `test_chunker` 26, `test_discover` 34 — all green, no regressions.

## Operator impact

The interrupted apply did **not** corrupt anything — it wrote to an un-promoted fresh version (never aliased `Chunk_current`, so the live bot never saw it). After merge, re-run `--phase prepare → review diff → sign → apply`; the apply will be quiet and ~33% fewer round trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)