### PR TITLE
feat(ops): finish cost_rollup — real DB I/O, per-callSite, verified prices

### DIFF
--- a/ai-core/scripts/cost_rollup.py
+++ b/ai-core/scripts/cost_rollup.py
@@ -28,9 +28,10 @@ thin wrapper that's easy to add.
 from __future__ import annotations
 
 import argparse
+import asyncio
 import logging
 from dataclasses import dataclass
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from typing import Optional
 
 
@@ -44,19 +45,34 @@ logger = logging.getLogger("cost_rollup")
 # (b) grep-ability matters -- "where did we get that $X number" should
 # resolve to a file, not a DB row.
 #
-# Note: cached input tokens are billed at ~50% of regular input per
-# OpenAI's prompt-cache docs. The ratio is confirmable at the freshness-
-# check point when touching the LLM client. Until then, treat these as
-# PLACEHOLDER values -- a production deploy must reconcile with the
-# billing-dashboard actual rates.
+# gpt-5.4 family rates VERIFIED 2026-05-19 against the operator's
+# OpenAI dashboard (same source that set src/config/models.py). An
+# UNKNOWN model (e.g. a dated snapshot like "o4-mini-2025-04-16", or a
+# model not yet priced here) -> compute_cost_usd returns $0 and logs a
+# WARN: the rollup still records the token counts, it just can't price
+# them until someone adds a row here. That is the deliberate safe
+# behavior (a mis-priced/guessed rate is worse than a flagged $0).
+# Operator-maintained: add a row when a new model ships.
 
 PRICE_PER_1M_TOKENS: dict[str, dict[str, float]] = {
-    # Stub rates; check openai.com/pricing at deploy.
-    "gpt-5.4-mini": {
-        "input": 0.15,
-        "cached_input": 0.075,  # 50% of input
-        "output": 0.60,
+    "gpt-5.4": {
+        "input": 2.50,
+        "cached_input": 0.25,
+        "output": 15.00,
     },
+    "gpt-5.4-mini": {
+        "input": 0.75,
+        "cached_input": 0.08,
+        "output": 4.50,
+    },
+    "gpt-5.4-nano": {
+        "input": 0.20,
+        "cached_input": 0.02,
+        "output": 1.25,
+    },
+    # Pre-rebuild model; kept so historical ModelTokenUsage rows price
+    # correctly. (Superseded by the gpt-5.4 tiers per the model-tier
+    # refactor; safe to leave.)
     "gpt-5.2": {
         "input": 2.50,
         "cached_input": 1.25,
@@ -87,22 +103,29 @@ class UsageRow:
 
 @dataclass(frozen=True)
 class DailyCostRow:
-    """One DailyCost row -- the output of rollup."""
+    """One DailyCost row -- the output of rollup. One row per
+    (date, model, call_site) to match the DailyCost @@unique key, so
+    the dashboard answers "which part of the pipeline costs money"
+    (synthesizer vs judge vs agent), not just "gpt-5.4 in general"."""
 
     the_date: date
     model: str
+    call_site: str
     input_tokens: int
     cached_input_tokens: int
     output_tokens: int
+    call_count: int
     usd: float
 
     def as_dict(self) -> dict:
         return {
             "date": self.the_date.isoformat(),
             "model": self.model,
+            "call_site": self.call_site,
             "input_tokens": self.input_tokens,
             "cached_input_tokens": self.cached_input_tokens,
             "output_tokens": self.output_tokens,
+            "call_count": self.call_count,
             "usd": round(self.usd, 4),
         }
 
@@ -147,29 +170,36 @@ def compute_cost_usd(
 def rollup_by_model(
     usage_rows: list[UsageRow], the_date: date
 ) -> list[DailyCostRow]:
-    """Aggregate a day's usage rows into one DailyCostRow per model."""
-    totals: dict[str, dict] = {}
+    """Aggregate a day's usage into one DailyCostRow per
+    (model, call_site). Name kept for back-compat with callers; it now
+    rolls up per (model, call_site) per the operator's Option-A
+    decision (the DailyCost @@unique key is (date, model, callSite)).
+    `call_count` = number of ModelTokenUsage rows in that bucket."""
+    totals: dict[tuple[str, str], dict] = {}
     for r in usage_rows:
+        key = (r.model, r.call_site or "unknown")
         t = totals.setdefault(
-            r.model,
-            {"input": 0, "cached": 0, "output": 0},
+            key, {"input": 0, "cached": 0, "output": 0, "n": 0}
         )
         t["input"] += r.input_tokens
         t["cached"] += r.cached_input_tokens
         t["output"] += r.output_tokens
+        t["n"] += 1
 
     return [
         DailyCostRow(
             the_date=the_date,
             model=model,
+            call_site=call_site,
             input_tokens=t["input"],
             cached_input_tokens=t["cached"],
             output_tokens=t["output"],
+            call_count=t["n"],
             usd=compute_cost_usd(
                 model, t["input"], t["cached"], t["output"]
             ),
         )
-        for model, t in totals.items()
+        for (model, call_site), t in totals.items()
     ]
 
 
@@ -187,37 +217,118 @@ def anomaly_ratio(today_total: float, trailing_avg: float) -> float:
 # --- DB wrapper (gated) ---------------------------------------------------
 
 
-def _load_usage_rows(the_date: date) -> list[UsageRow]:
-    """Load ModelTokenUsage rows for the given date. Gated on Prisma
-    being importable. In the sandbox this raises; the orchestrator
-    script catches and reports."""
+async def _aload_usage_rows(the_date: date) -> list[UsageRow]:
+    from prisma import Prisma  # type: ignore
+
+    # [00:00, next 00:00) UTC for the bucket date. createdAt is
+    # timestamptz; tz-aware bounds avoid an off-by-a-few-hours bleed.
+    start = datetime(
+        the_date.year, the_date.month, the_date.day, tzinfo=timezone.utc
+    )
+    end = start + timedelta(days=1)
+    db = Prisma()
+    await db.connect()
     try:
-        from prisma import Prisma  # type: ignore
+        recs = await db.modeltokenusage.find_many(
+            where={"createdAt": {"gte": start, "lt": end}}
+        )
+    finally:
+        await db.disconnect()
+    return [
+        UsageRow(
+            model=getattr(r, "llmModelName", "") or "unknown",
+            input_tokens=getattr(r, "promptTokens", 0) or 0,
+            cached_input_tokens=getattr(r, "cachedInputTokens", 0) or 0,
+            output_tokens=getattr(r, "completionTokens", 0) or 0,
+            # Legacy rows have callSite=None -> bucket as "unknown"
+            # (DailyCost.callSite is a non-null column).
+            call_site=getattr(r, "callSite", None) or "unknown",
+        )
+        for r in (recs or [])
+    ]
+
+
+def _load_usage_rows(the_date: date) -> list[UsageRow]:
+    """Load ModelTokenUsage rows for `the_date` (UTC day). Sync wrapper
+    around async Prisma -- this is a one-shot cron script, no running
+    loop, so asyncio.run is correct. Any failure (Prisma not
+    generated, tunnel/DB down) -> NotImplementedError so the CLI
+    reports cleanly and exits 2 instead of dumping a traceback."""
+    try:
+        return asyncio.run(_aload_usage_rows(the_date))
     except ImportError as e:
         raise NotImplementedError(
-            "Prisma client not generated. Run `npx prisma generate` "
-            "after adding the cached_input_tokens and call_site columns "
-            "to the ModelTokenUsage model, then retry."
+            "Prisma client not generated -- run `python -m prisma "
+            "generate` (venv-targeted), then retry."
+        ) from e
+    except Exception as e:  # noqa: BLE001
+        raise NotImplementedError(
+            f"Could not load ModelTokenUsage for {the_date} "
+            f"({type(e).__name__}: {e}). Is the DB/tunnel up?"
         ) from e
 
-    # TODO: real query
-    #   async with Prisma() as db:
-    #       rows = await db.modeltokenusage.find_many(
-    #           where={"createdAt": {"gte": start, "lt": end}}
-    #       )
-    #       return [UsageRow(...) for r in rows]
-    raise NotImplementedError("DB wiring -- week 6/7 task")
+
+async def _awrite_daily_cost(rows: list[DailyCostRow]) -> int:
+    from prisma import Prisma  # type: ignore
+
+    db = Prisma()
+    await db.connect()
+    n = 0
+    try:
+        for row in rows:
+            # prisma-client-py can't serialize a bare datetime.date;
+            # the @db.Date column takes a datetime. Midnight UTC of the
+            # bucket day -> the DB still stores just the date part.
+            dt = datetime(
+                row.the_date.year, row.the_date.month, row.the_date.day,
+                tzinfo=timezone.utc,
+            )
+            payload = {
+                "date": dt,
+                "model": row.model,
+                "callSite": row.call_site,
+                "inputTokens": row.input_tokens,
+                "cachedTokens": row.cached_input_tokens,
+                "outputTokens": row.output_tokens,
+                "callCount": row.call_count,
+                "usd": float(round(row.usd, 6)),
+            }
+            # Idempotent: the @@unique([date, model, callSite]) key ->
+            # prisma compound key `date_model_callSite`. Re-running a
+            # date overwrites that bucket (no duplicate rows).
+            await db.dailycost.upsert(
+                where={
+                    "date_model_callSite": {
+                        "date": dt,
+                        "model": row.model,
+                        "callSite": row.call_site,
+                    }
+                },
+                data={"create": payload, "update": payload},
+            )
+            n += 1
+    finally:
+        await db.disconnect()
+    return n
 
 
 def _write_daily_cost(rows: list[DailyCostRow]) -> None:
-    """Upsert DailyCost rows."""
+    """Idempotent upsert of DailyCost rows. Sync wrapper (cron script).
+    A failure raises NotImplementedError so the CLI exits 2 cleanly."""
+    if not rows:
+        return
     try:
-        from prisma import Prisma  # type: ignore  # noqa: F401
+        n = asyncio.run(_awrite_daily_cost(rows))
+        logger.info("wrote/updated %d DailyCost row(s)", n)
     except ImportError as e:
         raise NotImplementedError(
-            "Prisma client not generated. Cannot write DailyCost rows."
+            "Prisma client not generated -- cannot write DailyCost."
         ) from e
-    raise NotImplementedError("DB wiring -- week 6/7 task")
+    except Exception as e:  # noqa: BLE001
+        raise NotImplementedError(
+            f"Could not write DailyCost ({type(e).__name__}: {e}). "
+            f"Is the DB/tunnel up?"
+        ) from e
 
 
 # --- CLI -----------------------------------------------------------------

--- a/ai-core/scripts/test_cost_rollup.py
+++ b/ai-core/scripts/test_cost_rollup.py
@@ -59,21 +59,21 @@ from scripts.cost_rollup import (  # noqa: E402
 
 
 def test_no_cache_billed_input_plus_output() -> None:
-    # gpt-5.4-mini: input $0.15, output $0.60 per 1M tokens.
+    # gpt-5.4-mini (verified 2026-05-19): input $0.75, output $4.50 /1M.
     cost = compute_cost_usd("gpt-5.4-mini", input_tokens=1_000_000, cached_input_tokens=0, output_tokens=1_000_000)
-    assert abs(cost - (0.15 + 0.60)) < 1e-9
+    assert abs(cost - (0.75 + 4.50)) < 1e-9
 
 
 def test_full_cache_only_cached_rate() -> None:
-    # gpt-5.4-mini: cached_input $0.075 per 1M.
+    # gpt-5.4-mini cached_input $0.08 /1M (verified).
     cost = compute_cost_usd("gpt-5.4-mini", input_tokens=1_000_000, cached_input_tokens=1_000_000, output_tokens=0)
-    assert abs(cost - 0.075) < 1e-9
+    assert abs(cost - 0.08) < 1e-9
 
 
 def test_partial_cache_weighted_blend() -> None:
     # 60% cached, 40% uncached on 1M input tokens; no output.
     cost = compute_cost_usd("gpt-5.4-mini", input_tokens=1_000_000, cached_input_tokens=600_000, output_tokens=0)
-    expected = 0.4 * 0.15 + 0.6 * 0.075
+    expected = 0.4 * 0.75 + 0.6 * 0.08
     assert abs(cost - expected) < 1e-9
 
 
@@ -86,8 +86,8 @@ def test_cached_exceeds_input_caps_at_input() -> None:
     """If telemetry ever reports cached > input (it shouldn't), we
     must NOT bill negative tokens. Cap cached at input."""
     cost = compute_cost_usd("gpt-5.4-mini", input_tokens=100, cached_input_tokens=10_000, output_tokens=0)
-    # Effectively all 100 input tokens are cached.
-    expected = 100 * 0.075 / 1_000_000
+    # Effectively all 100 input tokens are cached (verified $0.08/1M).
+    expected = 100 * 0.08 / 1_000_000
     assert abs(cost - expected) < 1e-12
 
 
@@ -108,19 +108,25 @@ def test_rollup_empty_returns_empty() -> None:
     assert rollup_by_model([], date(2026, 4, 25)) == []
 
 
-def test_rollup_aggregates_across_call_sites() -> None:
+def test_rollup_per_model_callsite() -> None:
+    """Option A: one row per (model, call_site) -- so gpt-5.4-mini
+    used by agent_loop AND synthesizer is TWO rows, not collapsed.
+    call_count = #ModelTokenUsage rows in the bucket."""
     rows = [
         UsageRow(model="gpt-5.4-mini", input_tokens=1000, cached_input_tokens=500, output_tokens=200, call_site="agent_loop"),
+        UsageRow(model="gpt-5.4-mini", input_tokens=900, cached_input_tokens=100, output_tokens=50, call_site="agent_loop"),
         UsageRow(model="gpt-5.4-mini", input_tokens=2000, cached_input_tokens=1500, output_tokens=300, call_site="synthesizer"),
         UsageRow(model="gpt-5.2", input_tokens=500, cached_input_tokens=400, output_tokens=100, call_site="synthesizer"),
     ]
     out = rollup_by_model(rows, date(2026, 4, 25))
-    assert len(out) == 2
-    by_model = {r.model: r for r in out}
-    assert by_model["gpt-5.4-mini"].input_tokens == 3000
-    assert by_model["gpt-5.4-mini"].cached_input_tokens == 2000
-    assert by_model["gpt-5.4-mini"].output_tokens == 500
-    assert by_model["gpt-5.2"].input_tokens == 500
+    assert len(out) == 3  # (mini,agent_loop) (mini,synth) (5.2,synth)
+    by = {(r.model, r.call_site): r for r in out}
+    al = by[("gpt-5.4-mini", "agent_loop")]
+    assert al.input_tokens == 1900 and al.cached_input_tokens == 600
+    assert al.output_tokens == 250 and al.call_count == 2
+    assert by[("gpt-5.4-mini", "synthesizer")].input_tokens == 2000
+    assert by[("gpt-5.4-mini", "synthesizer")].call_count == 1
+    assert by[("gpt-5.2", "synthesizer")].input_tokens == 500
 
 
 def test_rollup_usd_computed_on_aggregates_not_per_row() -> None:
@@ -134,7 +140,9 @@ def test_rollup_usd_computed_on_aggregates_not_per_row() -> None:
         UsageRow(model="gpt-5.4-mini", input_tokens=333_334, cached_input_tokens=0, output_tokens=0),
     ]
     out = rollup_by_model(rows, date(2026, 4, 25))[0]
-    expected = 1_000_000 * 0.15 / 1_000_000  # = 0.15
+    # No call_site set -> all bucket to (gpt-5.4-mini, "unknown").
+    assert out.call_site == "unknown" and out.call_count == 3
+    expected = 1_000_000 * 0.75 / 1_000_000  # verified input $0.75/1M
     assert abs(out.usd - expected) < 1e-12
 
 
@@ -196,15 +204,19 @@ def test_daily_cost_row_serializes_to_dict() -> None:
     row = DailyCostRow(
         the_date=date(2026, 4, 25),
         model="gpt-5.4-mini",
+        call_site="synthesizer",
         input_tokens=1_000_000,
         cached_input_tokens=500_000,
         output_tokens=100_000,
+        call_count=42,
         usd=0.123456789,
     )
     d = row.as_dict()
     assert d["date"] == "2026-04-25"
     assert d["model"] == "gpt-5.4-mini"
+    assert d["call_site"] == "synthesizer"
     assert d["input_tokens"] == 1_000_000
+    assert d["call_count"] == 42
     # USD rounded to 4 decimal places for display.
     assert d["usd"] == 0.1235
 
@@ -219,7 +231,7 @@ def main() -> int:
         test_zero_tokens_returns_zero,
         test_embedding_output_is_free,
         test_rollup_empty_returns_empty,
-        test_rollup_aggregates_across_call_sites,
+        test_rollup_per_model_callsite,
         test_rollup_usd_computed_on_aggregates_not_per_row,
         test_rollup_preserves_date,
         test_anomaly_ratio_zero_avg_returns_zero,


### PR DESCRIPTION
Closes the Op-3 daily-cost rollup (pure logic existed; `_load_usage_rows`/`_write_daily_cost` were `501` stubs). **Operator decision applied: Option A** — one `DailyCost` row per `(date, model, callSite)` (the table's `@@unique` key), so the dashboard shows *which* pipeline stage spends (synthesizer vs judge vs agent), not just the model.

## Changes
- **Prices**: replaced stale placeholders (gpt-5.4-mini was wrongly $0.15) with the gpt-5.4 family **verified 2026-05-19** from your dashboard. Unknown/dated-snapshot models → `$0 + WARN` (records tokens, never guesses — safe by design).
- **`rollup_by_model`/`DailyCostRow`**: per `(model, call_site)` + `call_count`; legacy `callSite=None` → `"unknown"`.
- **`_load_usage_rows`/`_write_daily_cost`**: real async Prisma via sync `asyncio.run` wrappers (cron, no loop). Write = idempotent upsert on `date_model_callSite`. Failures → clean exit 2, no traceback.
- Fixed a real bug **caught by live testing**: `@db.Date` rejects a bare `datetime.date` → convert at the Prisma boundary.

## Verification
`test_cost_rollup` **16/16** (verified prices + per-callSite + the models.py-coverage lock-in). **Live against the shared DB**: loaded real `ModelTokenUsage` for 2026-05-12, rolled up correctly (legacy `o4-mini` snapshot → `$0+warn` as designed), ran the rollup **twice** → exactly **1** `DailyCost` row (idempotency proven).

Operator: schedule `python -m scripts.cost_rollup` daily (cron); `--backfill N` for history. Add a `PRICE_PER_1M_TOKENS` row when a new model ships (the lock-in test enforces this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)