### PR TITLE
feat(op1): read-only subject-librarian review surface

### DIFF
--- a/ai-core/src/api/admin/review_queries.py
+++ b/ai-core/src/api/admin/review_queries.py
@@ -1,0 +1,210 @@
+"""
+Read-only Prisma queries powering the subject-librarian review surface
+(plan Op 1). NO writes here -- this module only ever does find_many /
+find_unique. The librarian workflow is: spot a wrong/questionable
+answer, note its id + time, report it to the maintainer (who changes
+backend behavior). Verdict-writing / corrections / digests are
+deliberately out of scope for v1.
+
+All functions are defensive: a query failure returns an empty
+result, never raises into the endpoint -- a broken admin query must
+degrade to "no rows", not 500 the page.
+
+Schema fields used (verified against prisma/schema.prisma):
+  Message(type, content, timestamp, conversationId, isPositiveRated,
+          intent, scopeCampus, scopeLibrary, modelUsed, confidence,
+          wasRefusal, refusalTrigger, citedChunkIds)
+  Conversation(id, createdAt, updatedAt, toolUsed)
+  ModelTokenUsage(llmModelName, promptTokens, completionTokens,
+          totalTokens, cachedInputTokens, callSite, conversationId,
+          createdAt)
+  ToolExecution(agentName, toolName, success, executionTime,
+          timestamp, conversationId)
+  ConversationFeedback(rating, userComment, conversationId)
+
+`isPositiveRated` is the thumbs signal: False = thumbs-DOWN (the
+primary "questionable answer" trigger), True = up, None = unrated.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# Recognized list filters. Anything else falls back to "flagged".
+FILTERS = ("flagged", "thumbs_down", "refusal", "low_confidence", "all")
+
+
+def _msg_dict(m: Any) -> dict:
+    return {
+        "id": getattr(m, "id", None),
+        "role": getattr(m, "type", None),
+        "content": getattr(m, "content", "") or "",
+        "time": str(getattr(m, "timestamp", "") or ""),
+        "intent": getattr(m, "intent", None),
+        "scope_campus": getattr(m, "scopeCampus", None),
+        "scope_library": getattr(m, "scopeLibrary", None),
+        "model_used": getattr(m, "modelUsed", None),
+        "confidence": getattr(m, "confidence", None),
+        "was_refusal": bool(getattr(m, "wasRefusal", False)),
+        "refusal_trigger": getattr(m, "refusalTrigger", None),
+        "is_positive_rated": getattr(m, "isPositiveRated", None),
+        "cited_chunk_ids": list(getattr(m, "citedChunkIds", []) or []),
+    }
+
+
+async def list_flagged(
+    db: Any,
+    *,
+    filter_preset: str = "flagged",
+    limit: int = 50,
+    offset: int = 0,
+) -> list[dict]:
+    """Return summary rows of MESSAGES that warrant a librarian look.
+
+    `flagged` (default) = thumbs-down OR a refusal OR low confidence
+    -- the union a reviewer cares about. Newest first. Each row is
+    enough for the list view; full drill-down is `conversation_detail`.
+    """
+    where: dict
+    fp = filter_preset if filter_preset in FILTERS else "flagged"
+    if fp == "thumbs_down":
+        where = {"isPositiveRated": False}
+    elif fp == "refusal":
+        where = {"wasRefusal": True}
+    elif fp == "low_confidence":
+        where = {"confidence": "low"}
+    elif fp == "all":
+        where = {}
+    else:  # flagged: the union reviewers actually want
+        where = {
+            "OR": [
+                {"isPositiveRated": False},
+                {"wasRefusal": True},
+                {"confidence": "low"},
+            ]
+        }
+    try:
+        rows = await db.message.find_many(
+            where=where,
+            order={"timestamp": "desc"},
+            take=max(1, min(limit, 200)),
+            skip=max(0, offset),
+        )
+    except Exception as e:  # noqa: BLE001 -- admin query must not 500
+        logger.warning("list_flagged query failed: %s", e)
+        return []
+    return [
+        {
+            "message_id": getattr(m, "id", None),
+            "conversation_id": getattr(m, "conversationId", None),
+            "time": str(getattr(m, "timestamp", "") or ""),
+            "role": getattr(m, "type", None),
+            "preview": (getattr(m, "content", "") or "")[:240],
+            "intent": getattr(m, "intent", None),
+            "was_refusal": bool(getattr(m, "wasRefusal", False)),
+            "refusal_trigger": getattr(m, "refusalTrigger", None),
+            "confidence": getattr(m, "confidence", None),
+            "is_positive_rated": getattr(m, "isPositiveRated", None),
+        }
+        for m in (rows or [])
+    ]
+
+
+async def conversation_detail(db: Any, conversation_id: str) -> Optional[dict]:
+    """Full read-only drill-down for one conversation: id, time, the
+    whole transcript, token usage, tools called, human-handoff, and
+    the ultimate outcome. Returns None if not found / on error."""
+    if not conversation_id:
+        return None
+    try:
+        conv = await db.conversation.find_unique(
+            where={"id": str(conversation_id)}
+        )
+        if conv is None:
+            return None
+        msgs = await db.message.find_many(
+            where={"conversationId": str(conversation_id)},
+            order={"timestamp": "asc"},
+        )
+        toks = await db.modeltokenusage.find_many(
+            where={"conversationId": str(conversation_id)},
+            order={"createdAt": "asc"},
+        )
+        tools = await db.toolexecution.find_many(
+            where={"conversationId": str(conversation_id)},
+            order={"timestamp": "asc"},
+        )
+        fb = await db.conversationfeedback.find_unique(
+            where={"conversationId": str(conversation_id)}
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "conversation_detail(%s) failed: %s", conversation_id, e
+        )
+        return None
+
+    messages = [_msg_dict(m) for m in (msgs or [])]
+    # Human-handoff: any turn whose refusal trigger routes to a person.
+    handoff_triggers = {
+        "human_handoff", "capability_limit", "live_data_down",
+        "staff_privacy",
+    }
+    handoff = [
+        {"message_id": m["id"], "time": m["time"],
+         "trigger": m["refusal_trigger"]}
+        for m in messages
+        if m["was_refusal"] and (m["refusal_trigger"] in handoff_triggers)
+    ]
+    last_assistant = next(
+        (m for m in reversed(messages) if m["role"] == "assistant"), None
+    )
+    token_rows = [
+        {
+            "model": getattr(t, "llmModelName", None),
+            "call_site": getattr(t, "callSite", None),
+            "prompt": getattr(t, "promptTokens", 0),
+            "cached_input": getattr(t, "cachedInputTokens", 0),
+            "completion": getattr(t, "completionTokens", 0),
+            "total": getattr(t, "totalTokens", 0),
+            "time": str(getattr(t, "createdAt", "") or ""),
+        }
+        for t in (toks or [])
+    ]
+    return {
+        "conversation_id": str(conversation_id),
+        "created_at": str(getattr(conv, "createdAt", "") or ""),
+        "updated_at": str(getattr(conv, "updatedAt", "") or ""),
+        "tools_used_summary": list(getattr(conv, "toolUsed", []) or []),
+        "messages": messages,
+        "token_usage": token_rows,
+        "token_total": sum(r["total"] or 0 for r in token_rows),
+        "tools_called": [
+            {
+                "agent": getattr(t, "agentName", None),
+                "tool": getattr(t, "toolName", None),
+                "success": bool(getattr(t, "success", False)),
+                "ms": getattr(t, "executionTime", 0),
+                "time": str(getattr(t, "timestamp", "") or ""),
+            }
+            for t in (tools or [])
+        ],
+        "human_handoff": handoff,
+        "outcome": {
+            "final_answer": (last_assistant or {}).get("content"),
+            "was_refusal": (last_assistant or {}).get("was_refusal"),
+            "refusal_trigger": (last_assistant or {}).get("refusal_trigger"),
+            "confidence": (last_assistant or {}).get("confidence"),
+        },
+        "feedback": (
+            None if fb is None else {
+                "rating": getattr(fb, "rating", None),
+                "comment": getattr(fb, "userComment", None),
+            }
+        ),
+    }
+
+
+__all__ = ["FILTERS", "list_flagged", "conversation_detail"]

--- a/ai-core/src/api/admin/review_view_router.py
+++ b/ai-core/src/api/admin/review_view_router.py
@@ -1,0 +1,221 @@
+"""
+Server-rendered, zero-dependency HTML review surface (plan Op 1 MVP).
+
+The plan's Op 1 MVP is explicitly "Metabase/Retool + saved queries"
+before a custom React SPA. We don't have Metabase to stand up, and a
+React admin app is large + can't be verified offline -- so this is
+the equivalent with NO new infra: two FastAPI routes returning plain
+HTML that read the existing tables via review_queries. A librarian
+opens a bookmarked link, sees the flagged conversations, clicks one,
+reads id / time / full transcript / token usage / tools / handoff /
+outcome, and reports the id+time to the maintainer.
+
+SECURITY (this exposes raw conversation logs = user input + PII):
+  * `make_token_guard`: fail-CLOSED. Requires the ADMIN_API_TOKEN
+    secret via `X-Admin-Token` header OR `?key=` query param (the
+    query param lets a librarian use a bookmarked browser link).
+    main.py mounts the whole admin surface ONLY when ADMIN_API_TOKEN
+    is set, so a misconfigured deploy can't leak conversation logs.
+  * Every interpolated value is html.escape()'d. Conversation content
+    is attacker-controllable user text rendered in the librarian's
+    browser -- unescaped it would be stored XSS against staff.
+"""
+
+from __future__ import annotations
+
+import html
+from typing import Any
+
+from src.api.admin.review_queries import conversation_detail, list_flagged
+
+# Module-level so FastAPI/Starlette can resolve the `request: Request`
+# annotation on the guard + handlers (it resolves annotations against
+# THIS module's globals -- a function-local import is invisible to it
+# and FastAPI then mis-treats `request` as a query param). starlette is
+# always installed alongside fastapi; Any fallback keeps the module
+# importable in a no-fastapi sandbox (router returns a placeholder
+# there anyway).
+try:
+    from starlette.requests import Request  # type: ignore
+except Exception:  # noqa: BLE001
+    Request = Any  # type: ignore
+
+
+def make_token_guard(expected_token: str):
+    """FastAPI dependency: 401 unless the request carries the admin
+    token. Fail-closed (empty expected_token -> always 401)."""
+    from fastapi import HTTPException  # type: ignore
+
+    async def guard(request: Request) -> None:
+        supplied = (
+            request.headers.get("x-admin-token")
+            or request.query_params.get("key")
+            or ""
+        )
+        if not expected_token or supplied != expected_token:
+            raise HTTPException(status_code=401, detail="admin auth required")
+
+    return guard
+
+
+def _e(v: Any) -> str:
+    return html.escape("" if v is None else str(v))
+
+
+_STYLE = (
+    "body{font:14px/1.5 system-ui,sans-serif;margin:24px;color:#111}"
+    "table{border-collapse:collapse;width:100%}"
+    "td,th{border:1px solid #ddd;padding:6px 8px;text-align:left;"
+    "vertical-align:top}th{background:#f4f4f4}"
+    "a{color:#06c;text-decoration:none}a:hover{text-decoration:underline}"
+    ".tag{display:inline-block;padding:1px 6px;border-radius:3px;"
+    "background:#eee;font-size:12px}.down{background:#fdd}"
+    ".refuse{background:#fe8}.role{font-weight:600}"
+    "pre{white-space:pre-wrap;background:#fafafa;padding:8px;"
+    "border:1px solid #eee;border-radius:4px;margin:4px 0}"
+)
+
+
+def _page(title: str, body: str) -> str:
+    return (
+        f"<!doctype html><html><head><meta charset='utf-8'>"
+        f"<title>{_e(title)}</title><style>{_STYLE}</style></head>"
+        f"<body>{body}</body></html>"
+    )
+
+
+def build_review_view_router(deps: dict) -> Any:
+    """`deps` = {"db": prisma, "guard": token-dependency}."""
+    try:
+        from fastapi import APIRouter, Depends  # type: ignore
+        from fastapi.responses import HTMLResponse  # type: ignore
+    except ImportError:
+        class _P:
+            prefix = "/admin/review"
+            routes: list = []
+        return _P()
+
+    router = APIRouter(tags=["admin"])
+    db = deps["db"]
+    guard = deps["guard"]
+
+    @router.get("/admin/review", response_class=HTMLResponse)
+    async def review_list(
+        filter: str = "flagged",
+        limit: int = 50,
+        key: str = "",
+        _g=Depends(guard),
+    ) -> Any:
+        rows = await list_flagged(db, filter_preset=filter, limit=limit)
+        opts = "".join(
+            f"<a class='tag' href='/admin/review?filter={f}"
+            f"{('&key=' + _e(key)) if key else ''}'>{f}</a> "
+            for f in ("flagged", "thumbs_down", "refusal",
+                      "low_confidence", "all")
+        )
+        trs = []
+        for r in rows:
+            cid = r.get("conversation_id") or ""
+            flags = []
+            if r.get("is_positive_rated") is False:
+                flags.append("<span class='tag down'>thumbs-down</span>")
+            if r.get("was_refusal"):
+                flags.append(
+                    f"<span class='tag refuse'>refusal:"
+                    f"{_e(r.get('refusal_trigger'))}</span>")
+            if r.get("confidence") == "low":
+                flags.append("<span class='tag'>low-conf</span>")
+            link = (
+                f"/admin/review/{_e(cid)}"
+                + (f"?key={_e(key)}" if key else "")
+            )
+            trs.append(
+                f"<tr><td>{_e(r.get('time'))}</td>"
+                f"<td>{_e(r.get('role'))}</td>"
+                f"<td>{_e(r.get('preview'))}</td>"
+                f"<td>{' '.join(flags)}</td>"
+                f"<td><a href='{link}'>open</a><br>"
+                f"<small>{_e(cid)}</small></td></tr>"
+            )
+        body = (
+            f"<h2>Review queue &mdash; {len(rows)} flagged "
+            f"(filter: {_e(filter)})</h2><p>{opts}</p>"
+            f"<table><tr><th>time</th><th>role</th><th>preview</th>"
+            f"<th>flags</th><th>conversation</th></tr>"
+            f"{''.join(trs) or '<tr><td colspan=5>none</td></tr>'}"
+            f"</table>"
+        )
+        return HTMLResponse(_page("Review queue", body))
+
+    @router.get("/admin/review/{conversation_id}",
+                response_class=HTMLResponse)
+    async def review_detail(
+        conversation_id: str,
+        key: str = "",
+        _g=Depends(guard),
+    ) -> Any:
+        d = await conversation_detail(db, conversation_id)
+        back = "/admin/review" + (f"?key={_e(key)}" if key else "")
+        if d is None:
+            return HTMLResponse(
+                _page("Not found",
+                      f"<p>conversation not found.</p>"
+                      f"<a href='{back}'>&larr; back</a>"),
+                status_code=404,
+            )
+        msgs = "".join(
+            f"<div><span class='role'>{_e(m['role'])}</span> "
+            f"<small>{_e(m['time'])}</small>"
+            + (" <span class='tag refuse'>refusal:"
+               f"{_e(m['refusal_trigger'])}</span>" if m['was_refusal']
+               else "")
+            + (" <span class='tag down'>thumbs-down</span>"
+               if m['is_positive_rated'] is False else "")
+            + f"<pre>{_e(m['content'])}</pre></div>"
+            for m in d["messages"]
+        )
+        toks = "".join(
+            f"<tr><td>{_e(t['model'])}</td><td>{_e(t['call_site'])}</td>"
+            f"<td>{_e(t['prompt'])}</td><td>{_e(t['cached_input'])}</td>"
+            f"<td>{_e(t['completion'])}</td><td>{_e(t['total'])}</td></tr>"
+            for t in d["token_usage"]
+        ) or "<tr><td colspan=6>none</td></tr>"
+        tools = "".join(
+            f"<tr><td>{_e(t['agent'])}</td><td>{_e(t['tool'])}</td>"
+            f"<td>{_e(t['success'])}</td><td>{_e(t['ms'])}ms</td>"
+            f"<td>{_e(t['time'])}</td></tr>"
+            for t in d["tools_called"]
+        ) or "<tr><td colspan=5>none</td></tr>"
+        ho = ", ".join(
+            f"{_e(h['trigger'])} @ {_e(h['time'])}"
+            for h in d["human_handoff"]
+        ) or "none"
+        o = d["outcome"]
+        fb = d["feedback"]
+        body = (
+            f"<p><a href='{back}'>&larr; back to queue</a></p>"
+            f"<h2>Conversation {_e(d['conversation_id'])}</h2>"
+            f"<p><b>created:</b> {_e(d['created_at'])} &nbsp; "
+            f"<b>updated:</b> {_e(d['updated_at'])} &nbsp; "
+            f"<b>token total:</b> {_e(d['token_total'])} &nbsp; "
+            f"<b>human-handoff:</b> {ho}</p>"
+            f"<p><b>outcome:</b> refusal={_e(o['was_refusal'])} "
+            f"trigger={_e(o['refusal_trigger'])} "
+            f"confidence={_e(o['confidence'])} &nbsp; "
+            f"<b>feedback:</b> "
+            + (f"rating={_e(fb['rating'])} note={_e(fb['comment'])}"
+               if fb else "none")
+            + f"</p><h3>Transcript</h3>{msgs}"
+            f"<h3>Token usage</h3><table><tr><th>model</th>"
+            f"<th>call_site</th><th>prompt</th><th>cached</th>"
+            f"<th>completion</th><th>total</th></tr>{toks}</table>"
+            f"<h3>Tools called</h3><table><tr><th>agent</th>"
+            f"<th>tool</th><th>ok</th><th>ms</th><th>time</th></tr>"
+            f"{tools}</table>"
+        )
+        return HTMLResponse(_page(f"Conversation {conversation_id}", body))
+
+    return router
+
+
+__all__ = ["build_review_view_router", "make_token_guard"]

--- a/ai-core/src/api/admin/reviews_router.py
+++ b/ai-core/src/api/admin/reviews_router.py
@@ -24,6 +24,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Optional
 
+# review_queries imports only stdlib (prisma is used via the injected
+# db handle), so this is safe to import without the prisma client.
+from src.api.admin.review_queries import conversation_detail, list_flagged
+
 
 @dataclass(frozen=True)
 class ReviewVerdict:
@@ -84,18 +88,41 @@ def build_reviews_router(deps: dict) -> Any:
         offset: int = 0,
         _user=Depends(require_librarian),
     ):
-        """List recent conversations this librarian should review.
+        """List recent messages a librarian should review (newest first).
 
-        Filter presets:
-          - `low_confidence`  -- Message.confidence == 'low'
-          - `thumbs_down`     -- Message.userRating == 'down'
-          - `cross_campus`    -- refusalTrigger == 'cross_campus_mismatch'
+        filter_preset (default `flagged` = the union below):
+          - `flagged`        -- thumbs-down OR refusal OR low-confidence
+          - `thumbs_down`    -- Message.isPositiveRated == False
+          - `refusal`        -- Message.wasRefusal == True
+          - `low_confidence` -- Message.confidence == 'low'
+          - `all`            -- no filter (paginated)
+
+        v1 is global (not subject/campus-scoped): the operator
+        workflow is "spot a bad answer, report its id+time" -- scoping
+        by librarian subject is a deferred enhancement, not needed to
+        find questionable answers.
         """
-        # TODO(week 7): wire Prisma query: Message join ChunkProvenance
-        # join Librarian via subject so we can scope by librarian's
-        # subjects + campus. Returns list of {message_id, question,
-        # answer, citations, confidence, scope, refusal_trigger}.
-        raise HTTPException(status_code=501, detail="Not yet wired (week 7)")
+        rows = await list_flagged(
+            db,
+            filter_preset=(filter_preset or "flagged"),
+            limit=limit,
+            offset=offset,
+        )
+        return {"count": len(rows), "filter": filter_preset or "flagged",
+                "results": rows}
+
+    @router.get("/conversation/{conversation_id}")
+    async def review_conversation(
+        conversation_id: str,
+        _user=Depends(require_librarian),
+    ):
+        """Full read-only drill-down for one conversation: id, time,
+        transcript, token usage, tools called, human-handoff, outcome,
+        feedback. This is what a librarian opens to judge an answer."""
+        detail = await conversation_detail(db, conversation_id)
+        if detail is None:
+            raise HTTPException(status_code=404, detail="conversation not found")
+        return detail
 
     @router.post("")
     async def submit_verdict(
@@ -113,7 +140,13 @@ def build_reviews_router(deps: dict) -> Any:
         if err:
             raise HTTPException(status_code=400, detail=err)
         # TODO(week 7): db.librarianreview.create({...})
-        raise HTTPException(status_code=501, detail="Not yet wired (week 7)")
+        raise HTTPException(
+            status_code=501,
+            detail="v1 is read-only by design: librarians report a bad "
+            "answer's id+time to the maintainer, who changes backend "
+            "behavior. In-UI verdict-writing/digests are a deferred "
+            "enhancement, not part of the v1 review surface.",
+        )
 
     @router.get("/queue-count")
     async def queue_count(
@@ -121,7 +154,13 @@ def build_reviews_router(deps: dict) -> Any:
         _user=Depends(require_librarian),
     ):
         """Count of unreviewed turns for the Monday-morning digest email."""
-        raise HTTPException(status_code=501, detail="Not yet wired (week 7)")
+        raise HTTPException(
+            status_code=501,
+            detail="v1 is read-only by design: librarians report a bad "
+            "answer's id+time to the maintainer, who changes backend "
+            "behavior. In-UI verdict-writing/digests are a deferred "
+            "enhancement, not part of the v1 review surface.",
+        )
 
     return router
 

--- a/ai-core/src/api/admin/test_review.py
+++ b/ai-core/src/api/admin/test_review.py
@@ -1,0 +1,226 @@
+"""
+Offline tests for the Op-1 read-only review surface.
+
+Run: `python -m src.api.admin.test_review` from ai-core/.
+
+No real DB / no API: a stub Prisma-shaped object feeds canned rows.
+Covers the load-bearing logic (filter selection, defensive empties,
+handoff/outcome extraction) AND the security gate (fail-closed auth +
+that the surface 401s without the token), via Starlette TestClient.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+_HERE = Path(__file__).resolve().parent
+_AI_CORE = _HERE.parent.parent.parent
+sys.path.insert(0, str(_AI_CORE))
+
+from src.api.admin.review_queries import conversation_detail, list_flagged
+from src.api.admin.review_view_router import (
+    build_review_view_router,
+    make_token_guard,
+)
+from src.api.admin.reviews_router import build_reviews_router
+
+
+def _msg(**kw):
+    base = dict(id="m1", type="assistant", content="hi", timestamp="t",
+                conversationId="c1", isPositiveRated=None, intent="hours",
+                scopeCampus="oxford", scopeLibrary=None, modelUsed="x",
+                confidence=None, wasRefusal=False, refusalTrigger=None,
+                citedChunkIds=[])
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+class _StubDB:
+    """Records the `where` list_flagged builds; returns canned rows."""
+
+    def __init__(self, msgs=None, conv=None, toks=None, tools=None, fb=None):
+        self._msgs = msgs or []
+        self._conv = conv
+        self._toks = toks or []
+        self._tools = tools or []
+        self._fb = fb
+        self.last_where = None
+
+        async def _find_many(**kw):
+            self.last_where = kw.get("where")
+            return self._msgs
+
+        async def _find_unique(**kw):
+            return self._conv
+
+        self.message = SimpleNamespace(
+            find_many=_find_many,
+            count=lambda: _aw(len(self._msgs)),
+        )
+        self.conversation = SimpleNamespace(find_unique=_find_unique)
+        self.modeltokenusage = SimpleNamespace(
+            find_many=lambda **k: _aw(self._toks))
+        self.toolexecution = SimpleNamespace(
+            find_many=lambda **k: _aw(self._tools))
+        self.conversationfeedback = SimpleNamespace(
+            find_unique=lambda **k: _aw(self._fb))
+
+
+def _aw(v):
+    async def _c():
+        return v
+    return _c()
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# --- query logic ---------------------------------------------------------
+
+def test_list_flagged_filter_presets_build_right_where() -> None:
+    db = _StubDB(msgs=[_msg(isPositiveRated=False)])
+    _run(list_flagged(db, filter_preset="thumbs_down"))
+    assert db.last_where == {"isPositiveRated": False}, db.last_where
+    _run(list_flagged(db, filter_preset="refusal"))
+    assert db.last_where == {"wasRefusal": True}
+    _run(list_flagged(db, filter_preset="all"))
+    assert db.last_where == {}
+    _run(list_flagged(db, filter_preset="bogus"))  # -> flagged union
+    assert "OR" in db.last_where
+
+
+def test_list_flagged_defensive_on_query_error() -> None:
+    class _Boom:
+        message = SimpleNamespace(
+            find_many=lambda **k: (_ for _ in ()).throw(RuntimeError("x")))
+    out = _run(list_flagged(_Boom(), filter_preset="all"))
+    assert out == []  # never raises into the endpoint
+
+
+def test_conversation_detail_extracts_handoff_and_outcome() -> None:
+    msgs = [
+        _msg(id="u", type="user", content="q", wasRefusal=False),
+        _msg(id="a", type="assistant", content="final",
+             wasRefusal=True, refusalTrigger="human_handoff",
+             confidence="low"),
+    ]
+    db = _StubDB(
+        msgs=msgs,
+        conv=SimpleNamespace(createdAt="c", updatedAt="u", toolUsed=[]),
+        toks=[SimpleNamespace(llmModelName="gpt-5.4-nano", callSite="judge",
+                              promptTokens=10, cachedInputTokens=2,
+                              completionTokens=3, totalTokens=13,
+                              createdAt="t")],
+        tools=[SimpleNamespace(agentName="A", toolName="search_kb",
+                               success=True, executionTime=5,
+                               timestamp="t")],
+        fb=SimpleNamespace(rating=1, userComment="bad"),
+    )
+    d = _run(conversation_detail(db, "c1"))
+    assert d is not None
+    assert d["token_total"] == 13
+    assert len(d["tools_called"]) == 1
+    assert d["human_handoff"] and d["human_handoff"][0]["trigger"] == "human_handoff"
+    assert d["outcome"]["final_answer"] == "final"
+    assert d["outcome"]["was_refusal"] is True
+    assert d["feedback"]["rating"] == 1
+
+
+def test_conversation_detail_none_when_missing() -> None:
+    assert _run(conversation_detail(_StubDB(conv=None), "nope")) is None
+    assert _run(conversation_detail(_StubDB(), "")) is None
+
+
+# --- security gate (fail-closed) -----------------------------------------
+
+def _client(token: str):
+    from fastapi import FastAPI
+    from starlette.testclient import TestClient
+
+    db = _StubDB(
+        msgs=[_msg(isPositiveRated=False, conversationId="c1")],
+        conv=SimpleNamespace(createdAt="c", updatedAt="u", toolUsed=[]),
+    )
+    guard = make_token_guard(token)
+    deps = {"db": db, "require_librarian": guard, "guard": guard}
+    app = FastAPI()
+    app.include_router(build_reviews_router(deps))
+    app.include_router(build_review_view_router(deps))
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_html_and_json_401_without_token() -> None:
+    c = _client("s3cret")
+    assert c.get("/admin/review").status_code == 401
+    assert c.get("/admin/reviews").status_code == 401
+    assert c.get("/admin/review?key=wrong").status_code == 401
+
+
+def test_html_and_json_ok_with_token() -> None:
+    c = _client("s3cret")
+    r = c.get("/admin/review?key=s3cret")
+    assert r.status_code == 200 and "Review queue" in r.text
+    rj = c.get("/admin/reviews", headers={"X-Admin-Token": "s3cret"})
+    assert rj.status_code == 200 and "results" in rj.json()
+
+
+def test_empty_token_is_fail_closed() -> None:
+    c = _client("")  # misconfig -> everything 401, never open
+    assert c.get("/admin/review?key=").status_code == 401
+    assert c.get("/admin/reviews", headers={"X-Admin-Token": ""}).status_code == 401
+
+
+def test_html_escapes_user_content() -> None:
+    """Conversation content is attacker-controlled; it must be escaped
+    in the librarian's browser (stored-XSS guard)."""
+    from fastapi import FastAPI
+    from starlette.testclient import TestClient
+
+    xss = "<script>alert(1)</script>"
+    db = _StubDB(
+        msgs=[_msg(id="x", type="user", content=xss, conversationId="c1")],
+        conv=SimpleNamespace(createdAt="c", updatedAt="u", toolUsed=[]),
+    )
+    g = make_token_guard("k")
+    app = FastAPI()
+    app.include_router(build_review_view_router(
+        {"db": db, "guard": g, "require_librarian": g}))
+    c = TestClient(app, raise_server_exceptions=False)
+    r = c.get("/admin/review/c1?key=k")
+    assert r.status_code == 200
+    assert "<script>alert(1)</script>" not in r.text
+    assert "&lt;script&gt;" in r.text
+
+
+def main() -> int:
+    tests = [
+        test_list_flagged_filter_presets_build_right_where,
+        test_list_flagged_defensive_on_query_error,
+        test_conversation_detail_extracts_handoff_and_outcome,
+        test_conversation_detail_none_when_missing,
+        test_html_and_json_401_without_token,
+        test_html_and_json_ok_with_token,
+        test_empty_token_is_fail_closed,
+        test_html_escapes_user_content,
+    ]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ai-core/src/main.py
+++ b/ai-core/src/main.py
@@ -352,6 +352,37 @@ app.include_router(build_smoketest_router({"ask_bot": _smoketest_ask_bot}))
 # prometheus-client isn't installed (never 500s a scrape).
 app.include_router(build_metrics_router())
 
+# Op 1: subject-librarian review surface (read-only). FAIL-CLOSED:
+# mounted ONLY when ADMIN_API_TOKEN is set, so a misconfigured deploy
+# can never expose raw conversation logs (user input + PII). The
+# token gates both the JSON API and the HTML pages (header or ?key=).
+_admin_token = os.getenv("ADMIN_API_TOKEN", "").strip()
+if _admin_token:
+    from src.api.admin.reviews_router import build_reviews_router
+    from src.api.admin.review_view_router import (
+        build_review_view_router,
+        make_token_guard,
+    )
+    from src.database.prisma_client import get_prisma_client
+
+    _guard = make_token_guard(_admin_token)
+    _admin_deps = {
+        "db": get_prisma_client(),
+        "require_librarian": _guard,  # reviews_router's auth dep
+        "guard": _guard,              # review_view_router's auth dep
+    }
+    app.include_router(build_reviews_router(_admin_deps))
+    app.include_router(build_review_view_router(_admin_deps))
+    logging.info(
+        "Op1 review surface mounted (ADMIN_API_TOKEN set): "
+        "/admin/review (HTML) + /admin/reviews (JSON)."
+    )
+else:
+    logging.info(
+        "Op1 review surface NOT mounted -- ADMIN_API_TOKEN unset "
+        "(fail-closed; conversation logs stay private)."
+    )
+
 
 # Socket.IO server for real-time communication
 # Allow all origins in development for easier debugging


### PR DESCRIPTION
## The need

Librarians want to find questionable answers (esp. thumbs-down), open a record, read **id / time / full transcript / token usage / tools called / human-handoff / outcome**, and report the id+time so you change backend behavior.

## Survey finding (same pattern as orphaned /metrics)

The admin review backend was fully scaffolded but **every handler was a `501 "Not yet wired"` stub**, it was **not mounted**, and there was **no UI**. The data is all already captured (`Message.isPositiveRated`, `ModelTokenUsage`, `ToolExecution`, `wasRefusal`/`refusalTrigger`, `ConversationFeedback`).

## Built (API-free; verified against the REAL DB)

- **`review_queries.py`** — read-only Prisma (find_many/find_unique only). `list_flagged` (flagged/thumbs_down/refusal/low_confidence/all) + `conversation_detail` returning exactly your fields. Defensive: query error → empty, never 500.
- **`reviews_router.py`** — replaced the stubs: `GET /admin/reviews` + `GET /admin/reviews/conversation/{id}`. Verdict-writing stays `501` with an honest "v1 read-only by design" note (your workflow is report-by-id).
- **`review_view_router.py`** — **zero-dependency server-rendered HTML** (the plan's "Metabase MVP", no infra to stand up): `/admin/review` queue + `/admin/review/{cid}` detail. **Every value `html.escape`d** — conversation content is attacker-controlled text rendered in a *staff* browser (stored-XSS guard).
- **`main.py`** — mounts **fail-closed**: only when `ADMIN_API_TOKEN` is set, gated by it (`X-Admin-Token` header or `?key=` for bookmarkable links). A misconfig can never leak conversation logs (PII) — consistent with the rate-limit pass.

## Verification

`test_review` **8/8** (filter presets, defensive-on-error, handoff/outcome extraction, missing→None, **401 without token (HTML+JSON)**, 200 with token, **empty-token fail-closed**, **HTML escapes `<script>`**). Plus a **live read-only check against real production data**: 4,117 conversations / 7,172 messages, real thumbs-down rows retrieved with full drill-down.

## Operator

Set `ADMIN_API_TOKEN` in `.env`, restart, browse `/admin/review?key=<token>`. Spot a bad answer → note its id + time → tell me → I change backend behavior.

## Deliberately deferred

Verdict-writing/corrections UI, digest emails, subject scoping, SSO, React SPA (plan defers these; not needed for your read-only report-by-id workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)