### PR TITLE
feat(ops): /smoketest/v2 endpoint — independent synthetic monitor for v2 path

### DIFF
--- a/ai-core/src/api/admin/smoketest_router.py
+++ b/ai-core/src/api/admin/smoketest_router.py
@@ -25,10 +25,19 @@ from src.observability.smoketest import (
 def build_smoketest_router(deps: dict) -> Any:
     """Build the FastAPI router.
 
-    `deps` must include `ask_bot`, a callable that runs one canned
-    question through the full orchestrator (`(question: str) -> dict`).
-    The orchestrator isn't wired yet, so in prod the app's startup
-    will supply the real function; in dev this stays a stub.
+    `deps` must include `ask_bot` (legacy orchestrator) and optionally
+    `ask_bot_v2` (the rebuilt v2 orchestrator via `run_turn`). Each
+    callable runs one canned question through the full path and
+    returns a dict; `run_smoketest` checks the shape + citation
+    presence + latency.
+
+    Endpoints registered:
+      GET /smoketest      -- always; legacy path
+      GET /smoketest/v2   -- registered only if `ask_bot_v2` is provided
+
+    The split lets the external pinger (UptimeRobot / BetterStack)
+    poll each path independently so a v2-only outage doesn't mask the
+    legacy fallback's health, and vice versa.
     """
     try:
         from fastapi import APIRouter  # type: ignore
@@ -38,15 +47,15 @@ def build_smoketest_router(deps: dict) -> Any:
 
     router = APIRouter(tags=["ops"])
     ask_bot: Callable[[str], dict] = deps["ask_bot"]
+    ask_bot_v2: Callable[[str], dict] | None = deps.get("ask_bot_v2")
     latency_budget_ms = deps.get(
         "latency_budget_ms", DEFAULT_LATENCY_BUDGET_MS
     )
     question = deps.get("question", DEFAULT_QUESTION)
 
-    @router.get("/smoketest")
-    async def smoketest() -> Any:
+    def _run(ask: Callable[[str], dict]) -> Any:
         result: SmoketestResult = run_smoketest(
-            ask_bot=ask_bot,
+            ask_bot=ask,
             question=question,
             latency_budget_ms=latency_budget_ms,
         )
@@ -61,6 +70,15 @@ def build_smoketest_router(deps: dict) -> Any:
             content=payload,
             status_code=200 if result.passed else 503,
         )
+
+    @router.get("/smoketest")
+    async def smoketest() -> Any:
+        return _run(ask_bot)
+
+    if ask_bot_v2 is not None:
+        @router.get("/smoketest/v2")
+        async def smoketest_v2() -> Any:
+            return _run(ask_bot_v2)
 
     return router
 

--- a/ai-core/src/api/admin/test_smoketest_router.py
+++ b/ai-core/src/api/admin/test_smoketest_router.py
@@ -1,0 +1,84 @@
+"""Tests for build_smoketest_router.
+
+Covers the dual-endpoint behavior added 2026-05-22:
+  - /smoketest is always present (legacy path monitoring)
+  - /smoketest/v2 is registered ONLY when `ask_bot_v2` is provided,
+    so a legacy-only deploy doesn't expose a broken v2 endpoint
+"""
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from src.api.admin.smoketest_router import build_smoketest_router
+
+
+def _passing_ask(question: str) -> dict:
+    return {
+        "answer": "King opens at 7am [1].",
+        "citations": [{"n": 1, "url": "https://www.lib.miamioh.edu/about/locations/hours/", "snippet": "King 7am"}],
+        "is_refusal": False,
+    }
+
+
+def _refusal_ask(question: str) -> dict:
+    return {"answer": "I don't have a reliable answer.", "citations": [], "is_refusal": True}
+
+
+def _mount(deps: dict) -> TestClient:
+    app = FastAPI()
+    app.include_router(build_smoketest_router(deps))
+    return TestClient(app)
+
+
+def test_legacy_only_no_v2_route():
+    client = _mount({"ask_bot": _passing_ask})
+    # Legacy passes
+    r = client.get("/smoketest")
+    assert r.status_code == 200
+    assert r.json()["passed"] is True
+    # v2 NOT registered
+    r2 = client.get("/smoketest/v2")
+    assert r2.status_code == 404
+
+
+def test_v2_route_registered_when_ask_bot_v2_provided():
+    client = _mount({"ask_bot": _passing_ask, "ask_bot_v2": _passing_ask})
+    r = client.get("/smoketest/v2")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["passed"] is True
+    assert "King opens" in body["answer_preview"]
+
+
+def test_v2_endpoint_503s_when_v2_fails_but_legacy_still_200s():
+    # If only v2 is degraded (e.g., LibCal down for v2 path), the
+    # external pinger should see 503 for /smoketest/v2 and 200 for
+    # /smoketest. That's the point of two endpoints.
+    client = _mount({"ask_bot": _passing_ask, "ask_bot_v2": _refusal_ask})
+    assert client.get("/smoketest").status_code == 200
+    r = client.get("/smoketest/v2")
+    # Refusal is a hard-fail signal for smoketest (see run_smoketest)
+    assert r.status_code == 503
+
+
+def test_each_endpoint_uses_its_own_callable():
+    """ Guards against a refactor accidentally routing both endpoints
+    through the same callable. """
+    calls = {"legacy": 0, "v2": 0}
+
+    def legacy(q):
+        calls["legacy"] += 1
+        return _passing_ask(q)
+
+    def v2(q):
+        calls["v2"] += 1
+        return _passing_ask(q)
+
+    client = _mount({"ask_bot": legacy, "ask_bot_v2": v2})
+    client.get("/smoketest")
+    client.get("/smoketest/v2")
+    assert calls == {"legacy": 1, "v2": 1}

--- a/ai-core/src/main.py
+++ b/ai-core/src/main.py
@@ -346,7 +346,44 @@ def _smoketest_ask_bot(question: str) -> dict:
     return box.get("result") or {"answer": "", "citations": [], "is_refusal": False}
 
 
-app.include_router(build_smoketest_router({"ask_bot": _smoketest_ask_bot}))
+def _smoketest_ask_v2_bot(question: str) -> dict:
+    """Sync wrapper around the rebuilt orchestrator (run_turn) for
+    /smoketest/v2. Used by the external pinger to keep the v2 path's
+    health independently observable from the legacy /smoketest result.
+
+    Mirrors the legacy _smoketest_ask_bot's run-on-dedicated-thread
+    pattern (we're called from inside a running FastAPI event loop,
+    but run_turn is sync, so we just call it directly here -- no
+    nested asyncio.run needed). Returns the same shape the
+    legacy `ask_bot` does: {answer, citations, is_refusal}.
+
+    Deps are reused from the same lazy `_get_v2_deps()` singleton the
+    socket handler uses -- one build per process, not per smoketest
+    hit. A deps-build failure short-circuits to a clearly-labeled
+    error dict so the smoketest reports `passed=False` rather than
+    raising 500.
+    """
+    try:
+        deps = _get_v2_deps()
+    except Exception as e:  # noqa: BLE001
+        return {"answer": "", "citations": [], "is_refusal": False, "error": f"deps_unavailable: {e}"}
+    from src.graph.new_orchestrator import TurnRequest, run_turn  # noqa: WPS433
+    req = TurnRequest(
+        user_message=question,
+        conversation_id="smoketest-v2",
+    )
+    resp = run_turn(req, deps)
+    return {
+        "answer": resp.answer or "",
+        "citations": resp.citations or [],
+        "is_refusal": bool(resp.is_refusal),
+    }
+
+
+app.include_router(build_smoketest_router({
+    "ask_bot": _smoketest_ask_bot,
+    "ask_bot_v2": _smoketest_ask_v2_bot,
+}))
 
 # Op 3: Prometheus scrape target. Self-describes a 200 when
 # prometheus-client isn't installed (never 500s a scrape).


### PR DESCRIPTION
## Summary

Adds a dedicated `GET /smoketest/v2` endpoint that exercises the rebuilt orchestrator (`v2_serving.run_turn`), so the external pinger can independently watch both paths after the rollout flag flips.

## Why this matters

Before this change, `/smoketest` only checked the **legacy** path (`library_graph`). After flipping `VITE_V2_ROLLOUT_PERCENT > 0`, a v2-only outage (rebuilt synthesizer crashes, Weaviate down for v2 retrieval, etc.) would be **invisible** to the external pinger because the legacy fallback keeps serving fine.

With two endpoints:
- UptimeRobot / BetterStack polls both `/smoketest` and `/smoketest/v2`
- A v2-only outage 503s `/smoketest/v2` while `/smoketest` stays 200 → page on v2 specifically
- Legacy-only outage flips the inverse
- Both endpoints' result schemas are identical (`{passed, reason, latency_ms, answer_preview, checks}`)

## Changes

- `src/api/admin/smoketest_router.py` — accept optional `ask_bot_v2` dep; register `GET /smoketest/v2` only when provided (so a legacy-only deploy doesn't expose a broken v2 endpoint).
- `src/main.py` — add `_smoketest_ask_v2_bot` wrapper that reuses the same lazy `_get_v2_deps()` singleton the socket handler already uses (one deps-build per process, not per smoketest hit).
- `src/api/admin/test_smoketest_router.py` — 4 new tests:
  - v2 route NOT registered when callable absent
  - registered when provided
  - 503 on v2 failure with legacy still 200 (the key behavior)
  - refactor guard: each endpoint hits its own callable

## Test plan

- [x] `pytest src/api/admin/test_smoketest_router.py` — 4/4 pass
- [x] `pytest src/observability/test_smoketest.py src/graph/test_v2_serving.py` — 19/19 pass (regression)
- [ ] Post-merge: hit `https://chatbot.lib.miamioh.edu/smoketest/v2` from prod after `_get_v2_deps()` initialises

## External pinger config (post-launch)

Both URLs should be polled every 5 min:
```
https://chatbot.lib.miamioh.edu/smoketest      (legacy)
https://chatbot.lib.miamioh.edu/smoketest/v2   (v2 — added by this PR)
```
Alert on 2 consecutive non-200s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)