### PR TITLE
feat(etl+scope): index circulation recall/SWORD subpages + SWORD student aliases

### DIFF
--- a/ai-core/scripts/etl/config.py
+++ b/ai-core/scripts/etl/config.py
@@ -232,6 +232,25 @@ LIBGUIDE_SEED: Final[tuple[tuple[str, str, str, Optional[str]], ...]] = (
      "all", "all", None),
     ("https://libguides.lib.miamioh.edu/mul-circulation-policies",
      "all", "all", None),
+    # Circulation-policy SUBPAGES students actually ask about. The seed
+    # registry is non-recursive (curated > bulk), so seeding the parent
+    # guide above does NOT pull these in -- each subpage is its own URL
+    # and must be listed explicitly. All university-wide ("all"/"all"):
+    # they're Miami circulation policy, not a single campus's content
+    # (recall-request even has a dedicated SWORD/depository section).
+    #   - recall-request: students ask via "SWOD" / "SW deposit" /
+    #     "SW depository" / "recall"; covers SWORD remote-storage
+    #     retrieval (2-3 business days) + hold-shelf timelines.
+    #   - loan-periods-fines / loan-periods-ohiolink-ill: the two
+    #     distinct renewal paths the operator ruled for renew_basic
+    #     (Miami materials vs OhioLINK/ILL); gold #59 cites these.
+    # All three HEAD-verified 200, no redirect, 2026-05-17.
+    ("https://libguides.lib.miamioh.edu/mul-circulation-policies/recall-request",
+     "all", "all", None),
+    ("https://libguides.lib.miamioh.edu/mul-circulation-policies/loan-periods-fines",
+     "all", "all", None),
+    ("https://libguides.lib.miamioh.edu/mul-circulation-policies/loan-periods-ohiolink-ill",
+     "all", "all", None),
     ("https://libguides.lib.miamioh.edu/reserves-textbooks/",
      "all", "all", None),
 )

--- a/ai-core/src/scope/aliases.py
+++ b/ai-core/src/scope/aliases.py
@@ -149,6 +149,15 @@ LIBRARY_ALIASES: dict[str, Library] = {
     "regional depository": "sword",
     "the depository": "sword",
     "sword": "sword",
+    # Common student phrasings / misspellings (operator-reported:
+    # students ask about recalls/circulation using these). Bare
+    # "depository" is unambiguous in this domain -> SWORD. "sw deposit"
+    # carries the "sw " prefix so it can't collide with general
+    # "deposit" usage (e.g. thesis deposit).
+    "swod": "sword",
+    "sw depository": "sword",
+    "sw deposit": "sword",
+    "depository": "sword",
 }
 
 CAMPUS_ALIASES: dict[str, Campus] = {


### PR DESCRIPTION
## Why

You reported students ask circulation questions via **"SWOD" / "SW deposit" / "SW depository"** and about recalls. The canonical content is the `mul-circulation-policies/recall-request` subpage — WebFetched 2026-05-17, it has a dedicated **SWORD / Southwest Ohio Regional Depository** section (remote storage, 2–3 business-day retrieval, hold-shelf timelines).

## What

**`LIBGUIDE_SEED` is non-recursive** (curated > bulk by design), so the already-seeded parent `mul-circulation-policies` does *not* index its subpages. Added 3 subpages, each university-wide (`"all"/"all"`), all **HEAD-verified 200, no redirect 2026-05-17**:

- `…/recall-request` — this report (SWOD/recall + the depository section)
- `…/loan-periods-fines` + `…/loan-periods-ohiolink-ill` — completes the **renew_basic** ruling (gold #59 cites these two distinct renewal paths). Bundled because it's the same registry, same concern, and **one** operator ETL reindex picks up all three.

**SWORD aliases** (`src/scope/aliases.py`): added `swod`, `sw depository`, `sw deposit`, and bare `depository` → `sword`. Deliberately **not** bare `deposit` (would collide with thesis/scholarly deposit) — `sw deposit` keeps the `sw ` prefix. Smoke-verified `"where do I deposit my dissertation"` still → `oxford/None` (no false-collision); `"recall a SWOD book"` / `"SW depository"` / `"the depository"` → `middletown/sword`.

## Verification

- `py_compile` clean
- Offline suites that exercise this: **test_discover 34/34** (iterates `LIBGUIDE_SEED` dynamically — no pinned count), **test_classify 40/40**, **test_scope_filter 8/8**, **test_capability_scope 30/30**
- `test_policy_routing` is a **live-Weaviate integration test**, env-blocked here: every failure is `Connection refused (127.0.0.1:8888)`, zero routing-assertion failures. A data-only config/alias change cannot cause a socket error — not a regression.

## Operator action

Takes effect on the **next ETL `--phase prepare → apply`** (the 3 new seed URLs get crawled + indexed). Same reindex that was already pending for the renewal subpages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)