### PR TITLE
chore(etl): timezone-aware UTC instead of deprecated utcnow()

### DIFF
--- a/ai-core/scripts/etl/run_etl.py
+++ b/ai-core/scripts/etl/run_etl.py
@@ -219,7 +219,7 @@ def run(
         update_allowlist=_default_allowlist,
     )
 
-    started = dt.datetime.utcnow()
+    started = dt.datetime.now(dt.timezone.utc)
     report = diff_report.DiffReport(
         run_started_at=started,
         run_finished_at=started,  # placeholder; updated at end
@@ -321,7 +321,7 @@ def run(
         report.upsert.new_url_count = pipeline.update_allowlist(seen_for_allowlist)
 
     # 11. Diff report
-    report.run_finished_at = dt.datetime.utcnow()
+    report.run_finished_at = dt.datetime.now(dt.timezone.utc)
     diff_report.write_diff_report(report)
     return report
 
@@ -468,7 +468,7 @@ def main() -> int:
         # Mark the diff as applied so re-running --phase apply on the same
         # diff is a no-op (forced re-prepare for any new run).
         assert decision.token is not None
-        marker = gate.mark_applied(diff_path, decision.token, dt.datetime.utcnow())
+        marker = gate.mark_applied(diff_path, decision.token, dt.datetime.now(dt.timezone.utc))
         logger.info("apply complete; marker written: %s", marker)
         elapsed = time.time() - t0
         logger.info(
@@ -515,7 +515,7 @@ def main() -> int:
         # finished-at timestamp) and emit the approval template.
         diff_dir = Path(config.DIFF_REPORT_DIR)
         latest_md = max(diff_dir.glob("*.md"), key=lambda p: p.stat().st_mtime)
-        token_path = gate.write_approval_template(latest_md, dt.datetime.utcnow())
+        token_path = gate.write_approval_template(latest_md, dt.datetime.now(dt.timezone.utc))
         print()
         print(f"Diff:     {latest_md}")
         print(f"Approval: {token_path}")

--- a/ai-core/scripts/etl/upsert.py
+++ b/ai-core/scripts/etl/upsert.py
@@ -295,7 +295,7 @@ def make_upsert_step(
                 "featured_service": chunk.featured_service or "",
                 "content_hash": chunk.content_hash,
                 "deleted": False,
-                "ingested_at": dt.datetime.utcnow().isoformat(),
+                "ingested_at": dt.datetime.now(dt.timezone.utc).isoformat(),
             }
             # `existing` came from the get_chunk() probe above, so we
             # already know whether this is a create or an overwrite.
@@ -351,7 +351,7 @@ def make_tombstone_step(
         )
         gc_deleted = weaviate.gc_tombstones(
             collection=collection,
-            older_than=dt.datetime.utcnow() - dt.timedelta(days=gc_age_days),
+            older_than=dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=gc_age_days),
         )
         return UpsertResult(
             tombstoned_urls=list(tombstoned),
@@ -398,7 +398,7 @@ def make_allowlist_step(
                 "http_status": status,
                 "source": source,
                 "content_type": content_type,
-                "last_seen": dt.datetime.utcnow(),
+                "last_seen": dt.datetime.now(dt.timezone.utc),
             }
             for url, status, source, content_type in rows
         ]

--- a/ai-core/src/weaviate_adapters/etl_adapter.py
+++ b/ai-core/src/weaviate_adapters/etl_adapter.py
@@ -334,7 +334,7 @@ class WeaviateETLAdapter:
         # Iterate all objects to find non-seen ones. v4 supports
         # paginated iteration via collections.iterator().
         tombstoned: list[str] = []
-        now_iso = dt.datetime.utcnow().isoformat()
+        now_iso = dt.datetime.now(dt.timezone.utc).isoformat()
         try:
             for obj in coll.iterator(return_properties=["source_url", "deleted"]):
                 url = obj.properties.get("source_url")


### PR DESCRIPTION
## Why

`datetime.datetime.utcnow()` is deprecated in Python 3.12+ (removal scheduled). On 3.14.5 it still works but spams `DeprecationWarning` through every `--phase apply` run (the warnings you saw after the successful 20,335-chunk apply). This is future-breakage tech debt, not a current bug — the apply was valid.

## What

All 8 ETL/adapter call sites: `dt.datetime.utcnow()` → `dt.datetime.now(dt.timezone.utc)`. No new imports (`import datetime as dt` already present in all 3 files).

## Verified safe per consumer (not a blind swap)

| Site | Consumer | Why aware is safe |
|---|---|---|
| `run_etl` `started` + `run_finished_at` | `diff_report` duration subtraction | Changed **together** → aware−aware. strftime (filename/header) + version string have no `%z/%Z` → identical output. |
| `run_etl` `write_approval_template` / `gate.mark_applied` | `.approval`/`.applied` markers | Gate security boundary is `diff_hash = sha256(diff file)`; `verify_gate` compares `diff_hash` only. Timestamps are write-only strings — **no `fromisoformat` anywhere in gate.py**. Cosmetic. |
| `upsert` `ingested_at` / `etl_adapter` `tombstoned_at` | Weaviate date props | Aware ISO carries `+00:00` → RFC3339-**correct**. Naive form was technically non-compliant. Strict improvement. |
| `upsert` `last_seen` / `older_than` GC filter | Prisma DateTime / Weaviate where | Both accept aware datetimes. |

## Tests

Full matrix green, no regressions: `test_extract` 28, `test_classify` 40, `test_chunker` 26, `test_discover` 34, `test_gate` 9, `test_upsert` 22, `test_etl_adapter` 22. Files byte-compile clean.

## Scope

**Datetime deprecation only.** The Weaviate `Con004: connection not closed` ResourceWarning is intentionally **not** bundled: it's harmless for a batch process that exits (OS reclaims the socket immediately — only matters in long-lived processes), and fixing it properly is an adapter-lifecycle change (no `close()`/context-manager on `WeaviateETLAdapter` today, and the run site can't reach the adapter without restructuring). Separate small follow-up if wanted; not worth the risk of cramming a lifecycle change into a mechanical deprecation PR.

Non-blocking: does not affect the freshly-applied index. Safe to merge before or after the eval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)