### PR TITLE
feat(op3): per-request request_id middleware (close the structlog gap)

### DIFF
--- a/ai-core/src/main.py
+++ b/ai-core/src/main.py
@@ -42,6 +42,7 @@ from src.api.readiness_router import (
     make_libcal_probe,
 )
 from src.api.admin.smoketest_router import build_smoketest_router
+from src.observability.request_id_middleware import RequestIdMiddleware
 
 # ---------------------------------------------------------------------------
 # .env loading — MUST NOT follow symlinks on production
@@ -210,6 +211,12 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Op 3: bind one request_id per request so every structlog line in
+# the request carries it. Added LAST -> Starlette makes it the
+# OUTERMOST middleware, so the id is bound before anything else runs
+# and echoed back as X-Request-ID for user-report <-> log correlation.
+app.add_middleware(RequestIdMiddleware)
 
 # Include health/monitoring routers
 app.include_router(health_router)

--- a/ai-core/src/observability/request_id_middleware.py
+++ b/ai-core/src/observability/request_id_middleware.py
@@ -1,0 +1,69 @@
+"""
+Per-request request_id middleware (plan Op 3: "One request_id UUID
+generated at the FastAPI middleware layer, propagated through
+orchestrator -> tools -> LLM client -> memory writes. Every line
+carries it.").
+
+src/observability/logging.py already has new_request_id(),
+bind_request_context(), the ContextVar, and the structlog processor
+that merges request context into every line -- its bind_request_context
+docstring literally says "Call once at the FastAPI middleware
+boundary". That middleware just didn't exist: bind was only called
+inside the v2 orchestrator, so the legacy /ask path, every other
+endpoint, and any logging BEFORE the orchestrator runs had no
+request_id. This closes that.
+
+Behavior:
+  * Reuse an upstream X-Request-ID (proxy / distributed trace) ONLY
+    if it's safe -- ^[A-Za-z0-9._-]{1,128}$. A client-controlled
+    header that flows into every log line is a log-injection /
+    unbounded-value vector; reject anything else and mint a fresh id.
+  * Bind it before call_next so all structlog lines in the request
+    carry it; also expose on request.state.request_id.
+  * Echo it back as X-Request-ID so the browser / Sentry / curl can
+    correlate a user report to server logs.
+  * Telemetry never breaks a request: a handler exception is
+    re-raised (already bound, so the error log carries the id);
+    binding failure degrades to "no id" rather than 500.
+"""
+
+from __future__ import annotations
+
+import re
+
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from src.observability.logging import bind_request_context, new_request_id
+
+_HEADER = "X-Request-ID"
+# Conservative: ids appear verbatim in every log line. Bounded length,
+# log-safe charset. Anything else -> we mint our own.
+_SAFE_ID = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
+
+
+def _resolve_id(request) -> str:
+    incoming = request.headers.get(_HEADER, "")
+    if incoming and _SAFE_ID.match(incoming):
+        return incoming
+    return new_request_id()
+
+
+class RequestIdMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        rid = _resolve_id(request)
+        try:
+            bind_request_context(request_id=rid)
+            request.state.request_id = rid
+        except Exception:  # noqa: BLE001 -- never 500 over telemetry
+            pass
+
+        response = await call_next(request)
+
+        try:
+            response.headers[_HEADER] = rid
+        except Exception:  # noqa: BLE001
+            pass
+        return response
+
+
+__all__ = ["RequestIdMiddleware"]

--- a/ai-core/src/observability/test_request_id_middleware.py
+++ b/ai-core/src/observability/test_request_id_middleware.py
@@ -1,0 +1,131 @@
+"""
+Offline tests for RequestIdMiddleware.
+
+Run: `python -m src.observability.test_request_id_middleware` (ai-core/).
+
+Contract:
+  1. A response always carries X-Request-ID.
+  2. No/blank upstream header -> a fresh 32-hex id is minted.
+  3. A SAFE upstream id (proxy / distributed trace) is reused verbatim.
+  4. An UNSAFE upstream id (too long / bad chars / newline) is
+     rejected and a fresh id minted (log-injection / unbounded-value
+     defense).
+  5. The id reaches the handler BOTH via request.state.request_id AND
+     via the logging ContextVar (request_id_var) -- the latter guards
+     the known BaseHTTPMiddleware contextvar-propagation caveat; if
+     this assertion ever fails the middleware must become pure-ASGI.
+  6. A handler exception still propagates (telemetry never swallows).
+
+Starlette TestClient -- no network, no API, no DSN.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_AI_CORE = _HERE.parent.parent
+sys.path.insert(0, str(_AI_CORE))
+
+from fastapi import FastAPI, Request
+from starlette.testclient import TestClient
+
+from src.observability.logging import request_id_var
+from src.observability.request_id_middleware import RequestIdMiddleware
+
+_HEX32 = re.compile(r"^[0-9a-f]{32}$")
+
+
+def _client():
+    # NOTE: FastAPI resolves a handler's annotations against the
+    # MODULE globals, so `Request` MUST be imported at module scope --
+    # a function-local import makes `request: Request` unresolvable
+    # and FastAPI then treats it as a query param (422). This bit the
+    # first draft of this test; keep these imports at top level.
+    app = FastAPI()
+    app.add_middleware(RequestIdMiddleware)
+
+    @app.get("/echo")
+    async def echo(request: Request):
+        return {
+            "state": getattr(request.state, "request_id", None),
+            "ctx": request_id_var.get(),
+        }
+
+    @app.get("/boom")
+    async def boom():
+        raise RuntimeError("handler exploded")
+
+    return TestClient(app)
+
+
+def test_generates_id_when_absent() -> None:
+    r = _client().get("/echo")
+    assert r.status_code == 200
+    rid = r.headers.get("X-Request-ID")
+    assert rid and _HEX32.match(rid), rid
+
+
+def test_reuses_safe_upstream_id() -> None:
+    safe = "trace-abc.123_DEF"
+    r = _client().get("/echo", headers={"X-Request-ID": safe})
+    assert r.headers.get("X-Request-ID") == safe
+    assert r.json()["state"] == safe
+
+
+def test_rejects_unsafe_upstream_id() -> None:
+    for bad in ("x" * 200, "bad id with spaces", "inject\nlogline", "a;b|c"):
+        r = _client().get("/echo", headers={"X-Request-ID": bad})
+        out = r.headers.get("X-Request-ID")
+        assert out != bad and _HEX32.match(out or ""), (bad, out)
+
+
+def test_id_reaches_handler_state_and_contextvar() -> None:
+    r = _client().get("/echo")
+    body = r.json()
+    rid = r.headers["X-Request-ID"]
+    assert body["state"] == rid, ("state mismatch", body, rid)
+    # The load-bearing one: structlog lines emitted inside the handler
+    # only carry the id if the ContextVar propagated past
+    # BaseHTTPMiddleware. If this fails -> rewrite as pure ASGI.
+    assert body["ctx"] == rid, ("ContextVar did not propagate", body, rid)
+
+
+def test_handler_exception_still_propagates() -> None:
+    raised = False
+    try:
+        _client().get("/boom")
+    except RuntimeError as e:
+        raised = "handler exploded" in str(e)
+    except Exception:  # noqa: BLE001
+        raised = True
+    assert raised, "middleware swallowed a handler exception"
+
+
+def main() -> int:
+    tests = [
+        test_generates_id_when_absent,
+        test_reuses_safe_upstream_id,
+        test_rejects_unsafe_upstream_id,
+        test_id_reaches_handler_state_and_contextvar,
+        test_handler_exception_still_propagates,
+    ]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

Plan **Op 3**: *"One request_id UUID generated at the FastAPI middleware layer, propagated through orchestrator → tools → LLM client → memory writes. Every line carries it."*

`logging.py` already had `new_request_id()`, `bind_request_context()`, the ContextVar, and the structlog merge processor — its docstring even says *"Call once at the FastAPI middleware boundary"*. **That middleware didn't exist**: bind ran only inside the v2 orchestrator, so the legacy `/ask` path, every other endpoint, and any logging *before* the orchestrator had no request_id.

## What

`RequestIdMiddleware`:
- Reuses an upstream `X-Request-ID` **only if** `^[A-Za-z0-9._-]{1,128}$` (a client header that lands in every log line is a log-injection / unbounded-value vector) — else mints a fresh hex id.
- Binds before `call_next`; exposes `request.state.request_id`; echoes `X-Request-ID` back for user-report ↔ server-log correlation.
- Added **last** in `main.py` → Starlette makes it the **outermost** middleware (bound before anything else).
- Telemetry never breaks a request (bind failure → no-id; handler exception re-raised, not swallowed).

## Verified the BaseHTTPMiddleware ContextVar caveat does NOT bite here

Starlette 1.0.0: the test asserts the id reaches the handler via **both** `request.state` **and** `request_id_var` (the ContextVar) — so structlog lines emitted inside the handler/orchestrator carry the middleware-bound id. If a future Starlette regresses this, the test fails loudly and the middleware must go pure-ASGI.

## Verification (offline, no API)

- `py_compile` incl. `main.py`
- `test_request_id_middleware` **5/5**: generate-when-absent, reuse-safe-upstream, reject-unsafe-upstream, id-reaches-handler-state-**and**-contextvar, exception-still-propagates
- Transparency: the first test draft had a function-local `Request` import FastAPI couldn't resolve (→422); root-caused and fixed. The **middleware was correct throughout** (direct probe: 200 + header + contextvar propagation).

## Independence

Separate branch off `main`; no shared files with #65/#66/#67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)