### PR TITLE
feat(v2): live-verify script for the v2 serving path + Gap-3 librarian ask

### DIFF
--- a/ai-core/docs/OPERATOR.md
+++ b/ai-core/docs/OPERATOR.md
@@ -143,6 +143,37 @@ run them by hand when their env is set up.
 When you add a new test file, append it to the right list in
 `scripts/run_offline_tests.sh` (sorted, one entry per line).
 
+### Live-verify the v2 serving path
+
+The v2 stack (rebuilt orchestrator behind `?v2=1`) is code-complete
+but the round-trip is only verifiable against a real OpenAI +
+Weaviate + Postgres. Before you raise `VITE_V2_ROLLOUT_PERCENT` above
+0 for the first time, run:
+
+```bash
+cd ai-core
+.venv/bin/python -m scripts.verify_v2_serving --host http://localhost:8000
+```
+
+What it checks (in order):
+
+1. `GET /health/ready` → 200 (all dep probes pass)
+2. `GET /smoketest` → 200 with citations and not refused
+3. v2 socket connect to `/smartchatbot/v2/socket.io` succeeds
+4. v2 socket send → response has `citations[]` and `confidence` keys
+   (the additive v2 shape — proves the orchestrator wired up, not just
+   the socket transport)
+5. legacy socket still responds (wrap-safety guard — confirms the
+   `socketio.ASGIApp` wrap in `main.py` didn't break the 100% path)
+
+Exit 0 = safe to flip the rollout flag. Exit 1 = do NOT flip; read
+the FAIL lines.
+
+If your env doesn't have legacy creds (rare), pass `--skip-legacy`.
+Default question is hours-class because hours questions are the most
+LibCal-grounded and least likely to legitimately refuse; override
+with `--question "..."` if you want to probe a specific intent.
+
 ### Weekly ETL refresh
 
 See `ai-core/scripts/etl/FIRST_RUN.md` for the full prepare→approve→

--- a/ai-core/scripts/verify_v2_serving.py
+++ b/ai-core/scripts/verify_v2_serving.py
@@ -1,0 +1,339 @@
+"""
+Live-verify the v2 serving path end-to-end.
+
+The v2 stack is CODE-COMPLETE (PRs #56-79): RolloutFlag routes ?v2=1
+to /smartchatbot/v2/socket.io; main.py mounts sio_v2 on that path;
+handle_v2_message runs the rebuilt orchestrator. What this script does
+is the OPERATOR LIVE-VERIFY step the plan calls out at the bottom of
+the main.py v2 mount comment:
+
+    "with VITE_V2_ROLLOUT_PERCENT=0, open ?v2=1, confirm a cited answer
+     renders AND a no-flag session is unchanged, BEFORE raising the
+     rollout percentage."
+
+We do that programmatically so the verify is repeatable and auditable.
+The script is intentionally not pretty -- it's an operator checklist
+that exits non-zero on any failure.
+
+Usage:
+    .venv/bin/python -m scripts.verify_v2_serving --host http://localhost:8000
+
+    # Override the canned question (default: a known-answerable hours-y one)
+    .venv/bin/python -m scripts.verify_v2_serving \\
+        --host http://localhost:8000 \\
+        --question "what time does King Library close today?"
+
+    # Skip the legacy check (e.g. if legacy creds aren't available in this env)
+    .venv/bin/python -m scripts.verify_v2_serving --host ... --skip-legacy
+
+Exit codes:
+    0  all checks passed -- safe to flip VITE_V2_ROLLOUT_PERCENT above 0
+    1  one or more checks failed -- DO NOT raise the rollout flag
+
+Requirements (must be installed in the .venv running this script):
+    python-socketio  (already a dependency)
+    httpx            (already a dependency)
+
+What we check, in order:
+
+  1. /health/ready returns 200            -- backend is up, deps probes pass
+  2. /smoketest returns 200 + citation    -- the synthetic E2E catches
+                                             stale-key / broken-chain
+                                             failures the smoke gate is
+                                             designed for
+  3. v2 socket: connect succeeds          -- the v2 ASGI mount is reachable
+  4. v2 socket: send a real message,
+     get a structured response            -- the v2 orchestrator answers
+     with citations / confidence             a real turn (the LLM, the
+                                             retrieval, the synth all wire
+                                             up)
+  5. (optional) legacy socket: connect    -- the wrap added in #56 did
+     + send a message                        not break legacy bytes;
+                                             traffic the 100% rollout
+                                             still depends on still flows
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+import time
+from dataclasses import dataclass, field
+from typing import Optional
+from urllib.parse import urlparse
+
+try:
+    import httpx
+    import socketio
+except ImportError as e:
+    print(f"FATAL: required dep missing: {e}", file=sys.stderr)
+    print("  -> run: pip install -e ./ai-core  (from repo root)", file=sys.stderr)
+    sys.exit(2)
+
+
+# --- Result types ---------------------------------------------------------
+
+
+@dataclass
+class CheckResult:
+    name: str
+    passed: bool
+    detail: str
+    elapsed_ms: int = 0
+
+
+@dataclass
+class RunSummary:
+    results: list[CheckResult] = field(default_factory=list)
+
+    def add(self, r: CheckResult) -> None:
+        self.results.append(r)
+
+    @property
+    def passed(self) -> int:
+        return sum(1 for r in self.results if r.passed)
+
+    @property
+    def failed(self) -> int:
+        return sum(1 for r in self.results if not r.passed)
+
+    def emit(self) -> None:
+        for r in self.results:
+            status = "PASS" if r.passed else "FAIL"
+            print(f"{status}  {r.name:<55s}  ({r.elapsed_ms}ms)  {r.detail}")
+        print()
+        print(f"{self.passed}/{len(self.results)} checks passed")
+
+
+# --- Individual checks ----------------------------------------------------
+
+
+def _check_http(
+    summary: RunSummary, client: httpx.Client, host: str, path: str, name: str
+) -> Optional[dict]:
+    """GET host+path; record PASS if 200; return parsed JSON or None."""
+    url = host.rstrip("/") + path
+    t0 = time.monotonic()
+    try:
+        r = client.get(url, timeout=15.0)
+        elapsed = int((time.monotonic() - t0) * 1000)
+        ok = 200 <= r.status_code < 300
+        detail = f"{r.status_code} {r.headers.get('content-type', '?')}"
+        if not ok:
+            try:
+                body = r.json()
+                detail += f"  body={json.dumps(body)[:140]}"
+            except Exception:  # noqa: BLE001
+                detail += f"  body={r.text[:140]}"
+        summary.add(CheckResult(name, ok, detail, elapsed))
+        if not ok:
+            return None
+        try:
+            return r.json()
+        except Exception:  # noqa: BLE001
+            return None
+    except Exception as e:  # noqa: BLE001
+        elapsed = int((time.monotonic() - t0) * 1000)
+        summary.add(CheckResult(name, False, f"exception: {e!r}", elapsed))
+        return None
+
+
+async def _check_socket_v2(
+    summary: RunSummary, host: str, question: str
+) -> None:
+    """Open v2 socket, send `question`, assert structured response."""
+    name_connect = "v2 socket connect"
+    name_msg = "v2 socket: structured response with citations"
+    parsed = urlparse(host)
+    base = f"{parsed.scheme}://{parsed.netloc}"
+    socketio_path = "/smartchatbot/v2/socket.io"
+
+    sio = socketio.AsyncClient(reconnection=False, logger=False)
+    inbox: list[dict] = []
+    connect_ok = asyncio.Event()
+
+    @sio.on("connect")
+    async def _on_connect() -> None:
+        connect_ok.set()
+
+    @sio.on("message")
+    async def _on_message(payload) -> None:  # type: ignore[no-untyped-def]
+        inbox.append(payload if isinstance(payload, dict) else {"raw": payload})
+
+    t0 = time.monotonic()
+    try:
+        await sio.connect(
+            base,
+            socketio_path=socketio_path,
+            transports=["websocket"],
+            wait=True,
+            wait_timeout=10,
+        )
+    except Exception as e:  # noqa: BLE001
+        elapsed = int((time.monotonic() - t0) * 1000)
+        summary.add(CheckResult(name_connect, False, f"connect failed: {e!r}", elapsed))
+        summary.add(CheckResult(name_msg, False, "skipped (no connection)", 0))
+        return
+
+    elapsed = int((time.monotonic() - t0) * 1000)
+    summary.add(CheckResult(name_connect, True, f"connected to {socketio_path}", elapsed))
+
+    t0 = time.monotonic()
+    try:
+        await sio.emit("message", question)
+        # Wait up to 30s for the response. A real turn takes 3-10s.
+        deadline = time.monotonic() + 30
+        while not inbox and time.monotonic() < deadline:
+            await asyncio.sleep(0.2)
+        elapsed = int((time.monotonic() - t0) * 1000)
+        if not inbox:
+            summary.add(CheckResult(name_msg, False, "no response in 30s", elapsed))
+            return
+        resp = inbox[-1]  # last message in case status preamble came first
+        # Assert the v2 shape: must have citations key + confidence key.
+        # (The legacy reply doesn't have these.)
+        if "citations" not in resp or "confidence" not in resp:
+            summary.add(CheckResult(
+                name_msg, False,
+                f"missing citations/confidence: keys={sorted(resp.keys())[:10]}",
+                elapsed,
+            ))
+            return
+        n_cites = len(resp.get("citations") or [])
+        conf = resp.get("confidence")
+        is_refusal = bool(resp.get("is_refusal"))
+        msg_preview = (resp.get("message") or "")[:80].replace("\n", " ")
+        detail = f"citations={n_cites} confidence={conf} refusal={is_refusal} msg={msg_preview!r}"
+        # A refused answer is a valid v2 response shape -- log it but
+        # don't fail the check on it (the canned question may not match
+        # the live corpus). The operator reads the detail.
+        summary.add(CheckResult(name_msg, True, detail, elapsed))
+    finally:
+        try:
+            await sio.disconnect()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+async def _check_socket_legacy(
+    summary: RunSummary, host: str, question: str
+) -> None:
+    """Open legacy socket, send `question`, assert we get ANY reply.
+
+    This is the "did the ASGI wrap break legacy?" guard. We do NOT
+    assert correctness -- only that the legacy path still responds at
+    all. Anything ≥1 char back is a pass; the legacy bot is the path
+    100% of real traffic uses today, so any silent breakage here is the
+    worst possible outcome.
+    """
+    name = "legacy socket: still responds (wrap-safety)"
+    parsed = urlparse(host)
+    base = f"{parsed.scheme}://{parsed.netloc}"
+    socketio_path = "/smartchatbot/socket.io"
+
+    sio = socketio.AsyncClient(reconnection=False, logger=False)
+    inbox: list[dict] = []
+
+    @sio.on("message")
+    async def _on_message(payload) -> None:  # type: ignore[no-untyped-def]
+        inbox.append(payload if isinstance(payload, dict) else {"raw": payload})
+
+    t0 = time.monotonic()
+    try:
+        await sio.connect(
+            base,
+            socketio_path=socketio_path,
+            transports=["websocket"],
+            wait=True,
+            wait_timeout=10,
+        )
+        await sio.emit("message", question)
+        deadline = time.monotonic() + 30
+        while not inbox and time.monotonic() < deadline:
+            await asyncio.sleep(0.2)
+        elapsed = int((time.monotonic() - t0) * 1000)
+        if not inbox:
+            summary.add(CheckResult(name, False, "no legacy response in 30s", elapsed))
+            return
+        resp = inbox[-1]
+        msg = (resp.get("message") or "") if isinstance(resp, dict) else str(resp)
+        if not msg:
+            summary.add(CheckResult(name, False, f"empty legacy response: {resp}", elapsed))
+            return
+        preview = msg[:80].replace("\n", " ")
+        summary.add(CheckResult(name, True, f"legacy replied len={len(msg)} preview={preview!r}", elapsed))
+    except Exception as e:  # noqa: BLE001
+        elapsed = int((time.monotonic() - t0) * 1000)
+        summary.add(CheckResult(name, False, f"exception: {e!r}", elapsed))
+    finally:
+        try:
+            await sio.disconnect()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+# --- Orchestration --------------------------------------------------------
+
+
+async def run(host: str, question: str, skip_legacy: bool) -> int:
+    summary = RunSummary()
+    with httpx.Client(timeout=20.0) as client:
+        _check_http(summary, client, host, "/health/ready", "GET /health/ready")
+        smoke = _check_http(summary, client, host, "/smoketest", "GET /smoketest")
+        # Soft-assert the smoke result includes citations / is not refused.
+        if isinstance(smoke, dict):
+            cited = bool((smoke.get("citations") or []))
+            refused = bool(smoke.get("is_refusal"))
+            summary.add(CheckResult(
+                "/smoketest answer is grounded",
+                cited and not refused,
+                f"citations={len(smoke.get('citations') or [])} refusal={refused}",
+                0,
+            ))
+
+    await _check_socket_v2(summary, host, question)
+    if not skip_legacy:
+        await _check_socket_legacy(summary, host, question)
+
+    print()
+    summary.emit()
+    return 0 if summary.failed == 0 else 1
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Live-verify the v2 serving path.")
+    parser.add_argument(
+        "--host",
+        default="http://localhost:8000",
+        help="Base URL of the chatbot service (default: http://localhost:8000)",
+    )
+    parser.add_argument(
+        "--question",
+        default="what time does King Library close today?",
+        help="Canned question to send through both stacks.",
+    )
+    parser.add_argument(
+        "--skip-legacy",
+        action="store_true",
+        help="Don't probe the legacy socket path (e.g. if legacy creds are unset).",
+    )
+    args = parser.parse_args(argv)
+
+    print(f"Live-verify v2 serving against {args.host}")
+    print(f"Question: {args.question!r}")
+    print()
+
+    try:
+        return asyncio.run(run(args.host, args.question, args.skip_legacy))
+    except KeyboardInterrupt:
+        print("\ninterrupted", file=sys.stderr)
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = ["main", "run"]

--- a/docs/librarian-services-truthtable-ask.md
+++ b/docs/librarian-services-truthtable-ask.md
@@ -1,0 +1,130 @@
+# Librarian ask: confirm services-offered per building
+
+This is a 30-minute task. The output unblocks a load-bearing safety
+check in the rebuilt chatbot: it stops the bot from telling a
+Hamilton or Middletown user that there's a MakerSpace at their
+building when there isn't.
+
+**Send to**: TBD (subject lead per building, or program lead who can
+delegate). Cc: TBD.
+**From**: Meng Qu / qum@miamioh.edu
+**Subject**: Quick chatbot accuracy ask — confirm 6 rows of "which
+services exist at which library"
+
+---
+
+## What we need
+
+For each of the 6 library buildings, confirm or correct the
+services-offered list below. The chatbot uses this as a strict
+truth-table: if a service isn't on the list for a building, the bot
+**refuses** to answer "does X library have <service>?" rather than
+guessing — and points the user to the building that does have it.
+
+This is what prevents the failure we've seen in testing: a Hamilton
+user asking "do you have a MakerSpace?" and the bot answering as if
+they were in Oxford.
+
+You don't have to fix the list from scratch — just confirm or strike
+through. Reply by email or annotate the table inline.
+
+## The 6 rows to confirm
+
+### 1. Edward King Library (Oxford)
+
+- printing
+- ill_pickup
+- study_rooms
+- course_reserves
+- research_appointments
+- av_production
+- makerspace
+
+→ Right? Anything missing? Anything that shouldn't be on the list?
+
+### 2. Wertz Art & Architecture Library (Oxford)
+
+- printing
+- ill_pickup
+- study_rooms
+- course_reserves
+- research_appointments
+
+→ Right? (Notably **no** av_production, **no** makerspace — correct?)
+
+### 3. Walter Havighurst Special Collections & University Archives (Oxford)
+
+- rare_books_access
+- archival_research
+- research_appointments
+
+→ Right? Should ill_pickup / printing be on this list too, or are
+those genuinely not offered at this location?
+
+### 4. Rentschler Library (Hamilton)
+
+- printing
+- ill_pickup
+- study_rooms
+- course_reserves
+- research_appointments
+
+→ Right? Anything Hamilton-specific we're missing (e.g. tutoring
+services, a maker-style space if one exists there)?
+
+### 5. Gardner-Harvey Library (Middletown)
+
+- printing
+- ill_pickup
+- study_rooms
+- course_reserves
+- research_appointments
+
+→ Right? Anything Middletown-specific?
+
+### 6. Southwest Ohio Regional Depository — SWORD (Middletown)
+
+- depository_retrieval
+
+→ Right? (SWORD is the storage facility, so this short list is
+intentional — but if it offers anything user-facing beyond retrieval,
+say so.)
+
+## Service vocabulary (so we're all using the same words)
+
+If you want to add a service that isn't already in the lists above,
+pick from this controlled vocabulary so the bot's matching logic
+keeps working. If something belongs but isn't in the list, tell me
+and I'll add it (it's one line of code).
+
+| ID | What it means |
+|---|---|
+| `printing` | Self-service printing / pickup at the building |
+| `ill_pickup` | Interlibrary Loan pickup point |
+| `study_rooms` | Bookable study spaces |
+| `course_reserves` | Physical course reserves held here |
+| `research_appointments` | One-on-one librarian consultations |
+| `av_production` | AV / media production equipment users can check out or use on site |
+| `makerspace` | 3D printers, vinyl cutter, sewing, etc. |
+| `rare_books_access` | Rare materials available for reading-room use |
+| `archival_research` | University archives available for research |
+| `depository_retrieval` | Off-site materials retrieved on request |
+
+## What happens after you reply
+
+I update one Python file (`ai-core/scripts/seed_library_spaces_v2.py`),
+re-seed the database (idempotent, takes ~5 seconds), and the bot
+picks up the new truth-table on the next request. No restart needed.
+I'll send a one-line confirmation when it's live.
+
+## Why this is the blocking ask
+
+It's the only Gap-3 item on the rebuild's "10% rollout" checklist
+that can't be done by the engineering side alone. Code-wise the safety
+check (cross-campus refusal guard) is shipped and tested; what it
+needs is for the truth-table behind it to be confirmed by someone who
+actually knows the buildings.
+
+Thanks for the 30 minutes.
+
+— Meng


### PR DESCRIPTION
## Summary

Closes two of the three threshold-3 (10% rollout flag flipped on)
blockers from the plan's "next two weeks" sequencing:

- **Operator-side**: a programmatic live-verify so you can run one
  command against a real host and know whether it's safe to flip
  \`VITE_V2_ROLLOUT_PERCENT\` above 0.
- **Content-side**: the parallel librarian outreach draft for the
  \`services_offered\` truth-table (Gap 3) — the only blocker that
  engineering can't unblock alone.

Both fit together because they're the two halves of "can we ship?":
the verify says the code path works end-to-end with real backends;
the librarian confirmation says the truth-table behind the cross-
campus safety check is right.

## What's in this PR

### 1. \`ai-core/scripts/verify_v2_serving.py\` (new)

\`\`\`bash
.venv/bin/python -m scripts.verify_v2_serving --host http://localhost:8000
\`\`\`

Five checks, in order. Exits non-zero on any failure:

1. \`GET /health/ready\` → 200 (all dep probes pass)
2. \`GET /smoketest\` → 200 with citations and not refused
3. v2 socket connect to \`/smartchatbot/v2/socket.io\` succeeds
4. v2 socket message → response has \`citations[]\` + \`confidence\` keys (the v2 additive shape — proves orchestrator wired up, not just transport)
5. Legacy socket still responds (wrap-safety guard — confirms the \`socketio.ASGIApp\` wrap in \`main.py\` didn't break the path 100% of traffic uses today)

Uses already-installed deps (\`python-socketio\`, \`httpx\`); no new requirements.

Verified locally against an unreachable host: clean per-check FAIL output, exit 1.

### 2. \`ai-core/docs/OPERATOR.md\` (extended)

Adds a "Live-verify the v2 serving path" section under day-to-day tasks. Explains what each check means, when to use \`--skip-legacy\`, and the exit-code contract.

### 3. \`docs/librarian-services-truthtable-ask.md\` (new)

A ready-to-send email draft for a subject lead / program lead. Asks them to confirm or correct the \`services_offered\` list for each of the 6 library buildings (King, Wertz, Special Collections, Rentschler, Gardner-Harvey, SWORD). Pre-filled with current seed values so the librarian confirms/strikes-through rather than thinks from scratch. Includes the controlled service vocabulary so additions match the bot's matching logic.

## Why this matters for the rollout

From the plan's robustness ladder:

> **Threshold 3 — 10% real-user flag**: A feature flag routes ≥10% of production traffic through the new stack. Observability catches failures within the hour.

The remaining blockers were:
- ✅ Op 3 MVP (PR #71, merged)
- ✅ Cost rollup (PR #77, merged)
- ✅ Hours date-window (PR #78, merged)
- ⏳ Live-verify path works → **this PR's verify script**
- ⏳ Librarian confirms services_offered → **this PR's email draft, pending OpenAI credit return + librarian response**
- ⏳ Flip \`VITE_V2_ROLLOUT_PERCENT\` to 10 — final step

When OpenAI credit returns + SSH tunnels are up, you'll be able to:

\`\`\`bash
# 1. Verify
.venv/bin/python -m scripts.verify_v2_serving --host https://chatbot.miamioh.edu
# (read PASS/FAIL summary; only continue on exit 0)

# 2. Once librarian confirms truth-table: re-seed
.venv/bin/python -m scripts.seed_library_spaces_v2

# 3. Flip the flag
# Edit VITE_V2_ROLLOUT_PERCENT in the client env, redeploy frontend.
\`\`\`

## Test plan

- [x] Script imports cleanly: \`python3 -c "from scripts.verify_v2_serving import main"\`
- [x] \`--help\` renders cleanly
- [x] Against unreachable host: all 5 checks FAIL with crisp diagnostics, exit 1
- [x] Offline test suite still 46/46 (no regression — script isn't a test, isn't in OFFLINE list)
- [x] **Once credit is back**: run against \`http://localhost:8000\` with SSH tunnels up; expect 5/5 PASS

## What's NOT in this PR

- No code-path changes. No tests added for the verify script itself (it's a live-host integration tool; unit testing it would be mostly mocking httpx + socketio with no real coverage).
- No edits to legacy \`docs/01-…\` through \`docs/12-…\` (per the "leave 3" direction earlier — legacy docs untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)