### PR TITLE
feat(hours): 1-month date window — near-term dates go live, far ones refuse

### DIFF
--- a/ai-core/src/graph/new_orchestrator.py
+++ b/ai-core/src/graph/new_orchestrator.py
@@ -633,12 +633,37 @@ _LONG_PERIOD_HOURS_RE = re.compile(
 )
 
 
-def _is_long_period_hours(text: str) -> bool:
-    """True only when the question is about a date range LibCal can't
-    serve. Short-term words win (LibCal handles those, correctly)."""
+def _is_long_period_hours(text: str, today=None) -> bool:
+    """True only when the hours question can't be served live.
+
+    Operator ruling (hr_thanksgiving): a SPECIFIC date <= ~1 month out
+    IS answerable live (let the agent's get_hours handle that exact
+    date) -> NOT long-period. A specific date further out (e.g.
+    Thanksgiving 6 months away), a past date, or an open-ended range
+    ("summer hours") -> long-period -> point-to-page + "too far ahead"
+    explanation (PR #63).
+
+    `today` is injectable for tests; the call site passes none ->
+    real today.
+    """
     t = text or ""
+    # Short-term words always win (today/tonight/tomorrow -> live).
     if _SHORT_TERM_HOURS_RE.search(t):
         return False
+    # Date-aware window check (the new bit).
+    try:
+        from datetime import date as _date
+        from src.scope.date_window import resolve_target_date, within_window
+
+        ref = today or _date.today()
+        d = resolve_target_date(t, today=ref)
+        if d is not None:
+            # Specific date: live iff within the ~1-month window;
+            # otherwise (far future OR in the past) -> long-period.
+            return not within_window(d, today=ref)
+    except Exception:  # noqa: BLE001 -- never let date logic break routing
+        pass
+    # No resolvable specific date -> fall back to open-ended phrasing.
     return bool(_LONG_PERIOD_HOURS_RE.search(t))
 
 

--- a/ai-core/src/scope/date_window.py
+++ b/ai-core/src/scope/date_window.py
@@ -1,0 +1,137 @@
+"""
+Date extraction for the hours "1-month window" rule (operator ruling
+on hr_thanksgiving):
+
+  * a SPECIFIC date <= ~1 month out  -> answerable live via LibCal
+    (the agent's get_hours handles that exact date)
+  * a SPECIFIC date > 1 month out, or an open-ended range
+    ("summer hours") -> point to the hours page + explain it's too
+    far ahead to look up live (the PR #63 response)
+
+This module only does the *date extraction + window test*. It's pure,
+offline-testable (inject `today`), and dependency-guarded: if
+dateparser / holidays / pytz aren't importable it returns None and the
+caller falls back to the open-ended-phrasing regex -- never raises.
+
+The holiday + relative-date approach mirrors the proven
+`libcal_comprehensive_agent._extract_date_from_query`, kept standalone
+here so the v2 rule-B gate doesn't import the heavy legacy agent.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import date, datetime
+from typing import Optional
+
+# A specific date within this many days of "today" is treated as
+# answerable live (LibCal serves a near-term window). Beyond it ->
+# point-to-page. ~1 month per the operator ruling.
+WINDOW_DAYS = 31
+
+# Only trust a parsed date if the text actually contains a date-ish
+# token -- stops the parser inventing a date from stray numbers
+# ("room 204", "top 5 databases").
+_DATE_PATTERNS = (
+    r"\d{1,2}/\d{1,2}(/\d{2,4})?",
+    r"\d{4}-\d{2}-\d{2}",
+    r"\b(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\.?\s+\d{1,2}",
+    r"\b\d{1,2}(st|nd|rd|th)?\s+(of\s+)?(jan|feb|mar|apr|may|jun|jul|aug"
+    r"|sep|oct|nov|dec)[a-z]*",
+    r"\b(today|tonight|tomorrow|yesterday)\b",
+    r"\bnext\s+(week|month|monday|tuesday|wednesday|thursday|friday"
+    r"|saturday|sunday)\b",
+    r"\bthis\s+(monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b",
+    r"\bday\s+(after|before)\s+(tomorrow|yesterday)\b",
+)
+
+# keyword -> US holidays name fragment (matched against the holidays pkg).
+_HOLIDAYS = {
+    "new year": "New Year",
+    "mlk": "Martin Luther King",
+    "martin luther king": "Martin Luther King",
+    "presidents day": "Washington",
+    "president's day": "Washington",
+    "memorial day": "Memorial Day",
+    "independence day": "Independence Day",
+    "fourth of july": "Independence Day",
+    "4th of july": "Independence Day",
+    "july 4": "Independence Day",
+    "labor day": "Labor Day",
+    "columbus day": "Columbus Day",
+    "veterans day": "Veterans Day",
+    "thanksgiving": "Thanksgiving",
+    "christmas": "Christmas",
+}
+
+
+def resolve_target_date(
+    text: str, today: Optional[date] = None
+) -> Optional[date]:
+    """Return the concrete date the question is about, or None.
+
+    None means "no single specific date" (generic, or open-ended like
+    'summer hours') -- the caller then uses phrasing heuristics. Never
+    raises; missing optional deps -> None.
+    """
+    if not text:
+        return None
+    ref = today or date.today()
+    t = text.lower()
+
+    # 1) Named US holiday -> its next occurrence on/after `ref`.
+    try:
+        import holidays  # type: ignore
+
+        us = holidays.US(years=[ref.year, ref.year + 1])
+        for kw, frag in _HOLIDAYS.items():
+            if kw in t:
+                cands = sorted(
+                    d for d, name in us.items()
+                    if frag in name and d >= ref
+                )
+                if cands:
+                    return cands[0]
+    except Exception:  # noqa: BLE001 -- optional dep / parse issue
+        pass
+
+    # 2) Explicit / relative date -- only if a date token is present.
+    if not any(re.search(p, t) for p in _DATE_PATTERNS):
+        return None
+    settings = {
+        "PREFER_DATES_FROM": "future",
+        "RELATIVE_BASE": datetime(ref.year, ref.month, ref.day),
+        "DATE_ORDER": "MDY",
+    }
+    try:
+        # search_dates() finds a date phrase INSIDE free text
+        # ("library hours on May 25" -> May 25). Plain parse() tries
+        # the whole string and returns None on a sentence -- the bug a
+        # live test caught. Pre-guarded by _DATE_PATTERNS above so we
+        # don't run it on dateless text / false-positive on "top 5".
+        from dateparser.search import search_dates  # type: ignore
+
+        found = search_dates(text, settings=settings)
+        if found:
+            return found[0][1].date()
+    except Exception:  # noqa: BLE001 -- search extra missing / parse issue
+        pass
+    try:  # fallback: whole-string parse (works for "tomorrow" etc.)
+        import dateparser  # type: ignore
+
+        parsed = dateparser.parse(text, settings=settings)
+        if parsed is not None:
+            return parsed.date()
+    except Exception:  # noqa: BLE001
+        return None
+    return None
+
+
+def within_window(d: date, today: Optional[date] = None) -> bool:
+    """True if `d` is between today and today+WINDOW_DAYS inclusive
+    (a near-term date LibCal can answer live)."""
+    ref = today or date.today()
+    return 0 <= (d - ref).days <= WINDOW_DAYS
+
+
+__all__ = ["WINDOW_DAYS", "resolve_target_date", "within_window"]

--- a/ai-core/src/scope/test_date_window.py
+++ b/ai-core/src/scope/test_date_window.py
@@ -1,0 +1,124 @@
+"""
+Offline tests for the hours 1-month date-window rule.
+
+Run: `python -m src.scope.test_date_window` from ai-core/.
+
+Deterministic via an injected `today` -- no clock dependence, no API.
+Asserts the hr_thanksgiving operator ruling end-to-end through the v2
+gate `_is_long_period_hours`.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_AI_CORE = _HERE.parent.parent
+sys.path.insert(0, str(_AI_CORE))
+
+from src.scope.date_window import (
+    WINDOW_DAYS,
+    resolve_target_date,
+    within_window,
+)
+from src.graph.new_orchestrator import _is_long_period_hours
+
+_MAY19 = date(2026, 5, 19)
+
+
+def test_resolve_holiday_far() -> None:
+    d = resolve_target_date("are you open Thanksgiving day?", today=_MAY19)
+    assert d is not None and d.year == 2026 and d.month == 11
+    assert (d - _MAY19).days > WINDOW_DAYS  # ~6 months out
+
+
+def test_resolve_relative_and_explicit() -> None:
+    assert resolve_target_date("hours tomorrow", today=_MAY19) == date(2026, 5, 20)
+    d = resolve_target_date("library hours on May 25", today=_MAY19)
+    assert d == date(2026, 5, 25)
+    dec = resolve_target_date("open on December 25?", today=_MAY19)
+    assert dec == date(2026, 12, 25)
+
+
+def test_resolve_none_for_generic_or_openended() -> None:
+    assert resolve_target_date("what are the summer hours", today=_MAY19) is None
+    assert resolve_target_date("what are the library hours", today=_MAY19) is None
+    assert resolve_target_date("", today=_MAY19) is None
+
+
+def test_within_window() -> None:
+    assert within_window(_MAY19 + timedelta(days=10), today=_MAY19) is True
+    assert within_window(_MAY19 + timedelta(days=WINDOW_DAYS), today=_MAY19) is True
+    assert within_window(_MAY19 + timedelta(days=WINDOW_DAYS + 1), today=_MAY19) is False
+    assert within_window(_MAY19 - timedelta(days=1), today=_MAY19) is False  # past
+
+
+def test_gate_short_term_is_live() -> None:
+    assert _is_long_period_hours("is the library open tonight?", today=_MAY19) is False
+    assert _is_long_period_hours("what time do you close today", today=_MAY19) is False
+
+
+def test_gate_thanksgiving_far_is_long_period() -> None:
+    # hr_thanksgiving: 6 months out -> point-to-page + explain.
+    assert _is_long_period_hours("are you open Thanksgiving day?", today=_MAY19) is True
+
+
+def test_gate_thanksgiving_near_is_live() -> None:
+    # Same question, but asked ~2 weeks before -> answerable live.
+    assert _is_long_period_hours(
+        "are you open Thanksgiving day?", today=date(2026, 11, 12)
+    ) is False
+
+
+def test_gate_near_specific_date_is_live() -> None:
+    assert _is_long_period_hours("hours next Tuesday?", today=_MAY19) is False
+    assert _is_long_period_hours("library hours on May 25", today=_MAY19) is False
+
+
+def test_gate_far_specific_date_is_long_period() -> None:
+    assert _is_long_period_hours("hours on December 25?", today=_MAY19) is True
+
+
+def test_gate_openended_phrasing_is_long_period() -> None:
+    assert _is_long_period_hours("what are the summer hours", today=_MAY19) is True
+    assert _is_long_period_hours("hours during winter break?", today=_MAY19) is True
+
+
+def test_gate_generic_no_date_not_long_period() -> None:
+    # No date, no open-ended marker -> normal path (live), unchanged.
+    assert _is_long_period_hours("what are the library hours", today=_MAY19) is False
+
+
+def main() -> int:
+    tests = [
+        test_resolve_holiday_far,
+        test_resolve_relative_and_explicit,
+        test_resolve_none_for_generic_or_openended,
+        test_within_window,
+        test_gate_short_term_is_live,
+        test_gate_thanksgiving_far_is_long_period,
+        test_gate_thanksgiving_near_is_live,
+        test_gate_near_specific_date_is_live,
+        test_gate_far_specific_date_is_long_period,
+        test_gate_openended_phrasing_is_long_period,
+        test_gate_generic_no_date_not_long_period,
+    ]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes the **hr_thanksgiving** operator-ruling failure: a user asking
"are you open Thanksgiving day?" in May should NOT trigger a live
LibCal lookup for six months out (it has no data). The old gate only
matched phrasing ("summer hours", "winter break"), so a specific
distant holiday slipped through.

New behavior in `_is_long_period_hours(text, today=None)`:

| Question | Old | New |
|---|---|---|
| "are you open Thanksgiving day?" asked **May 19** | live (fails) | long-period -> point-to-page |
| Same question asked **Nov 12** | live | live (in window) |
| "hours on December 25?" asked May 19 | live (fails) | long-period |
| "hours tomorrow" | live | live |
| "library hours on May 25" | live | live |
| "what are the summer hours" | long-period | long-period (unchanged) |
| "what are the library hours" | not long-period | not long-period (unchanged) |

## What changed

- **NEW** `ai-core/src/scope/date_window.py` — `resolve_target_date`
  (named US holidays + dateparser, pre-guarded by a date-token regex
  so "room 204" isn't an invented date) and `within_window` (31 days,
  one tunable). Optional deps (`holidays`, `dateparser`, `pytz`)
  guarded — missing -> returns None, never raises.
- **MODIFIED** `ai-core/src/graph/new_orchestrator.py` —
  `_is_long_period_hours` grows an injectable `today` arg and threads
  the resolver before the existing phrasing fallback. Backward
  compatible: `today=None` defaults to real today.
- **NEW** `ai-core/src/scope/test_date_window.py` — 11 deterministic
  tests using injected today, covering the hr_thanksgiving ruling
  end-to-end through the gate.

## Why dateparser.search.search_dates and not plain parse

Live testing caught: `dateparser.parse("library hours on May 25")`
returns `None` — `parse()` tries the whole string as a date.
`search_dates()` extracts dates from inside free text. We keep a
small regex pre-guard so we don't run `search_dates` on text without
any date-ish token (stops false positives like "top 5 databases").

## Test plan

- [x] `python3 -m src.scope.test_date_window` — 11/11 pass
- [x] `python3 -m src.scope.test_service_availability` — 8/8 pass (no regression)
- [ ] Live spot-check after merge: ask the bot "are you open Thanksgiving?" on a non-Thanksgiving date; expect point-to-page response, not a live LibCal failure.

## Why this matters

This is one of the original captured-failure-mode cases that motivated
the rebuild. Closing it ratchets up the "trustworthy" metric on
hours-class questions, which are the highest-volume bucket in
LibChat transcripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)