### PR TITLE
chore(ops): eval results analyzer + OPERATOR runbook for the full eval

### DIFF
--- a/ai-core/docs/OPERATOR.md
+++ b/ai-core/docs/OPERATOR.md
@@ -196,6 +196,88 @@ If your env doesn't have legacy creds (rare), pass `--skip-legacy`.
 Default question is hours-class because hours questions are the most
 LibCal-grounded and least likely to legitimately refuse; override
 with `--question "..."` if you want to probe a specific intent.
+### Run the full real-LLM + judge eval
+
+This is the load-bearing quality measurement — 184 gold cases through
+the v2 stack (classifier + retrieval + agent + synth + judge). Real
+OpenAI, real Weaviate, real Postgres, real verdicts. ~20–30 minutes,
+~$0.30–$0.50 per run (the per-case cost is ~20× cheaper than originally
+budgeted; verified 2026-05-20).
+
+**Prerequisites (all three must be true or the run dies at startup or
+mid-flight with cryptic errors):**
+
+```bash
+# 1. Tunnels up (Weaviate on ulblwebp20, Postgres on ulblwebt04)
+ssh -fN -L 8888:127.0.0.1:8888 -L 50051:127.0.0.1:50051 qum@ulblwebp20.lib.miamioh.edu
+ssh -fN -L 5432:127.0.0.1:5432 qum@ulblwebt04.lib.miamioh.edu
+
+# 2. Verify
+nc -z -w2 127.0.0.1 8888 && nc -z -w2 127.0.0.1 50051 && nc -z -w2 127.0.0.1 5432 \
+  && echo "ALL TUNNELS UP" || echo "TUNNEL MISSING"
+
+# 3. OPENAI_API_KEY in .env (the project's resolve_model("basic") path will use it)
+```
+
+**Run it (note: `.venv/bin/python`, NOT system `python3` — prisma is
+only installed in the venv):**
+
+```bash
+cd ai-core
+.venv/bin/python -m src.eval.run_eval \
+    --with-real-llm --with-judge \
+    --results-out eval_results/full_eval_$(date +%Y%m%d).jsonl \
+    2>&1 | tee eval_results/full_eval_$(date +%Y%m%d).log
+```
+
+Streams per-case JSONL while it runs, so an interrupted run still
+leaves a partial-but-analyzable file behind.
+
+**Analyze the results:**
+
+```bash
+# Aggregate summary (PASS/PARTIAL/FAIL by judge verdict, cache hit, latency)
+.venv/bin/python -m scripts.analyze_eval_results eval_results/full_eval_YYYYMMDD.jsonl
+
+# Per-category PASS/FAIL table
+.venv/bin/python -m scripts.analyze_eval_results <jsonl> --by category
+
+# Per-intent breakdown
+.venv/bin/python -m scripts.analyze_eval_results <jsonl> --by intent
+
+# List every FAIL case with judge verdict + answer preview
+.venv/bin/python -m scripts.analyze_eval_results <jsonl> --fails
+
+# Drill into one specific case (full bot_answer, classifier candidates, tokens)
+.venv/bin/python -m scripts.analyze_eval_results <jsonl> --id fs_makerspace_3d
+
+# The 20 slowest cases (where latency budget lives)
+.venv/bin/python -m scripts.analyze_eval_results <jsonl> --slowest 20
+```
+
+The analyzer is tolerant of partial files — you can run it WHILE the
+eval is still going to spot-check progress without disturbing the
+streaming write.
+
+**Expected ballpark numbers** (refine as more runs come in):
+
+- PASS (correct + refused_correctly): aim for ≥ 75%
+- Scope-resolver match: ≥ 95% (the resolver is rule-based, ought to be near-perfect)
+- Cache hit rate: ≥ 60% across the whole run (first call cold-misses;
+  steady state warms up after ~3 cases)
+- p95 latency: < 30s per case (one slow case can spike this; spot-check
+  --slowest 5 if it's high)
+
+**Gotchas:**
+
+- If startup errors with `Weaviate unreachable -- the SSH tunnel is
+  down`, the runner is doing its job — re-run after the tunnel comes
+  back. Don't try to bypass.
+- If turn errors with `ModuleNotFoundError: No module named 'prisma'`,
+  you're on system python; rerun with `.venv/bin/python`.
+- A run produces ~$0.40 in OpenAI spend; the DailyCost rollup
+  (`scripts.cost_rollup`) WILL show this as a spike. Tag the date in
+  the cost dashboard so it's not flagged as anomaly.
 
 ### Weekly ETL refresh
 

--- a/ai-core/scripts/analyze_eval_results.py
+++ b/ai-core/scripts/analyze_eval_results.py
@@ -1,0 +1,216 @@
+"""
+Analyze a streaming JSONL written by `src.eval.run_eval --results-out PATH`.
+
+Why a separate tool: run_eval prints summary numbers but the file has
+RICH per-case data (clf_candidates, refusal triggers, cached tokens,
+the full bot_answer) that's easier to slice with one helper than by
+re-running the eval. Also: run_eval streams JSONL, so this works on a
+partially-complete file (useful while the full run is still going).
+
+Usage:
+    # Default summary: aggregate + per-category PASS/FAIL table
+    .venv/bin/python -m scripts.analyze_eval_results \\
+        eval_results/full_eval_20260520.jsonl
+
+    # Per-actual-intent breakdown
+    .venv/bin/python -m scripts.analyze_eval_results PATH --by intent
+
+    # List failures with judge verdict + reason
+    .venv/bin/python -m scripts.analyze_eval_results PATH --fails
+
+    # Drill into one case (full bot_answer, classifier candidates, etc.)
+    .venv/bin/python -m scripts.analyze_eval_results PATH --id fs_makerspace_3d
+
+    # Slowest 20 cases (where latency lives)
+    .venv/bin/python -m scripts.analyze_eval_results PATH --slowest 20
+
+Pass/fail mapping (matches the eval's own classification):
+    PASS    = correct | refused_correctly
+    PARTIAL = partial            (judged defensible but imperfect)
+    FAIL    = wrong | refused_incorrectly | answered_should_have_refused
+    SKIP    = no judge verdict (case didn't run far enough to be judged)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any, Optional
+
+
+PASS_VERDICTS = {"correct", "refused_correctly"}
+PARTIAL_VERDICTS = {"partial"}
+FAIL_VERDICTS = {"wrong", "refused_incorrectly", "answered_should_have_refused"}
+
+
+def _load(path: str) -> list[dict]:
+    rows: list[dict] = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError:
+                # streaming write -- last line may be partial mid-run
+                continue
+    return rows
+
+
+def _bucket(verdict: Optional[str]) -> str:
+    if verdict is None or verdict == "":
+        return "SKIP"
+    if verdict in PASS_VERDICTS:
+        return "PASS"
+    if verdict in PARTIAL_VERDICTS:
+        return "PARTIAL"
+    if verdict in FAIL_VERDICTS:
+        return "FAIL"
+    return "OTHER"
+
+
+def _summary(rows: list[dict]) -> None:
+    n = len(rows)
+    if n == 0:
+        print("(no rows yet)")
+        return
+
+    buckets = Counter(_bucket(r.get("judge_verdict")) for r in rows)
+    scope_ok = sum(1 for r in rows if r.get("scope_match"))
+    intent_ok = sum(1 for r in rows if r.get("intent_match"))
+    path_ok = sum(1 for r in rows if r.get("path_match"))
+    cited = sum(1 for r in rows if (r.get("bot_citations_count") or 0) > 0)
+    refusals = sum(1 for r in rows if r.get("bot_was_refusal"))
+
+    total_in = sum(r.get("input_tokens", 0) or 0 for r in rows)
+    total_cached = sum(r.get("cached_input_tokens", 0) or 0 for r in rows)
+    total_out = sum(r.get("output_tokens", 0) or 0 for r in rows)
+    cache_rate = (total_cached / total_in * 100) if total_in else 0
+
+    latencies = sorted(r.get("latency_ms", 0) or 0 for r in rows)
+    p50 = latencies[len(latencies) // 2] if latencies else 0
+    p95 = latencies[int(len(latencies) * 0.95)] if latencies else 0
+
+    print(f"Cases: {n}")
+    print()
+    print("Quality (judge verdict bucket):")
+    for b in ("PASS", "PARTIAL", "FAIL", "SKIP", "OTHER"):
+        c = buckets.get(b, 0)
+        pct = c / n * 100 if n else 0
+        print(f"  {b:8s}  {c:4d}  ({pct:5.1f}%)")
+    print()
+    print("Pipeline stages (per-row matches):")
+    print(f"  scope_match    {scope_ok}/{n}  ({scope_ok/n*100:.1f}%)")
+    print(f"  intent_match   {intent_ok}/{n}  ({intent_ok/n*100:.1f}%)")
+    print(f"  path_match     {path_ok}/{n}  ({path_ok/n*100:.1f}%)")
+    print()
+    print("Refusals + citations:")
+    print(f"  refusals       {refusals}/{n}")
+    print(f"  cited answers  {cited}/{n - refusals}  (of non-refusal answers)")
+    print()
+    print("Tokens + cache:")
+    print(f"  input  total   {total_in:,}")
+    print(f"  cached total   {total_cached:,}  ({cache_rate:.1f}% cache hit)")
+    print(f"  output total   {total_out:,}")
+    print()
+    print(f"Latency (ms): p50={p50}  p95={p95}")
+
+
+def _by_dimension(rows: list[dict], dim: str) -> None:
+    """Per-category (or per-actual-intent) PASS/PARTIAL/FAIL/SKIP table."""
+    key = "category" if dim == "category" else "actual_intent"
+    groups: dict[str, list[dict]] = defaultdict(list)
+    for r in rows:
+        groups[r.get(key) or "(none)"].append(r)
+
+    label_w = max(len(k) for k in groups) if groups else 12
+    label_w = max(label_w, len(key))
+    print(f"{key:<{label_w}}   N    PASS  PART  FAIL  SKIP   pass%")
+    print("-" * (label_w + 40))
+    for k in sorted(groups):
+        grp = groups[k]
+        b = Counter(_bucket(r.get("judge_verdict")) for r in grp)
+        n = len(grp)
+        passed = b.get("PASS", 0)
+        pct = passed / n * 100 if n else 0
+        print(f"{k:<{label_w}} {n:4d}  {passed:4d}  {b.get('PARTIAL', 0):4d}  "
+              f"{b.get('FAIL', 0):4d}  {b.get('SKIP', 0):4d}  {pct:5.1f}%")
+
+
+def _list_fails(rows: list[dict]) -> None:
+    fails = [r for r in rows if _bucket(r.get("judge_verdict")) == "FAIL"]
+    if not fails:
+        print("No FAIL verdicts.")
+        return
+    print(f"{len(fails)} FAIL cases:")
+    for r in fails:
+        qid = r.get("question_id", "?")
+        cat = r.get("category", "?")
+        v = r.get("judge_verdict", "?")
+        trig = r.get("bot_refusal_trigger") or "-"
+        ans = (r.get("bot_answer") or "").replace("\n", " ")[:100]
+        print(f"  {qid:40s} cat={cat:20s} verdict={v:35s} trig={trig:25s}")
+        print(f"    answer: {ans}")
+
+
+def _drill(rows: list[dict], qid: str) -> None:
+    matches = [r for r in rows if r.get("question_id") == qid]
+    if not matches:
+        print(f"No row with question_id={qid!r}")
+        return
+    r = matches[0]
+    print(json.dumps(r, indent=2))
+
+
+def _slowest(rows: list[dict], n: int) -> None:
+    ordered = sorted(rows, key=lambda r: r.get("latency_ms", 0) or 0, reverse=True)
+    for r in ordered[:n]:
+        qid = r.get("question_id", "?")
+        ms = r.get("latency_ms", 0)
+        cat = r.get("category", "?")
+        v = r.get("judge_verdict", "?")
+        print(f"  {ms:6d}ms  {qid:40s}  cat={cat:18s}  verdict={v}")
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Slice a run_eval JSONL.")
+    parser.add_argument("path", help="Path to results JSONL.")
+    parser.add_argument("--by", choices=["category", "intent"], default=None,
+                        help="Per-category or per-intent breakdown table.")
+    parser.add_argument("--fails", action="store_true",
+                        help="List FAIL cases with judge verdict + answer preview.")
+    parser.add_argument("--id", default=None,
+                        help="Drill into one case by question_id.")
+    parser.add_argument("--slowest", type=int, default=0,
+                        help="List the N slowest cases.")
+    args = parser.parse_args(argv)
+
+    if not Path(args.path).exists():
+        print(f"file not found: {args.path}", file=sys.stderr)
+        return 2
+
+    rows = _load(args.path)
+
+    if args.id:
+        _drill(rows, args.id)
+        return 0
+    if args.fails:
+        _list_fails(rows)
+        return 0
+    if args.slowest:
+        _slowest(rows, args.slowest)
+        return 0
+    if args.by:
+        _by_dimension(rows, args.by)
+        return 0
+
+    _summary(rows)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Two small additions to support the first real full eval (now running). Both are tools we'll keep using on every subsequent run.

### \`ai-core/scripts/analyze_eval_results.py\` (new)

Slices the streaming JSONL that \`run_eval --results-out PATH\` produces. Tolerant of partial files — works while the eval is mid-flight, so we can spot-check without disturbing the streaming write.

\`\`\`bash
.venv/bin/python -m scripts.analyze_eval_results <jsonl>             # summary
.venv/bin/python -m scripts.analyze_eval_results <jsonl> --by category
.venv/bin/python -m scripts.analyze_eval_results <jsonl> --by intent
.venv/bin/python -m scripts.analyze_eval_results <jsonl> --fails
.venv/bin/python -m scripts.analyze_eval_results <jsonl> --id <qid>
.venv/bin/python -m scripts.analyze_eval_results <jsonl> --slowest 20
\`\`\`

Pass/fail mapping matches \`run_eval\`'s own:
- **PASS**: \`correct\`, \`refused_correctly\`
- **PARTIAL**: \`partial\` (defensible but imperfect)
- **FAIL**: \`wrong\`, \`refused_incorrectly\`, \`answered_should_have_refused\`
- **SKIP**: no judge verdict (case didn't run far enough)

### \`ai-core/docs/OPERATOR.md\` (extended)

Adds a "Run the full real-LLM + judge eval" section between the offline test runner and the weekly ETL refresh. Covers the three real gotchas hit during today's first attempt:

- All three SSH tunnels (Weaviate \`ulblwebp20\` 8888 + 50051, Postgres \`ulblwebt04\` 5432) needed
- **\`.venv/bin/python\` NOT system \`python3\`** — system python doesn't have \`prisma\`; turns crash mid-run with cryptic \`ModuleNotFoundError\`
- The DailyCost rollup will flag the spend as an anomaly — tag the date

Plus the analyzer commands and initial baseline targets (PASS ≥ 75%, scope_match ≥ 95%, cache_hit ≥ 60%, p95_latency < 30s).

## Why this and not as part of the eval-results PR

The analyzer + runbook are reusable infrastructure — they apply to every future eval run, not just today's. Keeping them in their own PR means:
- They land independent of however today's results turn out
- Next time someone runs the eval, the docs reflect what we actually learned
- The "findings" PR for today's run can focus purely on the numbers + per-case analysis

## Test plan

- [x] Analyzer runs cleanly on the smoke (staff, 3 cases) output
- [x] Analyzer tolerates partial-file streaming (verified on in-progress full eval at 22/184)
- [x] Per-category breakdown table renders correctly
- [x] Offline test suite still passes (analyzer isn't a test, lives in scripts/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)