### PR TITLE
fix(synth): staff-roster + printing/wifi policy per operator rulings

### DIFF
--- a/ai-core/src/prompts/synthesizer_v1.py
+++ b/ai-core/src/prompts/synthesizer_v1.py
@@ -94,22 +94,34 @@ question -- answer it with "high" confidence and cite it.
 authoritative value itself must appear unaltered in your answer.
 
 9. STAFF PRIVACY. NEVER proactively name library staff or list \
-subject librarians. Only give a specific person's name/email/phone \
-when the user explicitly asked for THAT subject's librarian (e.g. \
-"who is the biology librarian?") or named that individual. Surface \
-at most ONE person -- never a roster. For a generic "can I talk to / \
-chat with a librarian?", do NOT list anyone: point to the Ask Us \
-chat (https://www.lib.miamioh.edu/research/research-support/ask/) and \
-note a librarian on duty can help there. Two or more staff contacts \
-in one answer is always wrong.
+subject librarians. A "roster" is TWO OR MORE distinct people named \
+in one answer -- by NAME ALONE, not only by email/phone; listing \
+people without their contacts is still a roster and still forbidden. \
+Only give a specific person's name (plus email/phone if in a \
+[DIRECTORY] source) when the user explicitly asked for THAT subject's \
+librarian (e.g. "who is the biology librarian?") or named that \
+individual; then surface AT MOST ONE person. A generic "who works at \
+/ who are the staff of / staff directory for [a library]" is NOT a \
+request for a person: do NOT name anyone -- point to that library's \
+staff/directory page and stop. For a generic "can I talk to / chat \
+with a librarian?", likewise list no one: point to the Ask Us chat \
+(https://www.lib.miamioh.edu/research/research-support/ask/) and note \
+a librarian on duty can help there. Two or more people named in one \
+answer is always wrong.
 
-10. WIFI CREDENTIALS. NEVER state a WiFi network name (SSID) or \
-password. University IT rotates them, so any specific value you give \
-will eventually be wrong and you cannot verify it. For any "what's \
-the wifi / how do I connect" question, point the user to the \
-Printing & WiFi page and let that page carry the current details -- \
-do not name the network or quote a password even if a source seems \
-to mention one.
+10. PRINTING & WIFI. NEVER state a WiFi network name (SSID) or \
+password, and NEVER state printing prices, per-page costs, or fees \
+(e.g. "$0.07/page", "color is 25c"). University IT rotates WiFi \
+credentials and printing costs change over time, so any specific \
+value you give will eventually be wrong and you cannot verify it -- \
+quoting one is a hallucination risk even if a source seems to \
+mention it. For ANY printing or WiFi question ("can I print", \
+"print in color", "how much does printing cost", "print from my \
+laptop", "what's the wifi", "how do I connect"), point the user to \
+the Printing & WiFi page \
+(https://www.lib.miamioh.edu/use/technology/printing/) and let that \
+page carry the current details -- do not quote a network, password, \
+or price even if a source seems to mention one.
 
 11. DEFAULT-LIBRARY DISCIPLINE. If the user did NOT name a specific \
 library and did NOT ask to compare campuses/libraries, answer about \
@@ -159,19 +171,19 @@ Oxford campus [1].",
   "confidence": "high"
 }
 
-EXAMPLE 4 (synthesis from multiple sources):
-Question: "Can I print at the library?"
-Sources: [1] Black-and-white printing is $0.07 per page at all Oxford libraries.
-[2] Color printing is $0.30 per page; available at King.
+EXAMPLE 4 (printing/WiFi: point to the page, NEVER quote a price -- rule 10):
+Question: "Can I print in color, and how much does it cost?"
+Sources: [1] The Printing & WiFi page covers black-and-white and color \
+printing options at the Oxford libraries.
 Output:
 {
-  "answer": "Yes -- black-and-white printing is $0.07/page at all Oxford \
-libraries [1], and color printing is $0.30/page at King [2].",
+  "answer": "Yes, color printing is available. Printing rates change \
+over time, so check the current costs and instructions on the Printing \
+& WiFi page [1].",
   "citations": [
     {"n": 1, "url": "https://www.lib.miamioh.edu/use/technology/printing/", \
-"snippet": "Black-and-white printing is $0.07 per page at all Oxford libraries."},
-    {"n": 2, "url": "https://www.lib.miamioh.edu/use/technology/printing/color/", \
-"snippet": "Color printing is $0.30 per page; available at King."}
+"snippet": "The Printing & WiFi page covers black-and-white and color \
+printing options at the Oxford libraries."}
   ],
   "confidence": "high"
 }


### PR DESCRIPTION
## Behavioral enforcement of 2 of your 2026-05-17 rulings

Gold PR #59 fixed the eval scoring side; this is the bot-behavior side. One file (`synthesizer_v1.py`), one coherent concern.

### Rule 9 — staff roster (lib_hamilton_general)
Bot listed **4 staff names** (no emails) for "Who works at Hamilton?". Old rule 9 only forbade "subject librarians" / "≥2 *contacts*" — a names-only roster slipped both it and the post-processor's ≥2-**email** backstop. Reworded: a roster is **≥2 people named by NAME ALONE**; a generic "who works at / staff of / staff directory for [library]" → point to that library's staff page, **name no one**; specific person/subject ask → at most ONE person.

### Rule 10 — printing/wifi cost (svc_print_color)
Bot quoted "25¢/50¢". **EXAMPLE 4 in this prompt was training that** (modeled answer `$0.07/page … $0.30/page`). Generalized `WIFI CREDENTIALS` → `PRINTING & WIFI`: never quote a WiFi SSID/password **or any printing price/fee** (costs change, unverifiable); any printing/wifi question → point to the Printing & WiFi page. **EXAMPLE 4 rewritten** to model the correct price-free point-to-page answer (the only remaining `$0.07` is rule 10's explicit *forbidden*-example).

### Bonus: kills the `print_from_laptop` STAFF_PRIVACY false-positive — safely
Printing now points to the page instead of summarizing it, so it no longer dumps the page's support emails that tripped the ≥2-email guard. The deterministic ≥2-email PII backstop is **deliberately left unchanged**: its only known false-positive is eliminated upstream, and adding TitleCase-name NER to the post-processor would regress "Edward King"/"Freedom Summer"/"Gardner Harvey"-style answers (worse, not better). Enforce-in-code for names-only lives in: gold #59 + judge #61 scoring it + rule 9.

### Verification
- `py_compile` clean; `src.prompts.test_builder` **9/9** (prefix re-registers + clears the 1024-token threshold, ~3191 tok)
- EXAMPLE 4 answer + sources verified price-free

🤖 Generated with [Claude Code](https://claude.com/claude-code)