### PR TITLE
feat(rollout): serve v2 orchestrator on its socket path (Gap 1, additive)

### DIFF
--- a/ai-core/src/graph/test_v2_serving.py
+++ b/ai-core/src/graph/test_v2_serving.py
@@ -1,0 +1,190 @@
+"""
+Offline tests for src.graph.v2_serving.
+
+Run: `python -m src.graph.test_v2_serving` from ai-core/.
+
+Covers the parts that MUST be correct and CAN be verified without
+OpenAI / Weaviate / Postgres:
+  * turnresponse_to_wire -- legacy keys preserved byte-for-byte;
+    additive v2 keys present; refusal -> needs_human; citations
+    sanitized; output is JSON-serializable.
+  * _extract_message -- str / dict / junk parsing parity with legacy.
+  * handle_v2_message -- builds the TurnRequest from the wire payload
+    + history and maps the result, using an INJECTED stub run_turn
+    (no network).
+
+`build_v2_deps()` is intentionally NOT executed here: it constructs a
+real classifier / tool backends (OpenAI + Weaviate + Postgres) and is
+the documented operator-verify boundary. We only assert it's importable
+and callable so a rename can't silently break the mount.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_AI_CORE = _HERE.parent.parent
+sys.path.insert(0, str(_AI_CORE))
+
+from src.graph.new_orchestrator import TurnResponse
+from src.graph import v2_serving as V
+
+
+def _resp(**over) -> TurnResponse:
+    base = dict(
+        answer="King opens at 7am [1].",
+        is_refusal=False,
+        refusal_trigger=None,
+        citations=[{"n": 1, "url": "https://x/y", "snippet": "7am"}],
+        confidence="high",
+        intent="hours",
+        scope={"campus": "oxford", "library": "king"},
+        model_used="gpt-5.4-mini",
+        tokens={"input": 10, "cached_input": 0, "output": 5},
+        fired_corrections=[],
+        agent_stopped_reason="answered",
+        latency_ms=42,
+        cited_chunk_ids=["c-1"],
+    )
+    base.update(over)
+    return TurnResponse(**base)
+
+
+def test_extract_message_parity() -> None:
+    assert V._extract_message("hi") == "hi"
+    assert V._extract_message({"message": "hi"}) == "hi"
+    assert V._extract_message({"nope": 1}) == ""
+    assert V._extract_message(None) == ""
+    assert V._extract_message(12345) == ""
+
+
+def test_wire_preserves_legacy_keys() -> None:
+    w = V.turnresponse_to_wire(_resp(), message_id="m1", conversation_id="c1")
+    # Exactly the keys the legacy React handler already reads.
+    for k in (
+        "messageId", "message", "conversationId", "intent",
+        "agents_used", "needs_human",
+    ):
+        assert k in w, f"missing legacy key {k}"
+    assert w["messageId"] == "m1"
+    assert w["conversationId"] == "c1"
+    assert w["message"] == "King opens at 7am [1]."
+    assert w["intent"] == "hours"
+    assert w["agents_used"] == ["answered"]
+    assert w["needs_human"] is False
+
+
+def test_wire_additive_v2_keys() -> None:
+    w = V.turnresponse_to_wire(_resp(), message_id=None, conversation_id="c")
+    assert w["confidence"] == "high"
+    assert w["is_refusal"] is False
+    assert w["citations"] == [
+        {"n": 1, "url": "https://x/y", "snippet": "7am"}
+    ]
+
+
+def test_refusal_sets_needs_human_and_flag() -> None:
+    w = V.turnresponse_to_wire(
+        _resp(is_refusal=True, refusal_trigger="no_results",
+              answer="I don't have a reliable answer.", citations=[]),
+        message_id="m", conversation_id="c",
+    )
+    assert w["needs_human"] is True
+    assert w["is_refusal"] is True
+    assert w["citations"] == []
+
+
+def test_wire_is_json_serializable() -> None:
+    w = V.turnresponse_to_wire(_resp(), message_id="m", conversation_id="c")
+    s = json.dumps(w)  # must not raise
+    assert json.loads(s)["message"] == "King opens at 7am [1]."
+
+
+def test_wire_sanitizes_non_dict_citations() -> None:
+    w = V.turnresponse_to_wire(
+        _resp(citations=[{"n": 1, "url": "u", "snippet": "s"}, "garbage", None]),
+        message_id="m", conversation_id="c",
+    )
+    assert w["citations"] == [{"n": 1, "url": "u", "snippet": "s"}]
+
+
+def test_handle_v2_message_builds_request_and_maps() -> None:
+    captured = {}
+
+    def stub_run_turn(req, deps):
+        captured["req"] = req
+        captured["deps"] = deps
+        return _resp(answer="stubbed [1].")
+
+    out = asyncio.run(
+        V.handle_v2_message(
+            {"message": "when does king open?"},
+            deps=object(),
+            conversation_id="conv-9",
+            message_id="mid-9",
+            conversation_history=[{"role": "user", "content": "hi"}],
+            run_turn_fn=stub_run_turn,
+        )
+    )
+    req = captured["req"]
+    assert req.user_message == "when does king open?"
+    assert req.conversation_id == "conv-9"
+    assert req.conversation_history == [{"role": "user", "content": "hi"}]
+    assert out["message"] == "stubbed [1]."
+    assert out["conversationId"] == "conv-9"
+    assert out["messageId"] == "mid-9"
+
+
+def test_handle_v2_message_accepts_bare_string() -> None:
+    def stub_run_turn(req, deps):
+        assert req.user_message == "bare"
+        return _resp()
+
+    out = asyncio.run(
+        V.handle_v2_message(
+            "bare", deps=object(), conversation_id="c",
+            run_turn_fn=stub_run_turn,
+        )
+    )
+    assert out["conversationId"] == "c"
+
+
+def test_build_v2_deps_importable_not_invoked() -> None:
+    # Operator-verify boundary: must exist + be callable, but we do
+    # NOT call it (it builds a real classifier / backends).
+    assert callable(V.build_v2_deps)
+
+
+def main() -> int:
+    tests = [
+        test_extract_message_parity,
+        test_wire_preserves_legacy_keys,
+        test_wire_additive_v2_keys,
+        test_refusal_sets_needs_human_and_flag,
+        test_wire_is_json_serializable,
+        test_wire_sanitizes_non_dict_citations,
+        test_handle_v2_message_builds_request_and_maps,
+        test_handle_v2_message_accepts_bare_string,
+        test_build_v2_deps_importable_not_invoked,
+    ]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ai-core/src/graph/v2_serving.py
+++ b/ai-core/src/graph/v2_serving.py
@@ -1,0 +1,184 @@
+"""
+v2 serving adapter: bridge the rebuilt orchestrator (`run_turn`) to the
+existing Socket.IO `"message"` wire contract the React app already
+speaks.
+
+Context (plan: Rollout "Behind a flag", robustness-ladder Gap 1):
+the frontend half is ALREADY done -- `services/RolloutFlag.js` routes
+flagged sessions to the `/smartchatbot/v2/socket.io` path, and
+`MessageContextProvider` + `ParseLinks`/`CitationChip` already render
+`{answer, citations:[{n,url,snippet}], confidence}`. What was missing
+is the BACKEND: nothing served that v2 socket path -- every entrypoint
+in main.py calls the legacy `library_graph`.
+
+This module is the seam. It is deliberately split so the part that
+MUST be correct is the part that is fully offline-testable:
+
+  * `turnresponse_to_wire()` -- PURE. Maps a `TurnResponse` to the
+    exact dict the legacy handler emits, PLUS the additive v2 keys
+    the frontend already consumes. Legacy keys are preserved verbatim
+    so the existing client code path is untouched. 100% unit-tested.
+
+  * `handle_v2_message()` -- the async turn flow (build TurnRequest
+    from the wire payload + history, call an injected `run_turn`,
+    map the result). `run_turn` is a parameter so tests inject a
+    stub -> no OpenAI / Weaviate / DB needed to verify the flow.
+
+  * `build_v2_deps()` -- constructs real `OrchestratorDeps`. This is
+    the ONLY part that cannot be verified offline (real OpenAI +
+    Weaviate + Postgres) and is bounded by Gap 10 (live tool
+    backends). It mirrors the PROVEN `run_eval._build_real_deps`
+    wiring rather than inventing one. Flagged for operator
+    live-verification; never claimed production-perfect.
+
+Nothing here imports or mutates the legacy path. Mounting it (main.py)
+is an additive ASGI wrap around the untouched legacy `socketio.ASGIApp`
+so legacy bytes are provably unchanged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Callable, Optional
+
+from src.graph.new_orchestrator import (
+    OrchestratorDeps,
+    TurnRequest,
+    TurnResponse,
+    run_turn,
+)
+
+
+def _extract_message(data: Any) -> str:
+    """Same parse the legacy `message` handler uses: accept a bare
+    string or `{"message": "..."}`."""
+    if isinstance(data, str):
+        return data
+    if isinstance(data, dict):
+        return data.get("message", "") or ""
+    return ""
+
+
+def turnresponse_to_wire(
+    resp: TurnResponse,
+    *,
+    message_id: Optional[str],
+    conversation_id: str,
+) -> dict:
+    """Map a `TurnResponse` to the Socket.IO `"message"` payload.
+
+    LEGACY KEYS (kept byte-for-byte so the existing React handler keeps
+    working): messageId, message, conversationId, intent, agents_used,
+    needs_human.
+
+    ADDITIVE v2 KEYS (the frontend already reads these when present --
+    see MessageContextProvider / ChatBotComponent): citations,
+    confidence. `needs_human` is driven by the refusal flag so a
+    refused turn surfaces the existing human-handoff widget.
+
+    Pure + JSON-safe by construction (str / list[dict] / bool only).
+    """
+    citations = [
+        {
+            "n": c.get("n"),
+            "url": c.get("url"),
+            "snippet": c.get("snippet"),
+        }
+        for c in (resp.citations or [])
+        if isinstance(c, dict)
+    ]
+    return {
+        "messageId": message_id,
+        "message": resp.answer or "",
+        "conversationId": conversation_id,
+        "intent": resp.intent,
+        # Legacy clients show a handoff affordance off `agents_used`/
+        # `needs_human`; a refusal is exactly when we want that.
+        "agents_used": [resp.agent_stopped_reason]
+        if resp.agent_stopped_reason
+        else [],
+        "needs_human": bool(resp.is_refusal),
+        # --- additive v2 keys (already consumed by the frontend) ---
+        "citations": citations,
+        "confidence": resp.confidence,
+        "is_refusal": bool(resp.is_refusal),
+    }
+
+
+async def handle_v2_message(
+    data: Any,
+    deps: OrchestratorDeps,
+    *,
+    conversation_id: str,
+    message_id: Optional[str] = None,
+    conversation_history: Optional[list[dict]] = None,
+    session_origin_url: Optional[str] = None,
+    run_turn_fn: Callable[..., TurnResponse] = run_turn,
+) -> dict:
+    """Run one v2 turn and return the wire payload.
+
+    `run_turn_fn` is injectable so unit tests exercise the full flow
+    with a stub (no OpenAI/Weaviate/DB). The real socket handler in
+    main.py owns conversation-store reads/writes + `sio.emit`, exactly
+    like the legacy handler -- this function is the pure middle.
+    """
+    text = _extract_message(data)
+    req = TurnRequest(
+        user_message=text,
+        conversation_id=conversation_id,
+        session_origin_url=session_origin_url,
+        conversation_history=conversation_history or [],
+    )
+    # run_turn is SYNC and a turn takes seconds; calling it directly in
+    # this async handler would block the whole event loop (every other
+    # socket client stalls). Offload to the default thread executor so
+    # concurrent turns don't serialize. In tests the injected stub is
+    # sync too -> runs in the executor just the same.
+    loop = asyncio.get_running_loop()
+    resp = await loop.run_in_executor(None, run_turn_fn, req, deps)
+    return turnresponse_to_wire(
+        resp, message_id=message_id, conversation_id=conversation_id
+    )
+
+
+def build_v2_deps() -> OrchestratorDeps:
+    """Construct real OrchestratorDeps for production v2 serving.
+
+    MIRRORS the proven `src/eval/run_eval.py::_build_real_deps`
+    construction (real classifier, the tools_v2 registry with real
+    backends, agent/synth LLM = None -> orchestrator's real-OpenAI
+    default). Scope/intent are NOT pre-resolved here (serving has no
+    gold pre-pass): the orchestrator resolves them per turn
+    internally, and the generic tools_v2 `search_kb` reads scope from
+    the turn -- so we keep the registry's default search_kb rather
+    than the eval's pre-bound one.
+
+    OPERATOR / Gap-10 BOUNDARY (cannot be verified offline -- needs
+    real OpenAI + Weaviate + Postgres, and live tool backends are
+    Gap 10): treat this as the interim serving wiring behind a 0%
+    rollout flag, not a finished production deps bundle. Verify with
+    a real `?v2=1` session before raising VITE_V2_ROLLOUT_PERCENT.
+    """
+    from src.eval.run_eval import _build_classifier
+    from src.tools_v2.registry import build_tool_registry
+    from src.eval.real_backends import build_eval_backends
+
+    classifier = _build_classifier()
+    registry = build_tool_registry(build_eval_backends())
+
+    return OrchestratorDeps(
+        classifier=classifier,
+        tool_registry=registry,
+        agent_llm=None,        # -> orchestrator real-OpenAI default
+        synthesizer_llm=None,  # -> ditto
+        load_corrections=lambda: [],
+        load_url_allowlist=lambda: set(),
+        lookup_service_availability=lambda intent, campus: None,
+    )
+
+
+__all__ = [
+    "build_v2_deps",
+    "handle_v2_message",
+    "turnresponse_to_wire",
+]

--- a/ai-core/src/main.py
+++ b/ai-core/src/main.py
@@ -848,6 +848,150 @@ async def provideMoreDetails(sid, data):
         }), to=sid)
 
 # ---------------------------------------------------------------------------
+# Rollout Gap 1: ADDITIVE v2 Socket.IO path (/smartchatbot/v2/socket.io)
+# ---------------------------------------------------------------------------
+# RolloutFlag.js already routes flagged sessions to that path; nothing
+# served it (every entrypoint above calls the legacy library_graph).
+# This serves it with the rebuilt orchestrator via run_turn.
+#
+# SAFETY: the legacy `sio` server, its handlers, and the line-336
+# `socketio.ASGIApp(sio, ...)` object are BYTE-UNCHANGED. We only WRAP
+# that object as the fall-through of a new outer ASGIApp, and register
+# v2 handlers under distinct names (sio_v2.on(...)) so they cannot
+# shadow the legacy module-level connect/message/disconnect. Legacy
+# sessions are provably unaffected; uvicorn still serves
+# `src.main:app_sio`.
+#
+# Deps are built LAZILY on first v2 message (NEVER at import) and
+# cached. A build failure (no OpenAI credit / Weaviate down) degrades
+# ONLY v2 sessions to a graceful error -- it cannot break app boot or
+# the legacy path.
+#
+# OPERATOR LIVE-VERIFY (not offline-testable -- needs real OpenAI +
+# Weaviate + Postgres): with VITE_V2_ROLLOUT_PERCENT=0, open `?v2=1`,
+# confirm a cited answer renders AND a no-flag session is unchanged,
+# BEFORE raising the rollout percentage.
+from src.graph.v2_serving import handle_v2_message, build_v2_deps  # noqa: E402
+
+sio_v2 = socketio.AsyncServer(
+    async_mode="asgi",
+    cors_allowed_origins=socketio_cors,
+    logger=False,
+    engineio_logger=False,
+)
+_v2_deps = None
+_v2_deps_error: Exception | None = None
+
+
+def _get_v2_deps():
+    """Lazy singleton; built on first v2 message, never at import.
+    A prior failure is sticky (don't hammer a down dependency)."""
+    global _v2_deps, _v2_deps_error
+    if _v2_deps is not None:
+        return _v2_deps
+    if _v2_deps_error is not None:
+        raise _v2_deps_error
+    try:
+        _v2_deps = build_v2_deps()
+        return _v2_deps
+    except Exception as e:  # noqa: BLE001
+        _v2_deps_error = e
+        raise
+
+
+async def _v2_connect(sid, environ):
+    logging.info(f"🔌 [v2] Client connected: {sid}")
+    conversation_id = await create_conversation()
+    client_conversations[sid] = conversation_id
+    await sio_v2.emit(
+        "status",
+        {"status": "connected", "conversationId": conversation_id},
+        to=sid,
+    )
+
+
+async def _v2_disconnect(sid):
+    logging.info(f"🔌 [v2] Client disconnected: {sid}")
+    client_conversations.pop(sid, None)
+
+
+async def _v2_message(sid, data):
+    text_input = (
+        data
+        if isinstance(data, str)
+        else (data.get("message", "") if isinstance(data, dict) else "")
+    )
+    conversation_id = client_conversations.get(sid)
+    if not conversation_id:
+        conversation_id = await create_conversation()
+        client_conversations[sid] = conversation_id
+    try:
+        await add_message(conversation_id, "user", text_input)
+        history = await get_conversation_history(conversation_id, limit=10)
+        try:
+            deps = _get_v2_deps()
+        except Exception as e:  # noqa: BLE001
+            logging.error(f"❌ [v2] deps unavailable: {e}", exc_info=True)
+            await sio_v2.emit(
+                "message",
+                json_serializable(
+                    {
+                        "messageId": None,
+                        "message": (
+                            "The v2 assistant is temporarily unavailable. "
+                            "Please try again or contact a librarian."
+                        ),
+                        "conversationId": conversation_id,
+                        "error": "v2_deps_unavailable",
+                    }
+                ),
+                to=sid,
+            )
+            return
+        wire = await handle_v2_message(
+            data,
+            deps,
+            conversation_id=conversation_id,
+            conversation_history=history,
+        )
+        message_id = await add_message(
+            conversation_id, "assistant", wire.get("message", "") or ""
+        )
+        wire["messageId"] = message_id
+        await sio_v2.emit("message", json_serializable(wire), to=sid)
+    except Exception as e:  # noqa: BLE001
+        logging.error(f"❌ [v2] Error: {e}", exc_info=True)
+        await sio_v2.emit(
+            "message",
+            json_serializable(
+                {
+                    "messageId": None,
+                    "message": (
+                        "I encountered an error. Please try again or "
+                        "contact a librarian."
+                    ),
+                    "error": str(e),
+                }
+            ),
+            to=sid,
+        )
+
+
+sio_v2.on("connect", _v2_connect)
+sio_v2.on("disconnect", _v2_disconnect)
+sio_v2.on("message", _v2_message)
+
+# Wrap (never mutate) the legacy ASGIApp. v2 path -> sio_v2; everything
+# else (legacy socket path + FastAPI) -> the untouched line-336 object.
+_legacy_app_sio = app_sio
+app_sio = socketio.ASGIApp(
+    sio_v2,
+    other_asgi_app=_legacy_app_sio,
+    socketio_path="/smartchatbot/v2/socket.io",
+)
+
+
+# ---------------------------------------------------------------------------
 # Programmatic uvicorn entry point  (preferred on production)
 # Usage:  python -m src.main
 # This passes UVICORN_LOG_CONFIG so every log line has a timestamp.


### PR DESCRIPTION
## Survey finding first

The **frontend half of Gap 1 was already implemented** by a prior session — `RolloutFlag.js` routes flagged sessions to `/smartchatbot/v2/socket.io`, and `MessageContextProvider` + `ParseLinks`/`CitationChip` + `ChatBotComponent` already render `{answer, citations:[{n,url,snippet}], confidence}`. Surveying first prevented a redundant frontend PR. The real gap was the **backend**: nothing served that v2 socket path.

## What

**`src/graph/v2_serving.py`** — the verifiable core:
- `turnresponse_to_wire()` — **pure**. Maps `TurnResponse` → the exact legacy `"message"` emit shape (legacy keys byte-for-byte) **plus** the additive `citations`/`confidence`/`is_refusal` the frontend already consumes. Refusal → `needs_human` (existing handoff widget fires).
- `handle_v2_message()` — builds `TurnRequest` from the wire payload+history, **offloads sync `run_turn` to a thread executor** (a seconds-long turn can't block the event loop), maps the result. `run_turn` injectable → stub-tested.
- `build_v2_deps()` — mirrors the **proven** `run_eval._build_real_deps` (not invented). The only non-offline-verifiable part; documented Gap-10/operator boundary.

**`main.py` mount is strictly additive — `git diff` = `144 insertions, 0 deletions`.** Legacy `sio`/handlers/line-336 ASGIApp are byte-unchanged; the new outer ASGIApp just *wraps* the untouched legacy object. v2 handlers registered via `sio_v2.on(...)` under distinct names (no shadowing). Deps build **lazily on first v2 message** — a failure (no credit/Weaviate) degrades only v2 sessions; app boot + legacy path cannot break.

## Verified offline (no API/Weaviate/DB)

- `py_compile` incl. `main.py`
- `test_v2_serving` **9/9**: legacy-key preservation, additive keys, refusal→needs_human, JSON-serializable, citation sanitization, request build (str+dict), `build_v2_deps` importable-not-invoked
- `v2_serving` imports cleanly (resolves the main.py import)

## Operator live-verify (rollout default 0% → no real users yet)

1. Boot; confirm a **no-flag** session is byte-identical to today (legacy untouched).
2. Open `?v2=1`; confirm a real **cited answer** renders via the v2 path.
3. Only then raise `VITE_V2_ROLLOUT_PERCENT` above 0.

Independent branch off `main`; isolated from #65–#69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)