### PR TITLE
feat(op3): frontend Sentry error tracking (no-op until DSN configured)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -15,6 +15,7 @@
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@sentry/react": "^8.0.0",
     "axios": "^1.13.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -6,6 +6,12 @@ import { SocketContextProvider } from './context/SocketContextProvider.jsx';
 import { MessageContextProvider } from './context/MessageContextProvider.jsx';
 import { Toaster } from '@/components/ui/sonner';
 import { TooltipProvider } from '@/components/ui/tooltip';
+import { initSentry } from './observability/sentry.js';
+
+// Fire-and-forget: no-ops without VITE_SENTRY_DSN. Not awaited --
+// blocking first paint on a dynamic import is worse UX than the few
+// ms before Sentry attaches; init() resolves near-immediately.
+initSentry();
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/client/src/observability/sentry.js
+++ b/client/src/observability/sentry.js
@@ -1,0 +1,60 @@
+// Frontend Sentry error tracking (plan Op 3 -> "Sentry browser SDK in
+// client/ for JS exceptions and source-mapped stack traces").
+// Counterpart to the backend src/observability/sentry.py; the plan
+// flags Sentry on BOTH backend and frontend as non-negotiable on
+// launch day -- without it, a broken deploy is reported by angry
+// students, not by us.
+//
+// Safety contract (so this is mergeable before a DSN exists):
+//   * No VITE_SENTRY_DSN          -> complete no-op.
+//   * @sentry/react fails to load -> caught, app still renders.
+//   * Idempotent (HMR / re-import safe).
+// Merging this changes runtime behavior by exactly zero until an
+// operator sets VITE_SENTRY_DSN.
+//
+// Privacy: sendDefaultPii:false -- this bot handles student questions;
+// we do not ship message bodies / IPs to a third party. Tracing
+// defaults to 0 (errors only); perf is opt-in via env.
+//
+// The @sentry/react import is dynamic so it's code-split OUT of the
+// main bundle and only fetched when a DSN is actually configured.
+
+let _initialized = false;
+
+export async function initSentry() {
+  if (_initialized) return true;
+
+  const dsn = import.meta.env.VITE_SENTRY_DSN;
+  if (!dsn) {
+    // Quiet by design: dev/preview without a DSN is the normal case.
+    return false;
+  }
+
+  try {
+    const Sentry = await import('@sentry/react');
+    let tracesSampleRate = Number(
+      import.meta.env.VITE_SENTRY_TRACES_SAMPLE_RATE ?? 0,
+    );
+    if (!Number.isFinite(tracesSampleRate)) tracesSampleRate = 0;
+
+    Sentry.init({
+      dsn,
+      environment: import.meta.env.MODE,
+      release: import.meta.env.VITE_SENTRY_RELEASE || undefined,
+      tracesSampleRate,
+      // Never ship message bodies / headers / IPs.
+      sendDefaultPii: false,
+    });
+    _initialized = true;
+    return true;
+  } catch (e) {
+    // A missing dep or a bad init must NOT take the chat UI down.
+    // eslint-disable-next-line no-console
+    console.warn('Sentry init skipped:', e?.message || e);
+    return false;
+  }
+}
+
+export function isSentryInitialized() {
+  return _initialized;
+}


### PR DESCRIPTION
## Why

Counterpart to backend Sentry (#65). Plan **Op 3** flags Sentry on **both** backend and frontend as non-negotiable for launch — without the browser SDK, a broken deploy or client JS exception is reported by angry students, not by us.

## What

- **`client/src/observability/sentry.js`** → `initSentry()`: gated on `VITE_SENTRY_DSN`; **dynamic** `import('@sentry/react')` so the SDK is code-split out of the main bundle and only fetched when a DSN is set; idempotent; never throws (a missing dep / bad init must not take the chat UI down). `sendDefaultPii:false`; tracing default `0` (errors only).
- **`client/src/main.jsx`**: `initSentry()` before render, fire-and-forget (blocking first paint on a dynamic import is worse UX than the few-ms gap before Sentry attaches).
- **`client/package.json`**: `@sentry/react` declared.

Merge-safe: zero behavior change until an operator sets `VITE_SENTRY_DSN`.

## Verified here (offline)

- `node --check client/src/observability/sentry.js` → syntax OK
- `client/package.json` still valid JSON
- `main.jsx` wiring present

## NOT verifiable in this environment — operator must do (flagged honestly, not claimed)

1. `npm install` — pulls `@sentry/react`. **The `^8.0.0` spec is a placeholder**; `npm install @sentry/react@latest` will pin the real current version + lockfile.
2. `npm run build` — confirm Vite resolves the dynamic import.
3. Set `VITE_SENTRY_DSN`, smoke that a thrown error lands in Sentry.

## Independence

Separate branch off `main`; not stacked on #65 or #66. Only touches `client/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)