### PR TITLE
chore(ops): operator runbook + one-shot offline test runner

### DIFF
--- a/ai-core/docs/OPERATOR.md
+++ b/ai-core/docs/OPERATOR.md
@@ -1,0 +1,306 @@
+# Operator Runbook — the new (v2-rebuild) surfaces
+
+This is the "what's running today, how do I touch it" doc for the
+**rebuild** surfaces shipped since the v3.1 legacy bot
+(PRs #71–78, May 2026). It is intentionally narrow:
+
+- **In scope:** the new HTTP endpoints, observability, rate limit,
+  3-tier model config, admin review surface, cost rollup, ETL gate,
+  hours date-window. The things an on-call needs to know to keep them
+  alive and figure out what just broke.
+- **Out of scope:** the legacy v3.1 serving path. That's documented
+  under `docs/01-…` through `docs/12-…` and remains correct for what
+  it covers. Today the legacy code still serves **100% of traffic**
+  (`VITE_V2_ROLLOUT_PERCENT=0`). Until that changes, "operating the
+  bot" largely means "operating the legacy bot via those docs."
+
+Companion docs you should know about:
+
+| Doc | When to read it |
+|---|---|
+| `ai-core/scripts/etl/FIRST_RUN.md` | Running the ETL prepare→approve→apply flow. |
+| `ai-core/admin/README.md` | Standing up the Metabase v0 review interim. |
+| `ai-core/docs/WEAVIATE_SERVER_DEPLOYMENT.md` | One-time Weaviate-server provisioning. |
+| `docs/notes.md` | Personal notes / SSH tunnel hosts (qum's working file). |
+
+---
+
+## 1. New HTTP surfaces
+
+All mounted from `ai-core/src/main.py`. They live alongside the legacy
+endpoints, so reaching them does **not** turn on the v2 bot.
+
+| Path | Purpose | When it appears |
+|---|---|---|
+| `GET /health/live` | Liveness — is the FastAPI worker responding? Always 200 if process is up. | Always. Use from load balancer. |
+| `GET /health/ready` | Readiness — runs Weaviate / Postgres / OpenAI / LibCal probes + ETL freshness. 200 only if all pass. | Always. Use from k8s readiness or status page. |
+| `GET /metrics` | Prometheus exposition (request rate, LLM token counts, cache-hit, refusal rate, tool latency). | Only if `prometheus-client` is installed. Otherwise serves a one-line sentinel. |
+| `GET /smoketest` | End-to-end synthetic: pushes a canned question through the agent + asserts citation + non-refusal + latency. | Always. Wire to UptimeRobot / BetterStack hitting every 5 min. |
+| `GET /admin/reviews` | List flagged conversations (thumb-down). | Only when `ADMIN_API_TOKEN` env var is set. Fail-closed. |
+| `GET /admin/reviews/{id}` | Drill into one conversation (tokens, tools, citations, handoff). | Same gate. |
+| `GET /admin/reviews/view` | Server-rendered HTML review page (auth = `?key=<token>`). | Same gate. Bookmarkable. |
+
+For the agent's own request/response endpoints, see the legacy docs —
+those haven't moved.
+
+### Auth note on `/admin/...`
+
+The whole admin router is mounted **only** when `ADMIN_API_TOKEN` is
+present in the environment. If it isn't, the routes do not exist
+(404, not 401). That's deliberate: no token = no admin surface, no way
+to brute force what isn't there.
+
+When the token IS set, every request must include:
+
+```
+GET /admin/reviews
+Authorization: Bearer <ADMIN_API_TOKEN>
+```
+
+…or for the HTML view, the token as a `?key=` query param so the URL
+is bookmarkable in a librarian's browser:
+
+```
+https://<host>/admin/reviews/view?key=<ADMIN_API_TOKEN>
+```
+
+Rotate the token by setting a new value and restarting; there's no
+session state to invalidate.
+
+---
+
+## 2. Environment variables (the new ones)
+
+These are the env vars introduced by the rebuild. Legacy vars are
+documented in `docs/07-ENVIRONMENT-VARIABLES.md`.
+
+### Model selection (PR #74)
+
+```env
+LLM_MODEL_BASIC=gpt-5.4-mini       # default chat agent + synthesizer
+LLM_MODEL_REASONING=gpt-5.4        # promoted for multi-hop / ambiguous
+LLM_MODEL_CHEAP=gpt-5.4-nano       # LLM-as-judge in eval, light tasks
+LLM_MODEL_EMBEDDING=text-embedding-3-large
+LLM_ALLOW_TEMPERATURE_CHEAP=0      # opt-in: send temperature to nano
+                                   # (gpt-5.4 family otherwise omits it)
+```
+
+The whole codebase reads through `src/config/models.py::resolve_model()`.
+Changing a model identifier in one of these vars + restart updates
+every call site. **Do not hard-code model strings.**
+
+The `gpt-5.4` family is a reasoning family; per OpenAI docs we don't
+send `temperature` to them by default. `supports_temperature(model)`
+gates that. The `LLM_ALLOW_TEMPERATURE_CHEAP` knob exists because the
+nano variant may accept temperature in some configs — leave at 0
+unless you've tested it and have a measurable reason.
+
+### Rate limit (PR #73)
+
+```env
+RATE_LIMIT_PER_IP_PER_MIN=20       # /ask + Socket.IO message events
+RATE_LIMIT_MESSAGE_CHAR_CAP=4000   # reject longer messages outright
+```
+
+Both have safe defaults baked in. The limiter **fails open** on
+internal errors — if Redis or the in-process store craters, traffic
+flows; the on-call sees a WARN in logs. Pick the limit based on what
+the upstream LLM rate limit lets you safely sustain.
+
+### Admin surface (PR #76)
+
+```env
+ADMIN_API_TOKEN=...                # presence gates the entire router
+                                   # generate with: openssl rand -hex 32
+```
+
+### Observability (PR #71)
+
+```env
+SENTRY_DSN=https://...             # backend errors → Sentry
+SENTRY_ENVIRONMENT=production      # or staging / dev
+```
+
+If `SENTRY_DSN` is unset, the Sentry init is a no-op (no exception,
+no log spam). Errors still print to stderr; nothing degrades.
+
+---
+
+## 3. Day-to-day tasks
+
+### Run the offline test suite before merging anything
+
+```bash
+cd ai-core
+bash scripts/run_offline_tests.sh
+```
+
+Exits non-zero if any of the offline-clean modules fail. The script
+lists which modules are **integration-only** (need prisma / Weaviate /
+OpenAI / Google CSE) at the bottom — those aren't run by the script;
+run them by hand when their env is set up.
+
+When you add a new test file, append it to the right list in
+`scripts/run_offline_tests.sh` (sorted, one entry per line).
+
+### Weekly ETL refresh
+
+See `ai-core/scripts/etl/FIRST_RUN.md` for the full prepare→approve→
+apply gate flow. The TL;DR cycle is:
+
+```bash
+# Operator (Mon 9am after the Sun 2am cron prepares the diff)
+.venv/bin/python -m scripts.etl.run_etl --phase prepare      # already cron'd
+# … librarian opens the diff, signs the .approval token …
+.venv/bin/python -m scripts.etl.run_etl --phase apply        # operator runs after sign-off
+```
+
+If the cron didn't run, the diff folder under `ai-core/data/diffs/`
+shows no new entry for the week — that's your signal.
+
+### Daily cost rollup (PR #77 — once merged)
+
+Cron:
+
+```cron
+0 2 * * *   cd /path/to/ai-core && .venv/bin/python -m scripts.cost_rollup
+```
+
+Reads yesterday's `ModelTokenUsage` rows, multiplies by the verified
+per-model price (in `scripts/cost_rollup.py::PRICE_PER_1M_TOKENS`),
+upserts one `DailyCost` row per `(date, model, call_site)`.
+
+Backfill:
+
+```bash
+.venv/bin/python -m scripts.cost_rollup --backfill 30   # last 30 days
+.venv/bin/python -m scripts.cost_rollup --date 2026-04-22  # one day
+```
+
+The upsert is keyed on `(date, model, call_site)` so re-running for a
+date you've already rolled up is a no-op, not a double-count. Verified
+live on 2026-05-19 with `--date 2026-05-12` ran twice → exactly one row.
+
+If you add a new model to `src/config/models.py` and don't add a row
+to `PRICE_PER_1M_TOKENS`, the lock-in test
+`scripts.test_cost_rollup::test_price_table_covers_models_in_use`
+fails loudly in the offline runner. Don't deploy past that.
+
+### Re-seed `LibrarySpace_v2`
+
+If a librarian gives you updated `services_offered` truth or fixes a
+URL in `scripts/seed_library_spaces_v2.py`:
+
+```bash
+cd ai-core
+.venv/bin/python -m scripts.seed_library_spaces_v2
+```
+
+The seed is idempotent (`@@unique([campus, library])` upsert). 6 rows
+total; running twice produces no duplicates. Last operator change was
+PR #75 (capacity bumps + hours_source path).
+
+### Look at flagged conversations
+
+Once `ADMIN_API_TOKEN` is set:
+
+- Librarian self-service: send them the URL
+  `https://<host>/admin/reviews/view?key=<TOKEN>` and ask them to
+  report any conversation by `message_id` + timestamp.
+- API: `curl -H "Authorization: Bearer $ADMIN_API_TOKEN"
+  https://<host>/admin/reviews`.
+
+Both are read-only by design — the librarian flags, the operator
+applies a `ManualCorrection` row by hand (the v0 path; the v1 UI is
+post-launch work).
+
+---
+
+## 4. Common alerts and what to do
+
+### `/health/ready` returns 503
+
+Body is JSON listing which probe failed. Most likely:
+
+- `weaviate`: Weaviate down. Check the SSH tunnel (ports 8888/50051
+  to `ulblwebp20.lib.miamioh.edu`). Restart the tunnel; readiness
+  recovers within one probe cycle.
+- `postgres`: DB connection lost. Most likely the SSH tunnel to
+  `ulblwebt04.lib.miamioh.edu` dropped. Restore the tunnel.
+- `openai`: OpenAI API unreachable from this host. If their status
+  page is green, it's network egress (firewall, proxy). If their
+  status page is red, you can't fix it — let it drain.
+- `etl_freshness > 8 days`: weekly cron hasn't completed. Read
+  `data/diffs/` to confirm; if last diff is old, the cron job is
+  broken; investigate the cron host, not the bot.
+
+### `/smoketest` failing
+
+The synthetic question went through and didn't return citations OR
+returned a refusal OR took > 8s. This catches "everything looks
+healthy individually but the chain is broken" (a stale OpenAI key,
+broken adapter wiring, a deploy that didn't pick up new env). Read
+the response body — it includes which assertion failed.
+
+### Daily cost spike alert
+
+A prompt regression (or accidental shell-loop) that tanks the cache
+hit rate burns budget invisibly until the rollup notices. When the
+1.5x trailing-7-day threshold trips:
+
+1. Query the last 24h of `ModelTokenUsage`, sort by `cached_input_tokens
+   / input_tokens` ascending. The call site at the bottom is your
+   prefix-drift suspect.
+2. Cross-check `src/prompts/builder.py` byte-stability log — every
+   prefix mismatch logs the offending stable_id.
+
+### Rate limiter logging WARN
+
+The limiter fails open on internal errors. A burst of
+`rate_limit_internal_error` WARNs means the limiter itself is broken
+(in-process store corrupted, Redis down). Traffic is flowing; users
+aren't blocked. Fix the limiter at convenience — don't page out.
+
+---
+
+## 5. What "deploy" actually does (today, May 2026)
+
+Today there's no real deploy automation for the rebuild. Operationally
+that means:
+
+1. Merge PR to `main`.
+2. SSH to the prod-ish host.
+3. `git pull` in the deploy checkout.
+4. `pip install -e .` if dependencies changed.
+5. `prisma generate` if `prisma/schema.prisma` changed.
+6. Restart the FastAPI worker.
+
+The legacy bot continues to serve traffic the whole time — v2 routes
+are reachable on the same process, just not used by the rollout flag
+yet. So a botched rebuild deploy degrades the new surfaces (admin,
+metrics, smoketest) but does not take the chat down.
+
+When you flip `VITE_V2_ROLLOUT_PERCENT` above 0 in the client, that's
+when "the chatbot is down" becomes a real risk from a rebuild deploy.
+That flip is a deliberate, separately-reviewed change, not a side
+effect of a code merge.
+
+---
+
+## 6. Where the rebuild stands (snapshot, 2026-05-19)
+
+For the long version, see the **Robustness ladder** section of the
+plan at `~/.claude/plans/i-am-a-web-breezy-prism.md`. Short version:
+
+- **Threshold 1 (Architecture)** — done.
+- **Threshold 2 (Internally usable)** — agent + synthesizer + scope +
+  service guard land; you can hit the v2 endpoints from the API.
+  Real-LLM eval validates quality (was blocked on OpenAI credit; user
+  is refilling).
+- **Threshold 3 (10% real-user flag)** — gated on: librarian sign-off
+  for `services_offered` truth (Gap 3), wiring `RolloutFlag` to send
+  traffic, +1 round of UAT.
+- **Threshold 4 (Robust)** — Op 1 v1 React admin, Op 2 correction
+  UI, full alerting on Op 3 metrics.
+
+This doc covers operating what exists. The plan covers what's next.

--- a/ai-core/scripts/run_offline_tests.sh
+++ b/ai-core/scripts/run_offline_tests.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# Run every offline-clean test module in ai-core/ and exit non-zero if
+# any fail. Intended for pre-PR and pre-deploy checks: it's the closest
+# thing this repo has to `make test`.
+#
+# What "offline-clean" means here: passes without network, without a DB
+# connection, without OpenAI / Google CSE / Weaviate credentials. The
+# integration tests (those that genuinely need live infra) are listed
+# at the bottom of this file and printed for awareness but not run.
+#
+# Usage:
+#   cd ai-core
+#   bash scripts/run_offline_tests.sh
+#
+# Exit codes:
+#   0  all offline tests passed
+#   1  one or more offline tests failed (real signal -- look at the FAIL lines)
+#
+# Adding a new test:
+#   * If it's offline-clean (no network/DB/keys), append it to OFFLINE.
+#   * If it needs live infra, append it to INTEGRATION with a one-word reason.
+#   * Either way: keep the lists sorted so PR diffs stay small.
+
+set -u  # NOT set -e -- we want to keep going through failures.
+
+cd "$(dirname "$0")/.." || {
+  echo "FATAL: could not cd to ai-core/" >&2
+  exit 2
+}
+
+# --- Offline-clean modules (the runnable set) ---------------------------
+# Sorted. Add to alphabetical position when extending.
+
+OFFLINE=(
+  scripts.etl.test_chunker
+  scripts.etl.test_classify
+  scripts.etl.test_diff_report
+  scripts.etl.test_discover
+  scripts.etl.test_extract
+  scripts.etl.test_gate
+  scripts.etl.test_upsert
+  scripts.test_cost_rollup
+  scripts.test_digest_email
+  scripts.test_google_agent_direct
+  src.agent.test_agent
+  src.agent.test_tool_registry
+  src.api.admin.test_review
+  src.api.admin.test_validators
+  src.api.test_rate_limit
+  src.config.test_capability_scope
+  src.config.test_models
+  src.database.test_urlseen_adapter
+  src.eval.test_calibrate_clarify
+  src.eval.test_inspect_turn
+  src.eval.test_judge
+  src.eval.test_smoke_e2e
+  src.graph.test_new_orchestrator
+  src.graph.test_v2_serving
+  src.llm.test_client
+  src.observability.test_cache_health
+  src.observability.test_logging
+  src.observability.test_metrics
+  src.observability.test_metrics_endpoint
+  src.observability.test_request_id_middleware
+  src.observability.test_sentry
+  src.observability.test_smoketest
+  src.prompts.test_builder
+  src.retrieval.test_scope_filter
+  src.retrieval.test_search
+  src.router.test_intent_capabilities
+  src.router.test_intent_knn
+  src.scope.test_date_window
+  src.scope.test_service_availability
+  src.synthesis.test_corrections
+  src.synthesis.test_post_processor
+  src.synthesis.test_refusal_templates
+  src.synthesis.test_synthesizer
+  src.tools.test_search_kb_tool
+  src.weaviate_adapters.test_etl_adapter
+  src.weaviate_adapters.test_search_adapter
+)
+
+# --- Integration tests (NOT run -- listed for awareness) ----------------
+# Format: "<module>  <one-word reason>"
+# Run these manually when the corresponding env is set up.
+
+INTEGRATION=(
+  "scripts.test_library_spaces           prisma"
+  "scripts.test_routing_smoke            prisma"
+  "src.eval.test_real_backends           prisma+weaviate"
+  "scripts.test_policy_routing           openai+weaviate"
+  "scripts.test_google_cse_cost_controls google-cse"
+)
+
+# --- Runner -------------------------------------------------------------
+
+PYTHON="${PYTHON:-python3}"
+START_TS=$(date +%s)
+
+passed=0
+failed=0
+failed_modules=()
+
+printf "Running %d offline test modules with %s\n" "${#OFFLINE[@]}" "$PYTHON"
+printf "Working dir: %s\n\n" "$(pwd)"
+
+for mod in "${OFFLINE[@]}"; do
+  out=$("$PYTHON" -m "$mod" 2>&1)
+  rc=$?
+  # Last non-empty line is usually the harness summary ("N/M passed").
+  last=$(printf '%s\n' "$out" | awk 'NF{line=$0} END{print line}' | tr -d '\r' | cut -c1-90)
+  if [ "$rc" -eq 0 ]; then
+    printf "PASS  %-55s  %s\n" "$mod" "$last"
+    passed=$((passed + 1))
+  else
+    printf "FAIL  %-55s  %s  (exit %d)\n" "$mod" "$last" "$rc"
+    failed=$((failed + 1))
+    failed_modules+=("$mod")
+  fi
+done
+
+elapsed=$(( $(date +%s) - START_TS ))
+
+printf "\n%s\n" "================================================================"
+printf "Offline:     %d/%d passed in %ds\n" "$passed" "${#OFFLINE[@]}" "$elapsed"
+if [ "$failed" -gt 0 ]; then
+  printf "FAILED:      %s\n" "${failed_modules[*]}"
+fi
+printf "\nIntegration (NOT run -- need live env):\n"
+for entry in "${INTEGRATION[@]}"; do
+  printf "  - %s\n" "$entry"
+done
+printf "%s\n" "================================================================"
+
+if [ "$failed" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Two small additions to close the doc/test-hygiene gap from the
rebuild surfaces shipped in PRs #71–78. No code paths change; this
is purely about operability.

### 1. `ai-core/docs/OPERATOR.md` — new day-to-day runbook

Narrow on purpose: covers only the **new (v2-rebuild) surfaces**.
The legacy v3.1 docs under \`docs/01-…\` through \`docs/12-…\` remain
authoritative for the path that still serves 100% of traffic. No
legacy doc was edited or moved.

What it covers:
- New HTTP surfaces (\`/health/ready\`, \`/metrics\`, \`/smoketest\`, \`/admin/...\`)
- New env vars (\`LLM_MODEL_*\`, \`RATE_LIMIT_*\`, \`ADMIN_API_TOKEN\`, \`SENTRY_DSN\`)
- Day-to-day tasks (offline tests, weekly ETL gate, cost rollup, re-seed v2 spaces, look at flagged conversations)
- Common alerts + recovery
- Where the rebuild stands relative to the robustness ladder

Points at \`ai-core/scripts/etl/FIRST_RUN.md\` and \`ai-core/admin/README.md\`
for the flows they already cover — no duplication.

### 2. \`ai-core/scripts/run_offline_tests.sh\` — one-shot test runner

\`\`\`bash
cd ai-core
bash scripts/run_offline_tests.sh
\`\`\`

- 46 offline-clean modules, ~13s end-to-end
- Exits non-zero on any failure
- Integration tests (need prisma / Weaviate / OpenAI / Google CSE)
  listed at the bottom of the script for awareness but **not run**
- Comment header says \"if you add a test, append to the right list (sorted)\"

## Why this exists

There was no top-level "run all the tests" entry point — each module
gets invoked individually as \`python -m <module>\`. That's painful at
PR review time and easy to skip. One shell script ends that.

The runbook closes the operator-side gap: the new surfaces have been
shipping at a rate that outpaces any single doc, and the legacy
\`docs/01-…\` index doesn't know about any of them.

## Current state on main

Runner reports \`Offline: 44/46 passed\` today, with both FAILs being
**real lock-in signal**:
- \`scripts.test_cost_rollup\` — price table missing \`gpt-5.4\` / \`gpt-5.4-nano\`; resolves when #77 merges
- \`src.scope.test_date_window\` — file not on main yet; resolves when #78 merges

That's exactly the runner doing its job. After both PRs merge: 46/46.

## Test plan

- [x] \`bash ai-core/scripts/run_offline_tests.sh\` — runs, exit code 1 (correct, 2 expected FAILs)
- [x] Operator runbook scans cleanly, all cross-references resolve
- [ ] After #77 + #78 merge: re-run; expect 46/46 and exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)