### PR TITLE
feat(models): env-driven 3-tier config (gpt-5.4 family) + call-shape fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,8 +21,15 @@
 # ================================= LLM (OpenAI) ==========================================
 OPENAI_ORGANIZATION_ID=your_org_id_here
 OPENAI_API_KEY=sk-your_api_key_here
-OPENAI_MODEL=o4-mini
-# Note: o4-mini is optimized for speed. Models starting with "o" don't support temperature parameter.
+# --- LLM model tiers (single source of truth: ai-core/src/config/models.py) ---
+# Switchable here without code edits. Defaults shown are the gpt-5.4 family
+# (verified 2026-05-19). All are REASONING models -> the client omits
+# `temperature` for them automatically (controlled via reasoning.effort).
+LLM_MODEL_BASIC=gpt-5.4-mini       # easy / surface questions, agent loop default
+LLM_MODEL_REASONING=gpt-5.4        # hard / sophisticated: ambiguous synthesis, multi-step
+LLM_MODEL_CHEAP=gpt-5.4-nano       # high-volume mechanical: eval judge, classifier-fallback, extraction
+LLM_MODEL_EMBEDDING=text-embedding-3-large  # changing this invalidates the whole vector index
+# DEPRECATED: OPENAI_MODEL is no longer read (replaced by the tiers above).
 # Alternative models: gpt-4o, gpt-4-turbo, gpt-4, gpt-3.5-turbo
 
 # ================================= Database & Vector DB ==========================================

--- a/ai-core/src/agents/libcal_comprehensive_agent.py
+++ b/ai-core/src/agents/libcal_comprehensive_agent.py
@@ -230,10 +230,11 @@ Respond with ONLY valid JSON:
 }}"""
         
         try:
-            model_name = os.getenv("OPENAI_MODEL", "o4-mini")
+            from src.config.models import resolve_model, is_reasoning_model
+            model_name = resolve_model("basic")  # env: LLM_MODEL_BASIC
             api_key = os.getenv("OPENAI_API_KEY", "")
             llm_kwargs = {"model": model_name, "api_key": api_key}
-            if not model_name.startswith("o"):
+            if not is_reasoning_model(model_name):  # reasoning -> no temperature
                 llm_kwargs["temperature"] = 0
             llm = ChatOpenAI(**llm_kwargs)
             

--- a/ai-core/src/api/summarize.py
+++ b/ai-core/src/api/summarize.py
@@ -12,7 +12,8 @@ import os
 router = APIRouter(tags=["summarize"])
 
 # Use o4-mini as specified in .env
-OPENAI_MODEL = os.getenv("OPENAI_MODEL", "o4-mini")
+from src.config.models import resolve_model, is_reasoning_model  # noqa: E402
+OPENAI_MODEL = resolve_model("basic")  # env: LLM_MODEL_BASIC (default gpt-5.4-mini)
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
 
 
@@ -47,7 +48,7 @@ async def summarize_chat(request: ChatSummaryRequest):
         # Initialize OpenAI chat model using o4-mini pattern from system
         # o4-mini doesn't support temperature parameter
         llm_kwargs = {"model": OPENAI_MODEL, "api_key": OPENAI_API_KEY}
-        if not OPENAI_MODEL.startswith("o"):
+        if not is_reasoning_model(OPENAI_MODEL):  # reasoning models reject temperature
             llm_kwargs["temperature"] = 0.3  # Lower temperature for focused summaries
         
         llm = ChatOpenAI(**llm_kwargs)

--- a/ai-core/src/classification/rag_classifier.py
+++ b/ai-core/src/classification/rag_classifier.py
@@ -34,14 +34,15 @@ from src.classification.category_examples import (
     ALL_CATEGORIES,
 )
 
-OPENAI_MODEL = os.getenv("OPENAI_MODEL", "o4-mini")
+from src.config.models import resolve_model, is_reasoning_model  # noqa: E402
+OPENAI_MODEL = resolve_model("basic")  # env: LLM_MODEL_BASIC (default gpt-5.4-mini)
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
 WEAVIATE_HOST = os.getenv("WEAVIATE_HOST", "localhost")
 WEAVIATE_SCHEME = os.getenv("WEAVIATE_SCHEME", "http")
 # No API key needed for local Docker
 
 llm_kwargs = {"model": OPENAI_MODEL, "api_key": OPENAI_API_KEY}
-if not OPENAI_MODEL.startswith("o"):
+if not is_reasoning_model(OPENAI_MODEL):  # reasoning models reject temperature
     llm_kwargs["temperature"] = 0
 llm = ChatOpenAI(**llm_kwargs)
 

--- a/ai-core/src/config/models.py
+++ b/ai-core/src/config/models.py
@@ -50,43 +50,94 @@ SEPARATE caches -- switching from BASIC_MODEL to REASONING_MODEL mid-conversatio
 forfeits the cache for that turn. Factor this into the model-routing decision.
 """
 
+import os
 from typing import Literal
 
 
-# --- Model identifiers -------------------------------------------------------
+# --- Model identifiers (env-driven; one place; .env-managed) -----------------
+#
+# Operator preference (2026-05-19): 3 tiers, switchable in .env without
+# code edits. Defaults are the gpt-5.4 family, VERIFIED 2026-05-19
+# against the operator's OpenAI dashboard + developers.openai.com
+# (guides/reasoning, /text, /migrate-to-responses):
+#
+#   id              reasoning  ctx      $/1M in / cached / out
+#   gpt-5.4         5/5        1.05M    2.50 / 0.25 / 15.00
+#   gpt-5.4-mini    4/5        400K     0.75 / 0.08 /  4.50
+#   gpt-5.4-nano    3/5        400K     0.20 / 0.02 /  1.25
+#
+# All three are REASONING models (reasoning-token support), expose both
+# /v1/chat/completions and /v1/responses, 128K max output, cutoff
+# 2025-08-31. Responses API: `input` (user), `instructions` (system),
+# `max_output_tokens` (NOT max_tokens), structured output via
+# `text.format`:{type:json_schema}, effort via `reasoning.effort`.
 
-BASIC_MODEL: str = "gpt-5.4-mini"
-"""Default model for agent loop, eval judge, and light extraction tasks."""
+BASIC_MODEL: str = os.getenv("LLM_MODEL_BASIC", "gpt-5.4-mini").strip()
+"""Easy / surface questions: agent loop default, light extraction.
+Env: LLM_MODEL_BASIC."""
 
-REASONING_MODEL: str = "gpt-5.2"
-"""High-reasoning model for ambiguous synthesis, multi-step tool calls,
-and clarification generation."""
+REASONING_MODEL: str = os.getenv("LLM_MODEL_REASONING", "gpt-5.4").strip()
+"""Hard / sophisticated questions: ambiguous synthesis, multi-step
+tool calls, clarification. Env: LLM_MODEL_REASONING."""
 
-EMBEDDING_MODEL: str = "text-embedding-3-large"
+CHEAP_MODEL: str = os.getenv("LLM_MODEL_CHEAP", "gpt-5.4-nano").strip()
+"""High-volume MECHANICAL calls where weak instruction-following is
+low-risk: LLM-as-judge in eval, classifier-fallback, light
+extraction/normalization. ~3.7x cheaper than basic, ~12x vs reasoning.
+NEVER route the grounded synthesizer or the tool-calling agent here --
+that reintroduces the hallucination/citation failures the rebuild
+exists to kill. Env: LLM_MODEL_CHEAP."""
+
+EMBEDDING_MODEL: str = os.getenv(
+    "LLM_MODEL_EMBEDDING", "text-embedding-3-large"
+).strip()
 """Embedding model for kNN classifier exemplars AND document chunks.
-Higher cost than -small but gives meaningful accuracy lift on noun-heavy
-library queries (e.g., 'Wertz', 'MakerSpace', 'ILL'). Corpus is small
-enough (~580 URLs, single-digit thousands of chunks) that the cost
-premium is negligible at our scale."""
+ONE embedding model across all use cases so the vector spaces align
+(changing it invalidates the whole index -- re-embed required).
+Env: LLM_MODEL_EMBEDDING."""
+
+
+# --- Call-shape gate (the load-bearing correctness helper) -------------------
+
+def is_reasoning_model(model_id: str) -> bool:
+    """True if `model_id` is a REASONING model -> the OpenAI client must
+    NOT send `temperature` (reasoning models reject/ignore it; control
+    is via `reasoning.effort`). Sending temperature to a reasoning model
+    risks a 400.
+
+    Basis (NOT a guess -- verified 2026-05-19): the o-series (o1/o3/o4
+    ...) and the entire gpt-5.x family (5.2, 5.4, 5.4-mini, 5.4-nano)
+    are reasoning models. Older gpt-4*/gpt-3* are not. Omitting
+    temperature is superset-safe: correct for reasoning models AND
+    harmless for non-reasoning ones (they use their default). The 3
+    OpenAI guides were silent on temperature for 5.4 specifically, so
+    we deliberately take the can't-break direction.
+
+    Replaces the legacy `OPENAI_MODEL.startswith("o")` check, which
+    missed the gpt-5.x reasoning family and would 400 the live bot
+    once the default moved to gpt-5.4.
+    """
+    m = (model_id or "").strip().lower()
+    return m.startswith("o") or m.startswith("gpt-5")
 
 
 # --- Type aliases for routing decisions --------------------------------------
 
-ModelTier = Literal["basic", "reasoning"]
-"""Logical tier consumers should pass when they don't care about the exact
-model ID -- lets us swap underlying models without touching call sites."""
+ModelTier = Literal["basic", "reasoning", "cheap"]
+"""Logical tier consumers pass when they don't care about the exact
+model ID -- lets us swap underlying models via .env without touching
+call sites."""
 
 
 def resolve_model(tier: ModelTier) -> str:
     """Resolve a logical tier to the current concrete model ID.
 
-    Always prefer this over hard-coding `BASIC_MODEL` / `REASONING_MODEL`
-    at call sites that conditionally pick a tier (e.g., the synthesizer's
-    routing logic).
+    Always prefer this over hard-coding the constants at call sites.
 
     Args:
-        tier: "basic" for high-throughput / cheap calls, "reasoning" for
-            ambiguous-synthesis / multi-step / clarification calls.
+        tier: "basic" (easy/surface), "reasoning" (hard/sophisticated),
+            or "cheap" (high-volume mechanical: judge / classifier
+            fallback / extraction).
 
     Returns:
         The current concrete model identifier string.
@@ -98,8 +149,11 @@ def resolve_model(tier: ModelTier) -> str:
         return BASIC_MODEL
     if tier == "reasoning":
         return REASONING_MODEL
+    if tier == "cheap":
+        return CHEAP_MODEL
     raise ValueError(
-        f"Unknown model tier: {tier!r}. Expected 'basic' or 'reasoning'."
+        f"Unknown model tier: {tier!r}. Expected 'basic', 'reasoning', "
+        f"or 'cheap'."
     )
 
 

--- a/ai-core/src/config/test_models.py
+++ b/ai-core/src/config/test_models.py
@@ -1,0 +1,103 @@
+"""
+Offline tests for the env-driven model config + call-shape gate.
+
+Run: `python -m src.config.test_models` from ai-core/.
+
+models.py resolves env at IMPORT time, so env-override tests reload
+the module (and always restore os.environ + a clean reload after, so
+later tests/imports see the real config).
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_AI_CORE = _HERE.parent.parent
+sys.path.insert(0, str(_AI_CORE))
+
+import src.config.models as M
+
+_TIER_ENV = (
+    "LLM_MODEL_BASIC", "LLM_MODEL_REASONING",
+    "LLM_MODEL_CHEAP", "LLM_MODEL_EMBEDDING",
+)
+
+
+def _reload_clean():
+    for k in _TIER_ENV:
+        os.environ.pop(k, None)
+    importlib.reload(M)
+
+
+def test_defaults_are_gpt54_family() -> None:
+    _reload_clean()
+    assert M.BASIC_MODEL == "gpt-5.4-mini", M.BASIC_MODEL
+    assert M.REASONING_MODEL == "gpt-5.4", M.REASONING_MODEL
+    assert M.CHEAP_MODEL == "gpt-5.4-nano", M.CHEAP_MODEL
+    assert M.EMBEDDING_MODEL == "text-embedding-3-large"
+
+
+def test_resolve_model_three_tiers() -> None:
+    _reload_clean()
+    assert M.resolve_model("basic") == "gpt-5.4-mini"
+    assert M.resolve_model("reasoning") == "gpt-5.4"
+    assert M.resolve_model("cheap") == "gpt-5.4-nano"
+    try:
+        M.resolve_model("bogus")  # type: ignore[arg-type]
+        assert False, "expected ValueError"
+    except ValueError:
+        pass
+
+
+def test_env_override() -> None:
+    os.environ["LLM_MODEL_BASIC"] = "gpt-5.4-mini-2099"
+    os.environ["LLM_MODEL_REASONING"] = "gpt-6"
+    os.environ["LLM_MODEL_CHEAP"] = "gpt-5.4-nano-x"
+    try:
+        importlib.reload(M)
+        assert M.resolve_model("basic") == "gpt-5.4-mini-2099"
+        assert M.resolve_model("reasoning") == "gpt-6"
+        assert M.resolve_model("cheap") == "gpt-5.4-nano-x"
+    finally:
+        _reload_clean()  # restore real config for any later import
+
+
+def test_is_reasoning_model() -> None:
+    _reload_clean()
+    for yes in ("o4-mini", "o1", "o3-mini", "gpt-5.2", "gpt-5.4",
+                "gpt-5.4-mini", "gpt-5.4-nano", "GPT-5.4-NANO"):
+        assert M.is_reasoning_model(yes) is True, yes
+    for no in ("gpt-4o", "gpt-4", "gpt-4o-mini", "gpt-3.5-turbo",
+               "text-embedding-3-large", "", None):
+        assert M.is_reasoning_model(no) is False, no  # must not raise
+
+
+def main() -> int:
+    tests = [
+        test_defaults_are_gpt54_family,
+        test_resolve_model_three_tiers,
+        test_env_override,
+        test_is_reasoning_model,
+    ]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    _reload_clean()
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ai-core/src/eval/judge.py
+++ b/ai-core/src/eval/judge.py
@@ -190,7 +190,7 @@ def judge_answer(
     *,
     judge_llm: JudgeLLM,
     prefix_id: str = "judge_v1",
-    model: str = "gpt-5.4-mini",
+    model: str = "",
 ) -> JudgeOutcome:
     """Score one bot answer.
 
@@ -201,9 +201,12 @@ def judge_answer(
             registered in src/prompts/judge_v1.py. Bump only if the
             rubric changes substantively (and update the eval gold
             set's expected verdicts in the same PR).
-        model: which model to use. Default gpt-5.4-mini -- the judge
-            runs once per question per regression run, so cheap is
-            fine; quality matters less than consistency.
+        model: which model to use. Default "" -> resolve_model("cheap")
+            (env LLM_MODEL_CHEAP, default gpt-5.4-nano). The judge is
+            high-volume mechanical rubric scoring once per question per
+            regression run -- nano is ~3.7x cheaper than mini and the
+            single biggest eval-cost line; consistency matters more
+            than reasoning depth here. Pass an explicit id to override.
 
     Returns:
         JudgeOutcome with parsed Verdict + raw response (for logs).
@@ -214,6 +217,9 @@ def judge_answer(
             question, and continues with the next.
     """
     suffix = build_judge_dynamic_suffix(request)
+    if not model:
+        from src.config.models import resolve_model
+        model = resolve_model("cheap")  # nano: cheapest tier for the judge
     raw, _usage = judge_llm(
         prefix_id=prefix_id,
         dynamic_suffix=suffix,

--- a/ai-core/src/graph/intent_normalizer.py
+++ b/ai-core/src/graph/intent_normalizer.py
@@ -15,12 +15,13 @@ from langchain_core.output_parsers import PydanticOutputParser
 from src.models.intent import NormalizedIntent
 
 # Use o4-mini as specified
-OPENAI_MODEL = os.getenv("OPENAI_MODEL", "o4-mini")
+from src.config.models import resolve_model, is_reasoning_model  # noqa: E402
+OPENAI_MODEL = resolve_model("basic")  # env: LLM_MODEL_BASIC (default gpt-5.4-mini)
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
 
 # o4-mini doesn't support temperature parameter
 llm_kwargs = {"model": OPENAI_MODEL, "api_key": OPENAI_API_KEY}
-if not OPENAI_MODEL.startswith("o"):
+if not is_reasoning_model(OPENAI_MODEL):  # reasoning models reject temperature
     llm_kwargs["temperature"] = 0
 
 llm = ChatOpenAI(**llm_kwargs)

--- a/ai-core/src/graph/orchestrator.py
+++ b/ai-core/src/graph/orchestrator.py
@@ -66,12 +66,13 @@ from src.config.research_question_detection import (
 from src.graph.rag_router import rag_router_node
 
 # Use o4-mini as specified
-OPENAI_MODEL = os.getenv("OPENAI_MODEL", "o4-mini")
+from src.config.models import resolve_model, is_reasoning_model  # noqa: E402
+OPENAI_MODEL = resolve_model("basic")  # env: LLM_MODEL_BASIC (default gpt-5.4-mini)
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
 
 # o4-mini doesn't support temperature parameter, only use it for other models
 llm_kwargs = {"model": OPENAI_MODEL, "api_key": OPENAI_API_KEY}
-if not OPENAI_MODEL.startswith("o"):
+if not is_reasoning_model(OPENAI_MODEL):  # reasoning models reject temperature
     llm_kwargs["temperature"] = 0
 llm = ChatOpenAI(**llm_kwargs)
 

--- a/ai-core/src/utils/fact_grounding.py
+++ b/ai-core/src/utils/fact_grounding.py
@@ -17,11 +17,12 @@ from langchain_core.messages import SystemMessage, HumanMessage
 root_dir = Path(__file__).resolve().parent.parent.parent.parent
 load_dotenv(dotenv_path=root_dir / ".env")
 
-OPENAI_MODEL = os.getenv("OPENAI_MODEL", "o4-mini")
+from src.config.models import resolve_model, is_reasoning_model  # noqa: E402
+OPENAI_MODEL = resolve_model("basic")  # env: LLM_MODEL_BASIC (default gpt-5.4-mini)
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
 
 llm_kwargs = {"model": OPENAI_MODEL, "api_key": OPENAI_API_KEY}
-if not OPENAI_MODEL.startswith("o"):
+if not is_reasoning_model(OPENAI_MODEL):  # reasoning models reject temperature
     llm_kwargs["temperature"] = 0
 llm = ChatOpenAI(**llm_kwargs)
 

--- a/ai-core/src/utils/query_understanding.py
+++ b/ai-core/src/utils/query_understanding.py
@@ -27,12 +27,13 @@ from langchain_core.messages import HumanMessage, SystemMessage
 root_dir = Path(__file__).resolve().parent.parent.parent.parent
 load_dotenv(dotenv_path=root_dir / ".env")
 
-OPENAI_MODEL = os.getenv("OPENAI_MODEL", "o4-mini")
+from src.config.models import resolve_model, is_reasoning_model  # noqa: E402
+OPENAI_MODEL = resolve_model("basic")  # env: LLM_MODEL_BASIC (default gpt-5.4-mini)
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
 
 # o4-mini doesn't support temperature parameter
 llm_kwargs = {"model": OPENAI_MODEL, "api_key": OPENAI_API_KEY}
-if not OPENAI_MODEL.startswith("o"):
+if not is_reasoning_model(OPENAI_MODEL):  # reasoning models reject temperature
     llm_kwargs["temperature"] = 0
 query_llm = ChatOpenAI(**llm_kwargs)
 


### PR DESCRIPTION
## What you asked for

Easy/surface → **gpt-5.4-mini**, hard/sophisticated → **gpt-5.4**, high-volume mechanical → **gpt-5.4-nano**, all switchable in `.env` with no code edits.

## Freshness rule: satisfied (verified, not guessed)

Model facts confirmed **2026-05-19** from your OpenAI dashboard screenshot + `developers.openai.com` (`guides/reasoning`, `/text`, `/migrate-to-responses`). `platform.openai.com`/`openai.com` were 403 — I stopped and asked rather than guess, per the rule. Verified: the 3 ids; all **reasoning** models; both `chat/completions`+`responses`; pricing /1M in·cached·out = `2.50·0.25·15` / `0.75·0.08·4.50` / `0.20·0.02·1.25`. The guides were silent on `temperature` for 5.4 → **omit it** (reasoning models reject/ignore it; superset-safe, can't-break direction). One explicitly-flagged decision; tell me if you have contrary info.

## Changes

- **`src/config/models.py`** — env-driven: `LLM_MODEL_BASIC/REASONING/CHEAP/EMBEDDING`; `resolve_model()` gains `"cheap"`; **new `is_reasoning_model()`** call-shape gate (True for o-series **and** gpt-5.x — the legacy `startswith("o")` missed gpt-5.x and would **400 the live bot** once default→gpt-5.4).
- **7 legacy files** (the path serving traffic today): `resolve_model("basic")` + `is_reasoning_model()` temperature gate.
- **`eval/judge.py`** → default `resolve_model("cheap")` (nano). Biggest single eval-cost line; ~3.7× cheaper than mini. Synthesizer/agent deliberately NOT moved to cheap.
- **`.env.example`** documents the 4 tiers + deprecates `OPENAI_MODEL`. (Your gitignored `.env` updated locally too — not in this PR.)

## Cost impact (real pricing)

Routing the eval **judge** mini→nano cuts that line ~70–85%. Default answers move o4-mini→gpt-5.4-mini (your choice); hard questions get gpt-5.4.

## Verification (offline)

`py_compile` all 10 files; **`test_models` 4/4** (defaults, 3-tier resolve + bad-tier raises, env-override via reload, `is_reasoning_model` gpt-5.4*=True/gpt-4*=False/None-safe). Regression: `new_orchestrator` 27/27, `v2_serving` 9/9, `builder` 9/9, `calibrate_clarify` 6/6, `metrics_endpoint` 6/6; imports clean, no circular. **Live API call-shape is operator-verified once credit returns** — this is the freshness-rule-gated change, grounded in verified docs.

Independent branch off `main`; excludes unrelated working-tree noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)