### PR TITLE
fix(classifier): persist clarify telemetry + conservative MARGIN_LOW 0.05→0.03

### DIFF
--- a/ai-core/src/eval/run_eval.py
+++ b/ai-core/src/eval/run_eval.py
@@ -148,6 +148,15 @@ class EvalResult:
     input_tokens: Optional[int] = None
     cached_input_tokens: Optional[int] = None
     output_tokens: Optional[int] = None
+    # Classifier telemetry (FIX #1: clarification-gate calibration).
+    # classify() was previously computed for routing then discarded;
+    # persisting score/margin/candidates lets MARGIN_LOW and a future
+    # high-confidence bypass be tuned from real eval data rather than
+    # guessed. clf_candidates is the top-k [[intent, score], ...].
+    clf_score: Optional[float] = None
+    clf_margin: Optional[float] = None
+    clf_needs_clarification: Optional[bool] = None
+    clf_candidates: Optional[list] = None
 
 
 @dataclass
@@ -664,13 +673,27 @@ def run_eval(
             # let the consecutive-failure circuit breaker stop a
             # hard-down tunnel cleanly with everything-so-far on disk.
             try:
+                # Classify once per turn. Drives routing in the real
+                # branch AND is persisted on `result` as telemetry so
+                # the clarification gate (MARGIN_LOW / a future
+                # high-confidence bypass) can be calibrated from eval
+                # data -- this was previously computed and discarded.
+                pre_classification = classifier.classify(q.question)
+                result.clf_score = pre_classification.score
+                result.clf_margin = pre_classification.margin
+                result.clf_needs_clarification = (
+                    pre_classification.needs_clarification
+                )
+                result.clf_candidates = [
+                    [str(_i), float(_sc)]
+                    for _i, _sc in (pre_classification.candidates or [])
+                ]
                 if with_real_llm:
                     # Pre-resolve scope + intent so the real search_kb
                     # tool filters/boosts to the right campus/library/
                     # featured-service for this turn. The orchestrator
                     # re-resolves both internally (deterministic) and
                     # arrives at the same values.
-                    pre_classification = classifier.classify(q.question)
                     _s = resolve_scope(
                         q.question,
                         session_origin_campus=q.needs_session_origin,  # type: ignore[arg-type]
@@ -1057,6 +1080,10 @@ def _result_row(r: "EvalResult") -> dict:
         "input_tokens": r.input_tokens,
         "cached_input_tokens": r.cached_input_tokens,
         "output_tokens": r.output_tokens,
+        "clf_score": r.clf_score,
+        "clf_margin": r.clf_margin,
+        "clf_needs_clarification": r.clf_needs_clarification,
+        "clf_candidates": r.clf_candidates,
         # Full answer LAST (longest field) so the line stays greppable
         # up front even when truncated in a pager.
         "bot_answer": r.bot_answer,

--- a/ai-core/src/router/intent_knn.py
+++ b/ai-core/src/router/intent_knn.py
@@ -94,8 +94,23 @@ class Classification:
 MARGIN_HIGH = 0.10
 """Above this margin, classifier is confident -- route without warning."""
 
-MARGIN_LOW = 0.05
-"""Below this margin, classifier is uncertain -- ask the user."""
+MARGIN_LOW = 0.03
+"""Below this margin, classifier is uncertain -- ask the user.
+
+Lowered 0.05 -> 0.03 from the 2026-05-17 full eval. 34/184 turns
+(18.5%) hit the clarification chip; in 18 of those the classifier had
+ALREADY picked the gold-correct intent (`actual_intent == gold_intent`)
+and bounced only because the #1/#2 *intent* margin was <0.05. Those
+pairs were semantically ADJACENT library topics (ILL~circulation,
+tech_checkout~adobe, databases~digital_collections, loan_policy~
+account) -- a thin margin there is topic adjacency the single
+tool-calling agent handles fine, not genuine user ambiguity. The plan
+requires clarification to be RARE and scope/building-bound, so 18.5%
+is a defect. 0.03 is a conservative, monotonic step (strictly fewer
+needless chips, no exemplar overfitting). The precise final value /
+a high-confidence-score bypass is to be calibrated from the new
+`clf_score`/`clf_margin`/`clf_candidates` eval telemetry on the next
+run -- this constant stays the single tuning knob, never buried."""
 
 SCORE_FLOOR = 0.50
 """Absolute top-1 cosine-similarity floor. Below this, NO exemplar is


### PR DESCRIPTION
## FIX #1 round 1 — clarification over-fire

The 2026-05-17 full eval: **34/184 (18.5%) turns hit the clarification chip**; the plan requires it to be *rare* and scope-bound.

**Non-obvious finding:** in **18 of 34**, `actual_intent == gold_intent` — the classifier was *already right* and bounced only because the #1/#2 intent margin was <0.05. Those pairs (ILL↔circulation, tech_checkout↔adobe, databases↔digital_collections, loan_policy↔account) are **adjacent library topics**, not user ambiguity — the single tool-calling agent handles adjacency fine.

You chose **telemetry + conservative step** (not guess a threshold). This PR delivers exactly that:

### 1. Classifier telemetry (zero-risk, unblocks calibration)
`run_eval.py` computed `classify()` for routing then **discarded** it. Now persisted per-turn on `EvalResult`/`_result_row`: `clf_score`, `clf_margin`, `clf_needs_clarification`, `clf_candidates` (top-k `[[intent,score],…]`). **No added cost** in `--with-real-llm` (same single classify call, no longer thrown away). This is the data to calibrate the gate from real numbers next run.

### 2. Conservative `MARGIN_LOW` 0.05 → 0.03
Monotonic (strictly fewer needless chips), no exemplar overfitting — the gold questions are the held-out measure and were deliberately **not** copied into exemplars. Stays the single, documented tuning knob.

### Deliberately deferred (needs the new telemetry to do honestly)
Precise final threshold + a high-confidence-score bypass + any targeted exemplar work — calibrated from `clf_*` on your next eval, not guessed now.

## Verification
- `py_compile` clean on both files
- Classifier suite **17/17** (test asserts relative to `MARGIN_LOW`, not a hard-coded `0.05` — lowering the constant is correctly absorbed)
- `EvalResult → _result_row → json` roundtrip smoke green

🤖 Generated with [Claude Code](https://claude.com/claude-code)