### PR TITLE
fix(hours): explain a far/holiday date can't be looked up live

### DIFF
--- a/ai-core/src/graph/new_orchestrator.py
+++ b/ai-core/src/graph/new_orchestrator.py
@@ -651,11 +651,20 @@ def _long_period_hours_response(
     (rule B). Deterministic, zero-LLM, cited -> the URL is real and
     verified so it passes any downstream URL check."""
     url = _HOURS_PAGE_URL.get(scope.campus, _HOURS_PAGE_URL["oxford"])
+    # Operator ruling 2026-05-17 (hr_thanksgiving): for a specific
+    # holiday / far-off date the bot must EXPLAIN that the date is
+    # beyond what it can check live and hand the lookup back to the
+    # user -- not just drop a URL. (The complementary "<=1 month away
+    # -> resolve the date + live LibCal lookup" branch is a deferred
+    # follow-up: it needs a named-date/relative-date resolver and a
+    # LibCal single-date call, which triggers the model/API freshness
+    # rule. No current gold case exercises it; not bundled here.)
     msg = (
-        "Library hours vary by term, break, and holiday, so the most "
-        "reliable place to see them for a date range is the hours "
-        f"page: {url} -- it always shows the current and upcoming "
-        "schedule."
+        "That's further out than I can look up live -- my hours check "
+        "only covers the near term, and the schedule shifts by term, "
+        "break, and holiday, so I can't reliably tell you that date "
+        "myself. The library's hours page always shows the current and "
+        f"upcoming schedule, so please check the date you need there: {url}."
     )
     return TurnResponse(
         answer=msg,


### PR DESCRIPTION
## Operator ruling — hr_thanksgiving (last of the 4 behavioral fixes)

For a specific holiday / far-off date the bot must **explain** the date is beyond its live window and hand the lookup back to the user — not just drop a URL. Old rule-B copy pointed to the hours page correctly but never said *"I can't check that date live, please look it up yourself"* (what you ruled, and what the corrected gold in #59 now expects).

### Change
**Message copy only.** Routing is unchanged — `thanksgiving`/holidays/months already short-circuit to the hours PAGE; `today/tonight/now/tomorrow` still veto → live LibCal. New copy:

> *"That's further out than I can look up live — my hours check only covers the near term, and the schedule shifts by term, break, and holiday, so I can't reliably tell you that date myself. The library's hours page always shows the current and upcoming schedule, so please check the date you need there: {url}."*

### Deliberately deferred (documented inline, flagged to you)
The complementary **"≤1 month away → resolve the named/relative date + live LibCal single-date lookup"** branch is a real feature (date resolver + LibCal single-date call → triggers the model/API freshness rule) and **no current gold case exercises it** (Thanksgiving 2026 is ~6 months from the 2026-05-17 eval date → the >1mo branch). Bundling it speculatively would violate better-not-worse / one-concern. Separate follow-up.

### Verification
- `py_compile` clean; `src.graph.test_new_orchestrator` **27/27** (long-period tests assert structural props — `point_to_url`, hours-page URL, zero tokens, not-refusal — *not* the message string, so the copy change is safe)
- Smoke: "Are you open Thanksgiving day?" → long-period=True; "summer hours" → True; "open right now" → False (live LibCal, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)