### PR TITLE
feat(ops): verify prompt caching on the four stable prefixes (~$0.02)

### DIFF
--- a/ai-core/docs/OPERATOR.md
+++ b/ai-core/docs/OPERATOR.md
@@ -143,6 +143,29 @@ run them by hand when their env is set up.
 When you add a new test file, append it to the right list in
 `scripts/run_offline_tests.sh` (sorted, one entry per line).
 
+### Verify prompt caching still works
+
+After editing any `src/prompts/*_v1.py` file (or changing the
+`LLM_MODEL_*` env vars to a new model family), re-verify the cache:
+
+```bash
+cd ai-core
+python -m scripts.verify_prompt_cache --prefix synthesizer_v1
+python -m scripts.verify_prompt_cache --prefix agent_v1 --model gpt-5.4-mini
+python -m scripts.verify_prompt_cache --prefix judge_v1 --model gpt-5.4-nano
+python -m scripts.verify_prompt_cache --prefix clarifier_v1 --model gpt-5.4-mini
+```
+
+Each makes a small number of real OpenAI calls (~$0.005) and exits
+non-zero if cache hit rate falls below 60%. The first call always
+misses (cold start); the rate is computed on calls 2..N.
+
+If a check fails, the byte-stability log in `src/prompts/builder.py`
+will show which prefix changed call-to-call. Fix it before deploying
+or expect the daily cost rollup to flag a regression within 24h.
+
+See findings: `ai-core/src/eval/findings/2026-05-20_cache_hit_verification.md`
+
 ### Live-verify the v2 serving path
 
 The v2 stack (rebuilt orchestrator behind `?v2=1`) is code-complete

--- a/ai-core/scripts/verify_prompt_cache.py
+++ b/ai-core/scripts/verify_prompt_cache.py
@@ -1,0 +1,172 @@
+"""
+Verify OpenAI prompt caching is actually firing for our stable prefixes.
+
+The plan's threshold-3 cost-cache gate (Verification §7) requires
+cached_input_tokens / input_tokens >= 0.6 across the eval. That number
+only happens if the stable prefix in `src/prompts/*_v1.py` is BIG ENOUGH
+(>=1024 tokens) AND BYTE-IDENTICAL call-to-call. PR #74 was designed
+around that contract; this script proves it works.
+
+Procedure:
+  1. Pick a stable prefix (default: synthesizer_v1).
+  2. Make N calls (default: 3) via the Responses API with:
+       - identical prefix
+       - varying small suffix
+       - same model
+     Wait briefly between calls so the cache can warm.
+  3. Read `usage.input_tokens_details.cached_tokens` per response.
+  4. Report per-call + the cache_hit_rate for calls 2..N.
+
+The first call ALWAYS misses (cache is cold). The second and later
+should be `>= 1024` cached_tokens if the prefix is correctly stable.
+
+Cost: tiny. ~3,200 input tokens per call * (mini @ $0.75/1M) ~ $0.0024
+per call uncached, ~$0.00026 per call when cached. 3 calls ≈ $0.005.
+
+Usage:
+    .venv/bin/python -m scripts.verify_prompt_cache
+    .venv/bin/python -m scripts.verify_prompt_cache --prefix agent_v1
+    .venv/bin/python -m scripts.verify_prompt_cache --calls 5 --model gpt-5.4-nano
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from typing import Any, Optional
+
+from openai import OpenAI
+
+
+# Load .env from the repo root the same way main.py does
+def _load_env() -> None:
+    from pathlib import Path
+    from dotenv import load_dotenv
+    here = Path(__file__).resolve().parent
+    # ai-core/scripts/ -> repo root is two parents up
+    root_env = here.parent.parent / ".env"
+    load_dotenv(root_env)
+
+
+def _resolve_prefix(prefix_id: str) -> str:
+    """Load a stable prefix by id (synthesizer_v1, agent_v1, etc.)."""
+    if prefix_id == "synthesizer_v1":
+        from src.prompts.synthesizer_v1 import SYNTHESIZER_V1_PREFIX
+        return SYNTHESIZER_V1_PREFIX
+    if prefix_id == "agent_v1":
+        from src.prompts.agent_v1 import AGENT_V1_PREFIX
+        return AGENT_V1_PREFIX
+    if prefix_id == "clarifier_v1":
+        from src.prompts.clarifier_v1 import CLARIFIER_V1_PREFIX
+        return CLARIFIER_V1_PREFIX
+    if prefix_id == "judge_v1":
+        from src.prompts.judge_v1 import JUDGE_V1_PREFIX
+        return JUDGE_V1_PREFIX
+    raise ValueError(f"unknown prefix id: {prefix_id}")
+
+
+def _extract_cached_tokens(usage: Any) -> int:
+    """The Responses API usage object exposes cached_tokens under
+    `input_tokens_details.cached_tokens` on current SDK versions. Older
+    surfaces had it as a top-level `cached_tokens` or under a slightly
+    different name. Be defensive."""
+    if usage is None:
+        return 0
+    # Newer SDK: usage.input_tokens_details.cached_tokens
+    details = getattr(usage, "input_tokens_details", None)
+    if details is not None:
+        v = getattr(details, "cached_tokens", None)
+        if v is not None:
+            return int(v)
+    # Some SDK versions: usage.prompt_tokens_details.cached_tokens
+    details = getattr(usage, "prompt_tokens_details", None)
+    if details is not None:
+        v = getattr(details, "cached_tokens", None)
+        if v is not None:
+            return int(v)
+    # Legacy / direct
+    v = getattr(usage, "cached_tokens", None)
+    if v is not None:
+        return int(v)
+    return 0
+
+
+def run(prefix_id: str, calls: int, model: str, sleep_ms: int) -> int:
+    _load_env()
+    prefix = _resolve_prefix(prefix_id)
+    print(f"Prefix: {prefix_id}  chars={len(prefix)}  approx_tokens~{len(prefix)//4}")
+    print(f"Model:  {model}")
+    print(f"Calls:  {calls}")
+    print()
+
+    client = OpenAI()
+    results: list[tuple[int, int, int]] = []  # (input, cached, output)
+    for i in range(1, calls + 1):
+        # Tiny per-call variant so OpenAI doesn't dedupe at request layer.
+        suffix = f"\n\nVariant {i}. Respond with the single word OK."
+        t0 = time.monotonic()
+        resp = client.responses.create(
+            model=model,
+            input=prefix + suffix,
+            max_output_tokens=20,
+        )
+        elapsed = int((time.monotonic() - t0) * 1000)
+        u = getattr(resp, "usage", None)
+        inp = int(getattr(u, "input_tokens", 0)) if u else 0
+        out = int(getattr(u, "output_tokens", 0)) if u else 0
+        cached = _extract_cached_tokens(u)
+        results.append((inp, cached, out))
+        pct = (cached / inp * 100) if inp else 0
+        print(f"  call {i}: input={inp:5d}  cached={cached:5d} ({pct:5.1f}%)  output={out:3d}  {elapsed}ms")
+        if i < calls and sleep_ms > 0:
+            time.sleep(sleep_ms / 1000)
+
+    print()
+    if len(results) >= 2:
+        cached_2plus = sum(c for _, c, _ in results[1:])
+        input_2plus = sum(i for i, _, _ in results[1:])
+        rate = (cached_2plus / input_2plus) if input_2plus else 0
+        print(f"Cache hit rate (calls 2..N): {cached_2plus}/{input_2plus} = {rate:.1%}")
+        # The plan's release gate is 0.6. The first call always misses;
+        # we measure the steady-state rate over calls 2..N.
+        ok = rate >= 0.6
+        print(f"Plan threshold (>= 60%):     {'PASS' if ok else 'FAIL'}")
+        return 0 if ok else 1
+    return 0
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Verify OpenAI prompt caching on a stable prefix.")
+    parser.add_argument(
+        "--prefix",
+        default="synthesizer_v1",
+        choices=["synthesizer_v1", "agent_v1", "clarifier_v1", "judge_v1"],
+        help="Which prompt prefix to test.",
+    )
+    parser.add_argument(
+        "--calls",
+        type=int,
+        default=3,
+        help="How many calls to make (default 3; first always misses).",
+    )
+    parser.add_argument(
+        "--model",
+        default="gpt-5.4-nano",
+        help="Model to use. Default nano (cheapest verification).",
+    )
+    parser.add_argument(
+        "--sleep-ms",
+        type=int,
+        default=500,
+        help="Sleep between calls to let cache propagate (ms; default 500).",
+    )
+    args = parser.parse_args(argv)
+    return run(args.prefix, args.calls, args.model, args.sleep_ms)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = ["main", "run"]

--- a/ai-core/src/eval/findings/2026-05-20_cache_hit_verification.md
+++ b/ai-core/src/eval/findings/2026-05-20_cache_hit_verification.md
@@ -1,0 +1,78 @@
+# Cache-hit verification on the four stable prefixes
+
+**Date:** 2026-05-20
+**Tool:** `ai-core/scripts/verify_prompt_cache.py`
+**Plan reference:** Verification §7 (cache-hit gate: `cached_input_tokens
+/ input_tokens >= 0.6`)
+
+## TL;DR
+
+All four production prefixes hit cache well above the 60% gate on
+their target models. The byte-stability discipline shipped in PR #74
+is working. Total spend to verify: ~$0.02.
+
+| Prefix | Production model | Input tokens | Cache hit (calls 2+) | Pass? |
+|---|---|---|---:|---|
+| `synthesizer_v1` | gpt-5.4-mini | 3094 | **91.0%** | ✅ |
+| `agent_v1` | gpt-5.4-mini | 1453 | **88.1%** | ✅ |
+| `judge_v1` | gpt-5.4-nano | 2620 | **68.4%** | ✅ |
+| `clarifier_v1` | gpt-5.4-mini | 1537 | **83.3%** | ✅ |
+
+First call always misses (cold cache). Calls 2+ hit cached_input as
+shown. Side benefit: cached calls are roughly 2-3× faster
+(synth: 2225ms cold → 696ms warm).
+
+## One bonus finding worth knowing
+
+The nano model has a **higher practical cache floor than mini** at our
+prefix sizes. Specifically:
+
+| Prefix | On nano | On mini |
+|---|---|---|
+| `synthesizer_v1` (3094 tok) | 91.0% | 91.0% |
+| `agent_v1` (1453 tok) | **0.0%** | 88.1% |
+
+A 1453-token prefix is above OpenAI's documented 1024-token cache
+minimum but doesn't actually cache on nano — observed empirically.
+This doesn't affect production because the agent runs on mini per
+`LLM_MODEL_BASIC` (PR #74). It WOULD affect anyone considering
+routing the agent through nano to save model-cost — the cache savings
+would vanish and the per-token-cost win would be offset by ~2× more
+billable input tokens.
+
+Practical implication: nano is fine for the judge (its prefix is 2620
+tokens, well above whatever nano's true floor is) and for any future
+nano call site as long as the stable prefix is >= ~2000 tokens. Keep
+that in mind when adding new call sites.
+
+## How to re-verify
+
+```bash
+cd ai-core
+python -m scripts.verify_prompt_cache --prefix synthesizer_v1
+python -m scripts.verify_prompt_cache --prefix agent_v1 --model gpt-5.4-mini
+python -m scripts.verify_prompt_cache --prefix judge_v1 --model gpt-5.4-nano
+python -m scripts.verify_prompt_cache --prefix clarifier_v1 --model gpt-5.4-mini
+```
+
+Each exits 0 if >= 60% cache hit, 1 otherwise. Cost per run: ~$0.005.
+
+Re-run when:
+- Editing any `_v1` prefix file (catches accidental byte drift).
+- Switching `LLM_MODEL_*` to a new model family (different cache rules).
+- The cost dashboard shows `cached_input_tokens / input_tokens < 0.6`
+  for a 1-hour rolling window (Op 3 alert).
+
+## What this unblocks
+
+The cost gate from plan Verification §7 is met. Combined with PR #77
+(cost rollup landing yesterday), we now have:
+
+1. **Cache investment proven** (this doc)
+2. **Cache measured per-call** (`cached_input_tokens` column on
+   `ModelTokenUsage` — PR #74)
+3. **Daily rollup of token cost** (`scripts/cost_rollup.py` — PR #77)
+
+That's the full cost-observability stack. Cost surprises after this
+point will surface in `DailyCost` within 24h instead of "noticed
+during the monthly billing review."


### PR DESCRIPTION
## Summary

The plan's threshold-3 cost gate (Verification §7) requires \`cached_input_tokens / input_tokens >= 0.6\` across the eval. PR #74 shipped the byte-stability discipline + padded prefixes to meet that target; nothing actually **measured it against the live API**. This PR proves it works.

## Results (measured today against real OpenAI)

| Prefix | Production model | Input tokens | Cache hit (calls 2+) | Pass? |
|---|---|---:|---:|---|
| \`synthesizer_v1\` | gpt-5.4-mini | 3094 | **91.0%** | ✅ |
| \`agent_v1\` | gpt-5.4-mini | 1453 | **88.1%** | ✅ |
| \`judge_v1\` | gpt-5.4-nano | 2620 | **68.4%** | ✅ |
| \`clarifier_v1\` | gpt-5.4-mini | 1537 | **83.3%** | ✅ |

All four pass the 60% gate. **Side benefit**: cached calls are 2–3× faster (synth: 2225ms cold → 696ms warm).

Total cost to measure: ~$0.02.

## What's in this PR

- **\`ai-core/scripts/verify_prompt_cache.py\`** — makes N real Responses-API calls with one of the four stable prefixes + tiny varying suffix, reads \`cached_input_tokens\` per call, computes hit rate over calls 2..N. Exits 0 if ≥ 60%, 1 otherwise. Cost ~$0.005/run.
- **\`ai-core/src/eval/findings/2026-05-20_cache_hit_verification.md\`** — today's results + how to re-verify.
- **\`ai-core/docs/OPERATOR.md\`** — new "Verify prompt caching still works" section pointing at the script + when to re-run (after editing a \`*_v1\` prefix file, or switching model env vars).

## One bonus finding worth flagging

Nano has a **higher practical cache floor than mini** at our prefix sizes:

| Prefix | On nano | On mini |
|---|---:|---:|
| \`synthesizer_v1\` (3094 tok) | 91.0% | 91.0% |
| \`agent_v1\` (1453 tok) | **0.0%** | 88.1% |

This doesn't affect production (the agent runs on mini per \`LLM_MODEL_BASIC\`) but is worth knowing if anyone considers routing the agent through nano to save model-cost — the cache savings would vanish.

## Why this matters

Combined with PR #74 (the \`cached_input_tokens\` column on \`ModelTokenUsage\`) and PR #77 (the \`DailyCost\` rollup), this closes the full **cost-observability stack**:

1. ✅ Cache investment proven (this PR)
2. ✅ Cache measured per-call (PR #74)
3. ✅ Daily rollup of token cost (PR #77)

Cost regressions after this point will surface in \`DailyCost\` within 24h instead of "noticed during the monthly billing review."

## Test plan

- [x] Each prefix tested on its production model — all 4 PASS
- [x] Cross-test: \`agent_v1\` on nano — documented 0% finding
- [x] Script exit code = 0 on PASS, 1 on FAIL (verified)
- [x] Offline runner still 46/46 (no regression — script isn't in the offline list because it spends real money)

🤖 Generated with [Claude Code](https://claude.com/claude-code)