### PR TITLE
feat(op3): backend Sentry error tracking (no-op until DSN configured)

### DIFF
--- a/ai-core/pyproject.toml
+++ b/ai-core/pyproject.toml
@@ -26,7 +26,8 @@ dependencies = [
   "holidays",
   "dateparser",
   "aiohttp",
-  "beautifulsoup4"
+  "beautifulsoup4",
+  "sentry-sdk[fastapi]"
 ]
 
 [tool.pyright]

--- a/ai-core/src/main.py
+++ b/ai-core/src/main.py
@@ -42,6 +42,7 @@ from src.api.readiness_router import (
     make_libcal_probe,
 )
 from src.api.admin.smoketest_router import build_smoketest_router
+from src.observability.sentry import init_sentry
 
 # ---------------------------------------------------------------------------
 # .env loading — MUST NOT follow symlinks on production
@@ -73,6 +74,13 @@ print(f"Loading .env from: {env_path}")
 setup_logging()
 logging.info(f"📂 .env loaded from: {env_path}  (root_dir={root_dir})")
 logging.info(f"📂 __file__ resolved WITHOUT symlinks: {_this_file}")
+
+# Op 3 (non-negotiable launch floor): wire Sentry BEFORE the FastAPI
+# app is created so sentry-sdk's auto-enabled FastAPI/Starlette
+# integration instruments the whole request path. No-op unless
+# SENTRY_DSN is set AND sentry-sdk is installed -- merging this is a
+# zero-behavior-change until an operator configures the DSN.
+init_sentry()
 
 
 def json_serializable(obj):

--- a/ai-core/src/observability/sentry.py
+++ b/ai-core/src/observability/sentry.py
@@ -1,0 +1,124 @@
+"""
+Sentry error tracking for the FastAPI backend.
+
+Plan: Operations -> Op 3 -> "Exception tracking. Sentry ... on both
+FastAPI backend and React frontend." Listed as NON-NEGOTIABLE on day
+one of launch (Op 3 minimum viable version + robustness-ladder Gap 6):
+without it, errors don't surface until a user complains about a 500.
+
+Design contract (so this is safe to merge BEFORE any DSN exists and
+BEFORE the sentry-sdk dependency is installed):
+
+  * No `SENTRY_DSN` env  -> complete no-op (returns False).
+  * `sentry_sdk` not importable -> complete no-op (returns False),
+    one INFO line, never raises. The dependency is declared in
+    pyproject, but the runtime guard means a not-yet-`pip install`ed
+    environment (CI, a dev box, the operator mid-upgrade) still boots
+    the app identically.
+  * Idempotent: a second call is a no-op (uvicorn --reload / test
+    re-import won't double-init).
+
+So merging this changes runtime behavior by exactly zero until an
+operator sets SENTRY_DSN. "Better, not worse" by construction.
+
+Privacy: `send_default_pii=False` — this bot handles student
+questions; we do NOT want message bodies / IPs shipped to a third
+party. Error type + stack trace + release tag is the signal; the
+content is not.
+
+Tracing: `traces_sample_rate` defaults to 0.0 (errors only). Perf
+tracing is opt-in via env because it adds request volume/cost and the
+day-one need is "we find out about exceptions", not APM.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Module-level idempotency guard. uvicorn --reload, pytest re-imports,
+# and a defensive double-call from main all must not re-init Sentry
+# (sentry_sdk tolerates it but we keep the contract explicit + cheap).
+_INITIALIZED = False
+
+
+def _env(name: str, default: str = "") -> str:
+    return (os.getenv(name) or default).strip()
+
+
+def init_sentry() -> bool:
+    """Initialize Sentry if (and only if) a DSN is configured and the
+    SDK is importable. Returns True iff Sentry is now active.
+
+    Call ONCE, as early as possible in process startup (before the
+    FastAPI app object is created) so sentry-sdk's auto-enabled
+    FastAPI/Starlette integration instruments the whole request path.
+    """
+    global _INITIALIZED
+    if _INITIALIZED:
+        return True
+
+    dsn = _env("SENTRY_DSN")
+    if not dsn:
+        logger.info("Sentry disabled: SENTRY_DSN not set (no-op).")
+        return False
+
+    try:
+        import sentry_sdk  # type: ignore
+    except Exception as e:  # noqa: BLE001 -- ImportError or partial install
+        # Declared in pyproject; if it's somehow not installed we must
+        # NOT take the app down for a missing observability dep.
+        logger.warning(
+            "Sentry DSN set but sentry-sdk unavailable (%s); skipping. "
+            "`pip install 'sentry-sdk[fastapi]'` to enable.",
+            e,
+        )
+        return False
+
+    # Environment + release are best-effort tags. NODE_ENV is what the
+    # rest of main.py already keys CORS off, so reuse it for parity.
+    environment = (
+        _env("SENTRY_ENVIRONMENT")
+        or _env("NODE_ENV", "development")
+    )
+    release: Optional[str] = _env("SENTRY_RELEASE") or None
+
+    try:
+        traces_sample_rate = float(_env("SENTRY_TRACES_SAMPLE_RATE", "0.0"))
+    except ValueError:
+        traces_sample_rate = 0.0
+
+    try:
+        # Minimal init: let sentry-sdk auto-enable the FastAPI/Starlette
+        # integrations (it detects them). We deliberately do NOT hard-
+        # import a specific integration module path -- those move
+        # between sentry-sdk majors and a bad import here would defeat
+        # the whole "never take the app down for observability" rule.
+        sentry_sdk.init(
+            dsn=dsn,
+            environment=environment,
+            release=release,
+            traces_sample_rate=traces_sample_rate,
+            # Privacy: never ship message bodies / headers / IPs.
+            send_default_pii=False,
+        )
+    except Exception as e:  # noqa: BLE001 -- never let telemetry crash boot
+        logger.warning("Sentry init failed (%s); continuing without it.", e)
+        return False
+
+    _INITIALIZED = True
+    logger.info(
+        "Sentry initialized (env=%s, release=%s, traces=%.3f).",
+        environment, release or "(unset)", traces_sample_rate,
+    )
+    return True
+
+
+def is_initialized() -> bool:
+    """True iff `init_sentry()` successfully activated Sentry. Lets
+    tests / health surfaces report Sentry status without poking
+    sentry_sdk internals."""
+    return _INITIALIZED

--- a/ai-core/src/observability/test_sentry.py
+++ b/ai-core/src/observability/test_sentry.py
@@ -1,0 +1,110 @@
+"""
+Unit tests for src.observability.sentry.
+
+Run: `python -m src.observability.test_sentry` from ai-core/.
+
+These verify the load-bearing SAFETY contract -- the reason this is
+mergeable before any DSN/dependency exists:
+
+  1. No DSN            -> no-op, returns False, never raises.
+  2. Blank/whitespace DSN -> treated as no DSN.
+  3. DSN set but sentry-sdk unimportable -> no-op, returns False,
+     never raises (the app must boot even if the obs dep is missing).
+  4. Idempotent: a second call short-circuits to True without
+     re-reading env or re-importing the SDK.
+
+Hermetic: NONE of these call `sentry_sdk.init` (no DSN / forced
+ImportError / idempotent short-circuit), so the suite passes whether
+or not sentry-sdk is installed in the venv and never mutates real
+Sentry global state.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_AI_CORE = _HERE.parent.parent
+sys.path.insert(0, str(_AI_CORE))
+
+from src.observability import sentry as S
+
+
+def _reset(monkeypatch_env: dict | None = None) -> None:
+    """Reset module init state + scrub Sentry env for a clean test."""
+    S._INITIALIZED = False
+    import os
+    for k in (
+        "SENTRY_DSN", "SENTRY_ENVIRONMENT", "SENTRY_RELEASE",
+        "SENTRY_TRACES_SAMPLE_RATE", "NODE_ENV",
+    ):
+        os.environ.pop(k, None)
+    for k, v in (monkeypatch_env or {}).items():
+        os.environ[k] = v
+
+
+def test_no_dsn_is_noop() -> None:
+    _reset()
+    assert S.init_sentry() is False
+    assert S.is_initialized() is False
+
+
+def test_blank_dsn_is_noop() -> None:
+    _reset({"SENTRY_DSN": "   "})
+    assert S.init_sentry() is False
+    assert S.is_initialized() is False
+
+
+def test_import_guard_when_sdk_missing_does_not_raise() -> None:
+    """DSN set but `import sentry_sdk` fails -> the app must still boot.
+    Setting sys.modules['sentry_sdk']=None makes `import sentry_sdk`
+    raise ImportError, simulating a not-installed dependency."""
+    _reset({"SENTRY_DSN": "https://abc@o0.ingest.sentry.io/0"})
+    saved = sys.modules.get("sentry_sdk", "MISSING")
+    sys.modules["sentry_sdk"] = None  # forces ImportError on import
+    try:
+        result = S.init_sentry()  # must NOT raise
+    finally:
+        if saved == "MISSING":
+            sys.modules.pop("sentry_sdk", None)
+        else:
+            sys.modules["sentry_sdk"] = saved
+    assert result is False
+    assert S.is_initialized() is False
+
+
+def test_idempotent_short_circuits() -> None:
+    """If already initialized, a second call returns True immediately
+    without touching env or the SDK (uvicorn --reload / re-import)."""
+    _reset()
+    S._INITIALIZED = True
+    assert S.init_sentry() is True
+    assert S.is_initialized() is True
+    _reset()  # leave global state clean for any later test
+
+
+def main() -> int:
+    tests = [
+        test_no_dsn_is_noop,
+        test_blank_dsn_is_noop,
+        test_import_guard_when_sdk_missing_does_not_raise,
+        test_idempotent_short_circuits,
+    ]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

Plan **Op 3 / Gap 6**: Sentry is flagged **non-negotiable for launch day** — without it, backend errors don't surface until a user reports a 500. Survey of the current app showed it was the **single biggest genuine Op 3 gap**: `grep sentry` across `ai-core` → nothing. (`/health/ready` with 4 probes and `/smoketest` were already wired — further along than the plan's "scaffolded" language implied.)

## What

- New `src/observability/sentry.py::init_sentry()`, called in `main.py` **before** the FastAPI app is created so sentry-sdk's auto-enabled FastAPI/Starlette integration instruments the whole request path.
- `sentry-sdk[fastapi]` declared in `pyproject.toml`.

## Safe to merge now — zero behavior change until a DSN exists

| Condition | Behavior |
|---|---|
| `SENTRY_DSN` unset | complete no-op, returns `False` |
| sentry-sdk not installed | no-op + one WARN, **never raises** (app still boots) |
| called twice | idempotent (uvicorn `--reload` / test re-import safe) |

Privacy: `send_default_pii=False` (no message bodies/IPs shipped — this bot handles student questions). Tracing `traces_sample_rate=0.0` (errors only; perf APM opt-in via env).

## Verification (fully offline — no API, no DSN)

- `py_compile` clean **including `main.py`** with the new import+call
- `src.observability.test_sentry` **4/4**: no-DSN no-op, blank-DSN, import-guard-when-sdk-missing, idempotent
- no-op smoke: `init_sentry()` → `False`, inactive, without a DSN

## Scope

**Backend only.** Frontend Sentry follows as a separate PR — it needs an `npm install @sentry/react` + Vite build check I can't run in this environment, and bundling a verified change with an unverifiable one violates one-concern-per-PR. Operator enables both later by setting `SENTRY_DSN` / `VITE_SENTRY_DSN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)