### PR TITLE
feat(op3): expose /metrics + time the HTTP layer (orphaned module wired)

### DIFF
--- a/ai-core/pyproject.toml
+++ b/ai-core/pyproject.toml
@@ -26,7 +26,8 @@ dependencies = [
   "holidays",
   "dateparser",
   "aiohttp",
-  "beautifulsoup4"
+  "beautifulsoup4",
+  "prometheus-client"
 ]
 
 [tool.pyright]

--- a/ai-core/src/api/metrics_router.py
+++ b/ai-core/src/api/metrics_router.py
@@ -1,0 +1,60 @@
+"""
+GET /metrics -- Prometheus exposition endpoint (plan Op 3 "Metrics").
+
+`src/observability/metrics.py` already DEFINES the counters/histograms
+and the record_* recording API, and the v2 orchestrator already calls
+them -- but nothing EXPOSED them for Prometheus to scrape and nothing
+timed the HTTP layer. This router (plus MetricsMiddleware) closes that
+"module exists, orphaned" gap.
+
+Follows the dependency-injected `build_*_router(deps)` convention used
+by readiness_router / smoketest_router, including the FastAPI-missing
+`_Placeholder` fallback so a dev/sandbox import never crashes.
+
+Safe by construction: `render_latest()` no-ops to a self-explaining
+plaintext 200 when prometheus_client isn't installed, so mounting
+this changes nothing until the (pyproject-declared) dep is present.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from src.observability.metrics import render_latest
+
+
+def build_metrics_router(deps: Optional[dict] = None) -> Any:
+    """Build the /metrics router.
+
+    `deps` is unused today (the endpoint is pure exposition) but kept
+    for parity with the other build_*_router factories and so a future
+    custom registry can be injected in tests without a signature break.
+    """
+    try:
+        from fastapi import APIRouter  # type: ignore
+        from fastapi.responses import Response  # type: ignore
+    except ImportError:
+        return _Placeholder("/metrics")
+
+    router = APIRouter(tags=["ops"])
+
+    @router.get("/metrics")
+    async def metrics() -> Any:
+        body, content_type = render_latest()
+        # Always 200: a scrape endpoint that 500s just turns one
+        # outage into two (the app's AND the monitoring's). The body
+        # self-describes when prometheus_client is absent.
+        return Response(content=body, media_type=content_type)
+
+    return router
+
+
+class _Placeholder:
+    """FastAPI-not-installed fallback so `import` doesn't crash dev."""
+
+    def __init__(self, prefix: str) -> None:
+        self.prefix = prefix
+        self.routes: list = []
+
+
+__all__ = ["build_metrics_router"]

--- a/ai-core/src/main.py
+++ b/ai-core/src/main.py
@@ -42,6 +42,8 @@ from src.api.readiness_router import (
     make_libcal_probe,
 )
 from src.api.admin.smoketest_router import build_smoketest_router
+from src.api.metrics_router import build_metrics_router
+from src.observability.metrics_middleware import MetricsMiddleware
 
 # ---------------------------------------------------------------------------
 # .env loading — MUST NOT follow symlinks on production
@@ -211,6 +213,11 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+# Op 3 (Metrics): time every request -> chatbot_request_* metrics.
+# No-ops invisibly until prometheus-client is installed; excludes the
+# /metrics + /health/live infra polls so they don't skew the signal.
+app.add_middleware(MetricsMiddleware)
+
 # Include health/monitoring routers
 app.include_router(health_router)
 app.include_router(summarize_router)
@@ -320,6 +327,10 @@ def _smoketest_ask_bot(question: str) -> dict:
 
 
 app.include_router(build_smoketest_router({"ask_bot": _smoketest_ask_bot}))
+
+# Op 3: Prometheus scrape target. Self-describes a 200 when
+# prometheus-client isn't installed (never 500s a scrape).
+app.include_router(build_metrics_router())
 
 
 # Socket.IO server for real-time communication

--- a/ai-core/src/observability/metrics.py
+++ b/ai-core/src/observability/metrics.py
@@ -164,9 +164,43 @@ def record_refusal(*, trigger: str) -> None:
     _metrics["refusal_count"].labels(trigger=trigger).inc()
 
 
+# Plaintext shown at /metrics when prometheus_client isn't installed.
+# A 200 with a self-explaining body beats a 500 -- a scrape failure
+# should say WHY, and the endpoint must never take a worker down.
+_METRICS_UNAVAILABLE = (
+    b"# prometheus_client not installed; metrics disabled.\n"
+    b"# `pip install prometheus-client` (declared in pyproject) to enable.\n"
+)
+_PLAINTEXT = "text/plain; charset=utf-8"
+
+
+def render_latest() -> tuple[bytes, str]:
+    """Return `(body, content_type)` for the /metrics endpoint.
+
+    Single lazy-detection point for the prometheus exposition side,
+    mirroring `_ensure_metrics()` for the recording side: if the lib
+    isn't importable we hand back a self-explaining plaintext body
+    (never raise -- a metrics scrape must not be able to 500 a
+    worker). Content type is the Prometheus exposition format when
+    available so Prometheus parses it correctly.
+    """
+    if not _ensure_metrics():
+        return _METRICS_UNAVAILABLE, _PLAINTEXT
+    try:
+        from prometheus_client import (  # type: ignore
+            CONTENT_TYPE_LATEST,
+            generate_latest,
+        )
+
+        return generate_latest(), CONTENT_TYPE_LATEST
+    except Exception:  # noqa: BLE001 -- never let a scrape crash the app
+        return _METRICS_UNAVAILABLE, _PLAINTEXT
+
+
 __all__ = [
     "record_llm_call",
     "record_refusal",
     "record_request",
     "record_tool_call",
+    "render_latest",
 ]

--- a/ai-core/src/observability/metrics_middleware.py
+++ b/ai-core/src/observability/metrics_middleware.py
@@ -1,0 +1,73 @@
+"""
+HTTP request-metrics middleware (plan Op 3: "Per HTTP endpoint:
+request rate, latency p50/p95/p99, error rate").
+
+`metrics.py` defines the counters and `record_request()`, but nothing
+timed the HTTP layer -- the v2 orchestrator records its own turn, yet
+the FastAPI request boundary (every endpoint, the legacy /ask path,
+errors) was unmeasured. This middleware closes that.
+
+Design rules:
+  * Label `endpoint` with the matched ROUTE TEMPLATE (e.g.
+    `/health/ready`), never the raw path -- raw paths carry
+    conversation ids and would explode Prometheus cardinality.
+    Unmatched (404) collapses to a single `<unmatched>` label.
+  * Telemetry must never break a request: the record_request call is
+    wrapped; an exception in the handler is recorded as status 500
+    and then RE-RAISED (Sentry / error handling must still see it).
+  * Skip the high-frequency infra polls (`/metrics` scrape every
+    ~15s, `/health/live` liveness every few s) -- counting them
+    drowns real-traffic rate/latency signal. Standard scrape hygiene.
+"""
+
+from __future__ import annotations
+
+import time
+
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from src.observability.metrics import record_request
+
+# Infra polling endpoints excluded from request metrics so they don't
+# dominate rate/latency. Matched against the resolved route template.
+_SKIP_ENDPOINTS = frozenset({"/metrics", "/health/live"})
+
+
+def _endpoint_label(request) -> str:
+    """Low-cardinality label: the matched route's path template, or
+    `<unmatched>` for 404s (never the raw URL path)."""
+    route = request.scope.get("route")
+    path = getattr(route, "path", None)
+    return path or "<unmatched>"
+
+
+class MetricsMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        start = time.perf_counter()
+        try:
+            response = await call_next(request)
+        except Exception:
+            # Handler blew up: record as a 500 for this endpoint, then
+            # re-raise so the normal error path + Sentry still fire.
+            latency_s = time.perf_counter() - start
+            self._safe_record(request, "500", latency_s)
+            raise
+
+        latency_s = time.perf_counter() - start
+        self._safe_record(request, str(response.status_code), latency_s)
+        return response
+
+    @staticmethod
+    def _safe_record(request, status: str, latency_s: float) -> None:
+        try:
+            endpoint = _endpoint_label(request)
+            if endpoint in _SKIP_ENDPOINTS:
+                return
+            record_request(
+                endpoint=endpoint, status=status, latency_s=latency_s
+            )
+        except Exception:  # noqa: BLE001 -- telemetry never breaks a request
+            return
+
+
+__all__ = ["MetricsMiddleware"]

--- a/ai-core/src/observability/test_metrics_endpoint.py
+++ b/ai-core/src/observability/test_metrics_endpoint.py
@@ -1,0 +1,140 @@
+"""
+Offline tests for the /metrics endpoint + MetricsMiddleware.
+
+Run: `python -m src.observability.test_metrics_endpoint` from ai-core/.
+
+prometheus_client is intentionally NOT a hard requirement, so in this
+venv it's absent -- which is exactly the merge-safety path we most
+need to prove:
+
+  1. /metrics serves a self-describing plaintext 200 (never 500s a
+     scrape) when prometheus_client is missing.
+  2. render_latest() returns (bytes, str) and never raises.
+  3. The middleware never breaks a normal request.
+  4. A handler exception still PROPAGATES (telemetry must not swallow
+     errors -- Sentry / error handling must still see them).
+  5. Endpoint labels are low-cardinality (route template, or the
+     single `<unmatched>` bucket for 404s) -- never the raw path.
+  6. The infra-poll skip set excludes /metrics and /health/live.
+
+Uses Starlette's TestClient (httpx-backed) -- no network, no API.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_AI_CORE = _HERE.parent.parent
+sys.path.insert(0, str(_AI_CORE))
+
+from src.observability.metrics import render_latest
+from src.observability.metrics_middleware import (
+    MetricsMiddleware,
+    _SKIP_ENDPOINTS,
+    _endpoint_label,
+)
+
+
+def _app():
+    from fastapi import FastAPI
+    from src.api.metrics_router import build_metrics_router
+
+    app = FastAPI()
+    app.add_middleware(MetricsMiddleware)
+    app.include_router(build_metrics_router())
+
+    @app.get("/ok")
+    async def ok():
+        return {"ok": True}
+
+    @app.get("/boom")
+    async def boom():
+        raise RuntimeError("handler exploded")
+
+    return app
+
+
+def _client():
+    from starlette.testclient import TestClient
+
+    return TestClient(_app())
+
+
+def test_metrics_endpoint_200_and_safe_without_prometheus() -> None:
+    r = _client().get("/metrics")
+    assert r.status_code == 200, r.status_code
+    assert r.headers["content-type"].startswith("text/plain")
+    assert "prometheus_client not installed" in r.text
+
+
+def test_render_latest_contract() -> None:
+    body, ctype = render_latest()
+    assert isinstance(body, (bytes, bytearray)), type(body)
+    assert isinstance(ctype, str) and ctype
+
+
+def test_normal_request_unaffected_by_middleware() -> None:
+    r = _client().get("/ok")
+    assert r.status_code == 200
+    assert r.json() == {"ok": True}
+
+
+def test_handler_exception_still_propagates() -> None:
+    """Telemetry must not swallow errors. TestClient re-raises server
+    exceptions by default; the middleware records a 500 then re-raises,
+    so this must surface the original RuntimeError."""
+    raised = False
+    try:
+        _client().get("/boom")
+    except RuntimeError as e:
+        raised = "handler exploded" in str(e)
+    except Exception:  # noqa: BLE001
+        raised = True  # some wrapping is fine; swallowing is not
+    assert raised, "middleware swallowed a handler exception"
+
+
+def test_endpoint_label_low_cardinality() -> None:
+    class _R:
+        path = "/use/{slug}"
+
+    class _Req:
+        def __init__(self, scope):
+            self.scope = scope
+
+    assert _endpoint_label(_Req({"route": _R()})) == "/use/{slug}"
+    assert _endpoint_label(_Req({})) == "<unmatched>"
+
+
+def test_infra_polls_are_skipped() -> None:
+    assert "/metrics" in _SKIP_ENDPOINTS
+    assert "/health/live" in _SKIP_ENDPOINTS
+
+
+def main() -> int:
+    tests = [
+        test_metrics_endpoint_200_and_safe_without_prometheus,
+        test_render_latest_contract,
+        test_normal_request_unaffected_by_middleware,
+        test_handler_exception_still_propagates,
+        test_endpoint_label_low_cardinality,
+        test_infra_polls_are_skipped,
+    ]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

Plan **Op 3 "Metrics"**: `src/observability/metrics.py` already defined the counters and the `record_*` API, and the v2 orchestrator already called them — but **nothing exposed them for Prometheus to scrape, and nothing timed the FastAPI request boundary**. Classic "module exists, orphaned" gap from the robustness ladder.

## What

- **`metrics.py`** → `render_latest() -> (body, content_type)`. Single lazy exposition point mirroring `_ensure_metrics()`; real Prometheus format when `prometheus-client` is present, self-describing plaintext otherwise. Never raises.
- **`src/api/metrics_router.py`** → `build_metrics_router()` `GET /metrics`, following the readiness/smoketest `build_*_router` + `_Placeholder` DI convention. **Always 200** (a scrape that 500s turns one outage into two).
- **`src/observability/metrics_middleware.py`** → `MetricsMiddleware` times every request. Endpoint label = matched **route template** (never raw path → no Prometheus cardinality blow-up); 404 → `<unmatched>`. Handler exceptions recorded as `500` **then re-raised** (telemetry must not swallow errors). `/metrics` + `/health/live` infra-polls excluded so they don't drown real-traffic signal.
- **`main.py`** wiring; **`pyproject.toml`** declares `prometheus-client`.

## Merge-safe

Zero behavior change until `prometheus-client` is installed: `record_*` and `render_latest` both no-op, and `/metrics` serves a 200 that says so. Same safe-without-dep pattern as the Sentry PR.

## Verification (fully offline — no API)

- `py_compile` incl. `main.py`
- **`test_metrics_endpoint` 6/6**: 200-without-prometheus, render contract, normal request unaffected, **exception-still-propagates** (not swallowed), low-cardinality label, infra-skip
- existing **`test_metrics` 9/9** (no regression from `render_latest` + `__all__`)

## Independence

Separate branch off `main`; **not stacked** on the backend-Sentry PR (#65). No shared files contaminated — caught and corrected a working-tree mix mid-implementation before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)