### PR TITLE
feat(scope): arm the cross-campus service-not-at-building guard (Gap 3)

### DIFF
--- a/ai-core/src/eval/run_eval.py
+++ b/ai-core/src/eval/run_eval.py
@@ -92,6 +92,7 @@ from src.router.intent_knn import (  # noqa: E402
 )
 from src.retrieval.scope_filter import ScopeFilter  # noqa: E402
 from src.scope.resolver import resolve_scope  # noqa: E402
+from src.scope.service_availability import build_service_guard  # noqa: E402
 
 logger = logging.getLogger("eval")
 
@@ -467,7 +468,12 @@ def _build_real_deps(
         synthesizer_llm=None,   # ditto
         load_corrections=lambda: [],
         load_url_allowlist=lambda: set(),
-        lookup_service_availability=lambda intent, campus: None,
+        # Real path: wire the cross-campus service guard (plan §8/§9
+        # SERVICE_NOT_AT_BUILDING). Reads the canonical seed SPACES, so
+        # no DB/async needed and it can't be silently disabled. The
+        # cross_campus gold cases (makerspace@hamilton etc.) exercise
+        # this. (The STUB deps above intentionally keep it None.)
+        lookup_service_availability=build_service_guard(),
     )
 
 

--- a/ai-core/src/graph/v2_serving.py
+++ b/ai-core/src/graph/v2_serving.py
@@ -162,6 +162,7 @@ def build_v2_deps() -> OrchestratorDeps:
     from src.eval.run_eval import _build_classifier
     from src.tools_v2.registry import build_tool_registry
     from src.eval.real_backends import build_eval_backends
+    from src.scope.service_availability import build_service_guard
 
     classifier = _build_classifier()
     registry = build_tool_registry(build_eval_backends())
@@ -173,7 +174,10 @@ def build_v2_deps() -> OrchestratorDeps:
         synthesizer_llm=None,  # -> ditto
         load_corrections=lambda: [],
         load_url_allowlist=lambda: set(),
-        lookup_service_availability=lambda intent, campus: None,
+        # Cross-campus service guard (plan §8/§9). Canonical seed
+        # SPACES-backed -> pure/sync, no DB at request time, cannot be
+        # silently disabled. Production serving MUST have this on.
+        lookup_service_availability=build_service_guard(),
     )
 
 

--- a/ai-core/src/scope/service_availability.py
+++ b/ai-core/src/scope/service_availability.py
@@ -1,0 +1,140 @@
+"""
+The cross-campus "service-not-at-this-building" guard (plan §8/§9).
+
+`build_service_guard()` returns the `lookup_service_availability`
+callable the orchestrator expects:
+
+    (intent: str, scope_campus: str) -> Optional[RefusalContext]
+
+It is the load-bearing DETERMINISTIC defense against the
+"MakerSpace at Hamilton" hallucination class: if the classified
+intent maps to a campus-restricted featured service and NO building
+on `scope_campus` offers it, the orchestrator short-circuits to a
+SERVICE_NOT_AT_BUILDING refusal BEFORE the agent/synthesizer can
+invent a "yes".
+
+WHY read the seed's `SPACES` constant instead of the DB:
+`scripts/seed_library_spaces_v2.py::SPACES` is the *authoritative*
+source (its own docstring: "This module's SPACES constant is the
+authoritative source ... Adding a new building or service is a
+one-edit append plus re-run"). The `LibrarySpace_v2` table is a
+projection of it (seeded FROM it; verified identical). Reading SPACES
+directly makes the guard pure/sync/offline-testable and means it
+CANNOT be silently disabled by the DB being unreachable -- the right
+property for a load-bearing safety guard. (`run_turn` calls this
+synchronously; a per-request async DB hit would be the wrong shape.)
+
+CONSERVATIVE BY DESIGN: only intents for services the plan §7 marks
+campus-restricted (MakerSpace, Special Collections) are gated.
+University-wide services (Adobe, ILL, newspapers, digital
+collections, printing) are NEVER gated -- they exist on every
+campus, so gating them would cause FALSE refusals (worse-not-better;
+plan §9 requires <10% refusal on legitimate questions). An unknown /
+ungated intent always returns None (no refusal).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable, Optional
+
+from src.synthesis.refusal_templates import RefusalContext
+
+logger = logging.getLogger(__name__)
+
+# intent -> (required service token(s), user-facing service name).
+# A campus "has" the service if ANY of its buildings lists ANY of the
+# required tokens in services_offered. Keep this MINIMAL: only the
+# plan §7 campus-restricted featured services. Adding an entry here
+# makes the guard refuse that intent on campuses lacking the service,
+# so it must be a service that genuinely doesn't exist parity-wide.
+_GATED_INTENTS: dict[str, tuple[frozenset[str], str]] = {
+    "makerspace_3d": (frozenset({"makerspace"}), "the MakerSpace"),
+    "special_collections": (
+        frozenset({"rare_books_access", "archival_research"}),
+        "Special Collections & University Archives",
+    ),
+}
+
+_CAMPUS_DISPLAY = {
+    "oxford": "Oxford",
+    "hamilton": "Hamilton",
+    "middletown": "Middletown",
+}
+
+
+def _load_spaces():
+    """The canonical truth table (seed SPACES). Defensive: any import
+    failure -> empty, which makes the guard a no-op (safe degradation:
+    a guard that can't load must NOT start refusing legitimate
+    questions; absence of data is not evidence of absence of service)."""
+    try:
+        from scripts.seed_library_spaces_v2 import SPACES  # type: ignore
+
+        return list(SPACES)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "service guard: could not load SPACES (%s); guard DISABLED "
+            "(returns None for all intents).", e,
+        )
+        return []
+
+
+def build_service_guard(
+    spaces: Optional[list] = None,
+) -> Callable[[str, str], Optional[RefusalContext]]:
+    """Build the `(intent, scope_campus) -> Optional[RefusalContext]`
+    guard, closing over an in-memory copy of the truth table.
+
+    `spaces` is injectable for tests (a list of objects/rows with
+    `.campus`, `.library`, `.name`, `.services_offered`). Production
+    passes nothing -> the canonical seed SPACES.
+    """
+    rows = spaces if spaces is not None else _load_spaces()
+
+    # campus -> union of all services offered by any building there.
+    campus_services: dict[str, set[str]] = {}
+    # required-token -> a human phrase for where it DOES exist.
+    for r in rows:
+        campus = (getattr(r, "campus", "") or "").lower()
+        svcs = set(getattr(r, "services_offered", []) or [])
+        campus_services.setdefault(campus, set()).update(svcs)
+
+    def _where_phrase(required: frozenset[str]) -> Optional[str]:
+        for r in rows:
+            svcs = set(getattr(r, "services_offered", []) or [])
+            if required & svcs:
+                name = getattr(r, "name", None) or getattr(r, "library", "")
+                camp = _CAMPUS_DISPLAY.get(
+                    (getattr(r, "campus", "") or "").lower(),
+                    (getattr(r, "campus", "") or "").title(),
+                )
+                return f"{name} on the {camp} campus"
+        return None
+
+    def guard(intent: str, scope_campus: str) -> Optional[RefusalContext]:
+        if not rows:
+            # Truth table unavailable (import failed / injected empty).
+            # SAFE DEGRADATION: absence of data is NOT evidence of
+            # absence of service -- a guard that can't load its table
+            # must NOT start false-refusing legitimate questions.
+            return None
+        spec = _GATED_INTENTS.get(intent or "")
+        if spec is None:
+            return None  # ungated/unknown intent -> never refuse
+        required, label = spec
+        campus = (scope_campus or "oxford").lower()
+        if required & campus_services.get(campus, set()):
+            return None  # the service IS offered on this campus -> proceed
+        # Service is genuinely not on this campus -> refuse, and say
+        # where it DOES exist so the refusal is actionable.
+        return RefusalContext(
+            service_name=label,
+            campus_display=_CAMPUS_DISPLAY.get(campus, campus.title()),
+            service_available_at=_where_phrase(required),
+        )
+
+    return guard
+
+
+__all__ = ["build_service_guard"]

--- a/ai-core/src/scope/test_service_availability.py
+++ b/ai-core/src/scope/test_service_availability.py
@@ -1,0 +1,137 @@
+"""
+Offline tests for the cross-campus service-availability guard.
+
+Run: `python -m src.scope.test_service_availability` from ai-core/.
+
+Pure/sync/no-DB/no-OpenAI. Synthetic rows give deterministic control;
+the final test locks the REAL production behavior against the
+canonical seed SPACES (the load-bearing "MakerSpace at Hamilton"
+case the whole guard exists for).
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_AI_CORE = _HERE.parent.parent
+sys.path.insert(0, str(_AI_CORE))
+
+from src.scope.service_availability import build_service_guard
+from src.synthesis.refusal_templates import RefusalContext
+
+
+@dataclass(frozen=True)
+class _Row:
+    campus: str
+    library: str
+    name: str
+    services_offered: list = field(default_factory=list)
+
+
+# King has makerspace; Rentschler (Hamilton) does not -- the canonical
+# shape of the real data, in miniature.
+_SYNTH = [
+    _Row("oxford", "king", "Edward King Library",
+         ["printing", "makerspace", "study_rooms"]),
+    _Row("oxford", "special", "Special Collections",
+         ["rare_books_access", "archival_research"]),
+    _Row("hamilton", "rentschler", "Rentschler Library",
+         ["printing", "study_rooms"]),
+    _Row("middletown", "gardner_harvey", "Gardner-Harvey Library",
+         ["printing", "study_rooms"]),
+]
+
+
+def test_gated_missing_campus_refuses_with_context() -> None:
+    g = build_service_guard(_SYNTH)
+    r = g("makerspace_3d", "hamilton")
+    assert isinstance(r, RefusalContext), r
+    assert r.service_name == "the MakerSpace"
+    assert r.campus_display == "Hamilton"
+    assert r.service_available_at == "Edward King Library on the Oxford campus"
+
+
+def test_gated_present_campus_allows() -> None:
+    g = build_service_guard(_SYNTH)
+    assert g("makerspace_3d", "oxford") is None
+
+
+def test_special_collections_gating() -> None:
+    g = build_service_guard(_SYNTH)
+    assert g("special_collections", "middletown") is not None
+    assert g("special_collections", "oxford") is None
+
+
+def test_ungated_intent_never_refuses() -> None:
+    g = build_service_guard(_SYNTH)
+    # University-wide / common services must NOT be gated anywhere.
+    for intent in ("interlibrary_loan", "printing_wifi", "adobe_access",
+                   "newspapers", "hours", "subject_librarian"):
+        assert g(intent, "hamilton") is None, intent
+
+
+def test_unknown_intent_returns_none() -> None:
+    g = build_service_guard(_SYNTH)
+    assert g("totally_unknown_intent", "middletown") is None
+
+
+def test_empty_or_none_campus_defaults_oxford() -> None:
+    g = build_service_guard(_SYNTH)
+    # Default scope is Oxford -> King has makerspace -> no refusal.
+    assert g("makerspace_3d", "") is None
+    assert g("makerspace_3d", None) is None
+
+
+def test_no_spaces_disables_guard_safely() -> None:
+    """Safe degradation: if the truth table can't load, the guard must
+    NOT start refusing legitimate questions."""
+    g = build_service_guard([])
+    assert g("makerspace_3d", "hamilton") is None
+
+
+def test_canonical_seed_locks_real_behavior() -> None:
+    """No-arg build reads the real seed SPACES. This locks the plan's
+    load-bearing behavior against the actual shipped data."""
+    g = build_service_guard()  # canonical SPACES
+    hamilton = g("makerspace_3d", "hamilton")
+    assert isinstance(hamilton, RefusalContext), hamilton
+    assert "MakerSpace" in (hamilton.service_name or "")
+    assert "Oxford" in (hamilton.service_available_at or "")
+    assert g("makerspace_3d", "oxford") is None
+    assert g("special_collections", "middletown") is not None
+    assert g("special_collections", "oxford") is None
+    # Ungated stays open campus-wide.
+    assert g("interlibrary_loan", "hamilton") is None
+
+
+def main() -> int:
+    tests = [
+        test_gated_missing_campus_refuses_with_context,
+        test_gated_present_campus_allows,
+        test_special_collections_gating,
+        test_ungated_intent_never_refuses,
+        test_unknown_intent_returns_none,
+        test_empty_or_none_campus_defaults_oxford,
+        test_no_spaces_disables_guard_safely,
+        test_canonical_seed_locks_real_behavior,
+    ]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prisma/migrations/20260518_add_libraryspace_v2.sql
+++ b/prisma/migrations/20260518_add_libraryspace_v2.sql
@@ -1,0 +1,75 @@
+-- =============================================================================
+-- ADDITIVE: create the v2 LibrarySpace truth table (plan §8).
+--
+-- WHY: the cross-campus "service not at this building" guard
+-- (orchestrator `lookup_service_availability`, refusal trigger
+-- SERVICE_NOT_AT_BUILDING) is the load-bearing deterministic defense
+-- against the "MakerSpace at Hamilton" hallucination class. It needs a
+-- per-(campus, library) services truth table. The live schema has none:
+--   "Library"      = 4 buildings, no campus, no SWORD/Wertz
+--   "LibrarySpace" = 4 King sub-spaces, services/equipment empty
+-- and that legacy "LibrarySpace" is still read by the v1 booking path
+-- during the 8-week rollout, so it must NOT be repurposed.
+--
+-- DESIGN: a NEW, FLAT table `LibrarySpace_v2`, exactly the shape
+-- `ai-core/scripts/seed_library_spaces_v2.py` already targets
+-- (`db.libraryspace_v2`, upsert key (campus, library)). Same risk
+-- profile as 20260514 / 20260516 hotfixes but LOWER: this creates a
+-- brand-new table and touches no existing column or row.
+--
+-- WHAT THIS DOES (idempotent -- safe to re-run):
+--   * CREATE TABLE IF NOT EXISTS "LibrarySpace_v2"
+--   * CREATE UNIQUE INDEX IF NOT EXISTS on (campus, library)
+--   All additive. No table rewrite, no backfill, no NOT-NULL on
+--   existing data (the table is new and empty until the seed runs).
+--
+-- WHAT THIS DOES NOT DO:
+--   * Touch "LibrarySpace", "Library", or any v1 booking path.
+--   * Backfill / migrate any row.
+--
+-- ROLLBACK (legacy unaffected):  DROP TABLE IF EXISTS "LibrarySpace_v2";
+--
+-- `id` has no DB default: every insert goes through Prisma, whose
+-- `@default(uuid())` supplies it client-side (avoids depending on a
+-- pgcrypto/pg-version-specific gen_random_uuid()). Column names are
+-- snake_case to match seed_library_spaces_v2.py's asdict() keys
+-- 1:1; createdAt/updatedAt are camelCase to match the Prisma
+-- convention used by the legacy "LibrarySpace" table.
+--
+-- APPLY (one of):
+--   psql "$DATABASE_URL" -f prisma/migrations/20260518_add_libraryspace_v2.sql
+--   # or, from ai-core/ with the venv:
+--   VIRTUAL_ENV=.../.venv .venv/bin/python -m prisma db execute \
+--     --file ../prisma/migrations/20260518_add_libraryspace_v2.sql \
+--     --schema ../prisma/schema.prisma
+-- (This run applied it via the verified Prisma execute_raw connection,
+--  statement-by-statement, each idempotent.)
+-- =============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS "LibrarySpace_v2" (
+    "id"               TEXT        PRIMARY KEY,
+    "library"          TEXT        NOT NULL,
+    "campus"           TEXT        NOT NULL,
+    "name"             TEXT        NOT NULL,
+    "building_role"    TEXT        NOT NULL,
+    "address"          TEXT,
+    "phone"            TEXT,
+    "libcal_id"        TEXT,
+    "capacity"         INTEGER,
+    "equipment"        TEXT[]      NOT NULL DEFAULT ARRAY[]::TEXT[],
+    "services_offered" TEXT[]      NOT NULL DEFAULT ARRAY[]::TEXT[],
+    "hours_source"     TEXT,
+    "source_url"       TEXT,
+    "createdAt"        TIMESTAMP   NOT NULL DEFAULT now(),
+    "updatedAt"        TIMESTAMP   NOT NULL DEFAULT now()
+);
+
+-- The seed upserts on (campus, library); Prisma's compound-unique
+-- where-key is `campus_library` (field order in @@unique). A UNIQUE
+-- index permits this; IF NOT EXISTS keeps the whole file idempotent.
+CREATE UNIQUE INDEX IF NOT EXISTS "LibrarySpace_v2_campus_library_key"
+    ON "LibrarySpace_v2" ("campus", "library");
+
+COMMIT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -238,6 +238,35 @@ model LibrarySpace {
   @@index([libcalBuildingId])
 }
 
+// Smart-chatbot rebuild v2 (plan §8). FLAT per-(campus, library) truth
+// table -- the load-bearing source for the cross-campus
+// "service-not-at-this-building" guard. Deliberately NOT related to the
+// legacy `LibrarySpace`/`Library` (still read by the v1 booking path
+// during the 8-week rollout). Table created idempotently by
+// prisma/migrations/20260518_add_libraryspace_v2.sql; seeded by
+// scripts/seed_library_spaces_v2.py (upsert key = (campus, library)).
+// Field names are snake_case to match that seed's asdict() keys 1:1.
+model LibrarySpace_v2 {
+  id               String   @id @default(uuid())
+  library          String // king|wertz|special|rentschler|gardner_harvey|sword
+  campus           String // oxford|hamilton|middletown
+  name             String
+  building_role    String // main_building|sub_building|department|depository
+  address          String?
+  phone            String?
+  libcal_id        String?
+  capacity         Int?
+  equipment        String[] @default([])
+  services_offered String[] @default([])
+  hours_source     String?
+  source_url       String?
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  @@unique([campus, library])
+  @@map("LibrarySpace_v2")
+}
+
 // Librarian/Staff Directory (verified contacts only)
 model Librarian {
   id                String   @id @default(uuid())


### PR DESCRIPTION
## Why

The plan §8/§9 **load-bearing deterministic defense** against the "MakerSpace at Hamilton" hallucination class. It was never armed: `lookup_service_availability` was a `lambda: None` stub in every deps site, and the live DB had no per-(campus,library) services truth table (`Library`=4 buildings/no campus; `LibrarySpace`=4 King subspaces, services empty — and that legacy table is still read by the v1 booking path, so it couldn't be repurposed).

## DB changes — applied to shared `smartchatbot_db` with operator go-ahead

Additive + idempotent + **reversible**; legacy untouched (re-verified `LibrarySpace` still 4 rows):
- **NEW table `LibrarySpace_v2`** via `prisma/migrations/20260518_add_libraryspace_v2.sql` — `CREATE TABLE/UNIQUE INDEX IF NOT EXISTS`, same proven-safe pattern as the `20260514`/`20260516` hotfix SQLs. (`prisma migrate` deliberately **not** used — documented history-drift makes it a no-op.) **Rollback:** `DROP TABLE IF EXISTS "LibrarySpace_v2";`
- `+model LibrarySpace_v2` in `schema.prisma`; client regenerated into the venv; `db.libraryspace_v2` accessor **verified**.
- Seeded the **6 canonical buildings** via the pre-existing `seed_library_spaces_v2.py` (idempotent; re-run → still 6). Verified King *has* `makerspace`, Rentschler/Hamilton has *none*.

## Code

`src/scope/service_availability.py::build_service_guard()` reads the seed's **canonical `SPACES`** (the DB is a projection of it) → pure/sync/offline, no per-request DB call in sync `run_turn`, **cannot be silently disabled by DB-down**. Conservative: only plan §7 campus-restricted services (`makerspace_3d`, `special_collections`) are gated; university-wide services never gated (plan §9: <10% refusal on legit Qs). **Safe degradation**: unloadable table → guard returns `None` for everything (a real bug the test caught — first cut *refused* everything on load failure).

Wired into the **real-LLM eval** + **serving** deps; the stub wiring-eval deps stay `None` intentionally (documented; no DB there).

## Verification (offline — no OpenAI, no DB at test time)

`py_compile` clean; **`test_service_availability` 8/8** incl. a canonical lock against the *real shipped* `SPACES` (`makerspace_3d@hamilton`→SERVICE_NOT_AT_BUILDING, `@oxford`→None; `special_collections@middletown`→refuse; ILL/printing never gated). Regression: `new_orchestrator` 27/27, `v2_serving` 9/9, `builder` 9/9; `run_eval`+`v2_serving` import clean with the guard wired.

## Scope note

Excludes `client/package-lock.json` (the `npm install` materialization of merged #67's `@sentry/react` — separate concern, own follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)