### PR TITLE
fix(booking): availability questions answer with rooms; slots survive across turns (P3 live check)

### DIFF
--- a/ai-core/src/graph/new_orchestrator.py
+++ b/ai-core/src/graph/new_orchestrator.py
@@ -470,6 +470,30 @@ def run_turn(
                 latency_ms=latency_ms, cited_chunk_ids=[],
             )
 
+    # --- 2.145. Room-availability question short-circuit ---
+    # A dated "what rooms are available ...?" is a QUESTION -- answer it
+    # with live availability (or the reservation-page grid), never the
+    # book_room slot-collection flow (P3 live check 2026-07-14). Skipped
+    # mid-booking-flow: there, "9am to 10am, any room available?" is a
+    # slot-fill that must reach the agent.
+    if not booking_flow:
+        _avail = _room_availability_answer(request.user_message, scope, deps)
+        if _avail is not None:
+            _ans, _cites = _avail
+            latency_ms = int((time.monotonic() - turn_start) * 1000)
+            record_request(endpoint="/chat", status="room_availability",
+                           latency_s=latency_ms / 1000)
+            return TurnResponse(
+                answer=_ans, is_refusal=False, refusal_trigger=None,
+                citations=_cites, confidence="high",
+                intent=classification.intent, scope=scope.as_filter(),
+                model_used=model_basic,
+                tokens={"input": 0, "cached_input": 0, "output": 0},
+                fired_corrections=[],
+                agent_stopped_reason="room_availability_short_circuit",
+                latency_ms=latency_ms, cited_chunk_ids=[],
+            )
+
     # --- 2.15. Verified-pointer short-circuits (eval review 2026-06-29 P2) ---
     # Narrow, operator-verified deterministic answers: staff directory /
     # Rentschler staff (#42/#72/#98), King lockers (#24), no-alumni-card
@@ -706,10 +730,22 @@ def run_turn(
         scope_library=scope.library,
         conversation_history=request.conversation_history,
     )
+    # On room_booking turns, wrap the registry so book_room args the
+    # LLM dropped are back-filled from slots the user gave in EARLIER
+    # turns (P3 live check 2026-07-14: turn 1's date + times were
+    # acknowledged, then lost when turn 2 supplied name/email). See
+    # _extract_booking_slots / _SlotFillingRegistry.
+    agent_registry: ToolRegistry = deps.tool_registry
+    if classification.intent == "room_booking":
+        _slots = _extract_booking_slots(
+            _user_texts(request.conversation_history, request.user_message)
+        )
+        if _slots:
+            agent_registry = _SlotFillingRegistry(deps.tool_registry, _slots)
     agent_start = time.monotonic()
     agent_outcome: AgentOutcome = run_agent(
         agent_req,
-        deps.tool_registry,
+        agent_registry,
         llm=deps.agent_llm,
         model=model,
     )
@@ -1746,6 +1782,126 @@ def _room_reservation_answer(message: str) -> "Optional[tuple[str, list[dict]]]"
     )
 
 
+# --- Room-availability QUESTION short-circuit (P3 live check 2026-07-14) ---
+#
+# "What study rooms are available at King tomorrow from 9am to 10am?"
+# is a question, not a booking -- but it classifies as room_booking and
+# the agent prompt biases hard toward book_room, so the live bot opened
+# the slot-collection flow ("I still need: first name, last name,
+# email ...") for a user who never asked to book. Answer availability
+# questions deterministically with get_room_availability instead; the
+# user can then say "book it" and reach the booking flow on purpose.
+
+# availability word + room noun within one clause, either order.
+_ROOM_AVAIL_RE = re.compile(
+    r"\b(?:availab\w*|free|vacant|unbooked)\b[^.?!]*\b(?:study\s+)?rooms?\b"
+    r"|\b(?:study\s+)?rooms?\b[^.?!]*\b(?:availab\w*|free|vacant|unbooked)\b",
+    re.IGNORECASE,
+)
+
+_AVAIL_RESERVE_PAGES = {
+    "king": (_ROOMS_KING_RESERVE_URL,
+             "LibCal — Miami University Libraries room reservations"),
+    "wertz": (_ROOMS_KING_RESERVE_URL,
+              "LibCal — Miami University Libraries room reservations"),
+    "rentschler": (_ROOMS_HAMILTON_RESERVE_URL,
+                   "LibCal — Rentschler Library room reservations"),
+    "gardner_harvey": (_ROOMS_MIDDLETOWN_RESERVE_URL,
+                       "LibCal — Gardner-Harvey Library room reservations"),
+}
+
+
+def _avail_canonical_library(message: str, scope: "Scope") -> str:
+    """Canonical library id for an availability lookup: the building the
+    MESSAGE names, else the session scope, else the campus default."""
+    m = _SLOT_BUILDING_RE.search(message or "")
+    if m:
+        word = m.group(0).lower()
+        if "king" in word:
+            return "king"
+        if "wertz" in word or "art" in word:
+            return "wertz"
+        if "rentschler" in word:
+            return "rentschler"
+        return "gardner_harvey"
+    if scope.library in _AVAIL_RESERVE_PAGES:
+        return scope.library
+    return {
+        "hamilton": "rentschler",
+        "middletown": "gardner_harvey",
+    }.get(scope.campus, "king")
+
+
+def _room_availability_answer(
+    message: str, scope: "Scope", deps: "OrchestratorDeps"
+) -> "Optional[tuple[str, list[dict]]]":
+    """Deterministic answer for dated room-availability QUESTIONS.
+    Returns (answer, citations) or None to fall through.
+
+    Fires only when the message carries a date/time signal AND no
+    booking verb: existence questions ("are there study rooms at
+    King?") keep the agent's evidence-based answer / the 2.14 pointer,
+    and actual booking requests keep the agent's book_room flow.
+    With a full time window it checks live LibCal; without one (or when
+    LibCal is down) it points at the reservation page's live grid --
+    either way it never opens the booking slot-collection flow."""
+    m = message or ""
+    if not _ROOM_AVAIL_RE.search(m):
+        return None
+    if _ROOM_RESERVE_RE.search(m):  # booking verb -> a real transaction
+        return None
+    if re.search(r"\bcancel", m, re.IGNORECASE):
+        return None
+    if _ROOM_OTHER_SPACE_RE.search(m):
+        return None
+    slots = _extract_booking_slots([m])
+    has_window = bool(slots.get("start_time") and slots.get("end_time"))
+    if not has_window and not slots.get("date"):
+        return None  # undated existence/how-to question -- existing paths
+    canon = _avail_canonical_library(m, scope)
+    reserve_url, reserve_label = _AVAIL_RESERVE_PAGES[canon]
+    citations = [{"n": 1, "url": reserve_url, "snippet": reserve_label}]
+
+    if has_window:
+        # A dated question without a date ("any rooms free 9 to 10am?")
+        # means today.
+        try:
+            from src.agent.tool_registry import ToolCall
+            result = deps.tool_registry.dispatch(ToolCall(
+                id="room-availability", name="get_room_availability",
+                arguments={
+                    "library": canon,
+                    "date": slots.get("date") or "today",
+                    "start_time": slots["start_time"],
+                    "end_time": slots["end_time"],
+                    "capacity": slots.get("room_capacity"),
+                },
+            ))
+        except Exception:  # noqa: BLE001 -- degrade to the pointer answer
+            result = None
+        if result is not None and not result.is_error:
+            data = result.data if isinstance(result.data, dict) else {}
+            entries = data.get("slots") or []
+            first = entries[0] if entries and isinstance(entries[0], dict) else {}
+            text = str(first.get("text") or "").strip()
+            if first.get("success") and text:
+                answer = (
+                    f"{text}\n\nYou can book on the reservation page [1], "
+                    f"or ask me to book one right here in chat."
+                )
+                return answer, citations
+
+    # No usable time window, or LibCal degraded: point at the live grid
+    # instead of guessing (and instead of opening the booking flow).
+    answer = (
+        "You can see live room availability and book on the reservation "
+        "page [1]. Or tell me the date and a start and end time (for "
+        "example 'tomorrow 9am to 10am') and I'll check for you right "
+        "here."
+    )
+    return answer, citations
+
+
 # --- P2 verified-pointer short-circuits (eval review 2026-06-29) -----------
 #
 # Each fires on a narrow message pattern and answers with operator-
@@ -2770,6 +2926,143 @@ def _last_book_room_text(agent_outcome: AgentOutcome) -> Optional[str]:
                 if t:
                     text = t
     return text
+
+
+# --- Booking-slot accumulation (P3 live check 2026-07-14) ------------------
+#
+# Live defect: the LLM only reliably passes CURRENT-turn details into
+# book_room args. Turn 1 gave date + times ("tomorrow from 9am to
+# 10am") and the flow acknowledged them (asked only for name/email);
+# turn 2 gave name/email, and the turn-2 book_room call carried ONLY
+# name/email -- the backend re-asked for date/start/end. The agent sees
+# the full history, but "sees" is not "passes". So we extract booking
+# slots from the user's messages DETERMINISTICALLY and fill in whatever
+# the LLM dropped at dispatch time.
+#
+# Conservative by design: only unambiguous patterns are recognized, and
+# extracted slots only FILL args the LLM omitted -- LLM-provided args
+# always win, so an in-flow correction ("actually make it 2pm") is
+# preserved. `confirm` is NEVER filled: the write gate stays tied to an
+# explicit confirmation in the user's latest message.
+
+_SLOT_DATE_RE = re.compile(
+    r"\b(?:today|tonight|tomorrow|day\s+after\s+tomorrow"
+    r"|(?:next\s+|this\s+)?(?:monday|tuesday|wednesday|thursday|friday"
+    r"|saturday|sunday))\b"
+    r"|\b\d{4}-\d{2}-\d{2}\b"
+    r"|\b\d{1,2}/\d{1,2}(?:/\d{2,4})?\b",
+    re.IGNORECASE,
+)
+# "9am to 10am", "9 - 10am", "from 9:30 until 11 am". The END must carry
+# am/pm so a bare "9 to 10" (could be a date range, a page range...)
+# never matches; a meridiem-less START inherits the end's ("9 to 10am"
+# -> 9am). The v1 parsers downstream accept these raw strings.
+_SLOT_TIME_RANGE_RE = re.compile(
+    r"\b(\d{1,2}(?::\d{2})?)\s*(am|pm)?\s*(?:-|–|—|to|until|till|thru|through)\s*"
+    r"(\d{1,2}(?::\d{2})?)\s*(am|pm)\b",
+    re.IGNORECASE,
+)
+_SLOT_EMAIL_RE = re.compile(r"\b[\w.+-]+@[\w-]+(?:\.[\w-]+)+\b")
+_SLOT_CAPACITY_RE = re.compile(
+    r"\b(?:party|group)\s+of\s+(\d{1,2})\b"
+    r"|\b(\d{1,2})\s+(?:people|persons|person)\b",
+    re.IGNORECASE,
+)
+# Lead-in is case-insensitive; the NAME tokens must be capitalized so
+# "I'm looking for a room" can't be read as first_name="looking".
+_SLOT_NAME_RE = re.compile(
+    r"(?i:\bmy\s+name\s+is|\bmy\s+name's|\bi\s+am|\bi'm|\bthis\s+is)\s+"
+    r"([A-Z][a-zA-Z'-]*)\s+([A-Z][a-zA-Z'-]*)\b"
+)
+# Only REAL bookable-library names -- campus words ("Hamilton") and
+# non-bookable spaces are left to the LLM / backend validator.
+_SLOT_BUILDING_RE = re.compile(
+    r"\b(?:king|wertz|art\s*(?:&|and)\s*architecture|rentschler"
+    r"|gardner[- ]?harvey)\b",
+    re.IGNORECASE,
+)
+
+
+def _extract_booking_slots(texts: list[str]) -> dict:
+    """Scan user-message texts IN ORDER and return the booking slots
+    they contain; a later mention of a slot overrides an earlier one
+    (so 'actually Friday' wins over turn 1's 'tomorrow')."""
+    slots: dict = {}
+    for text in texts:
+        t = text or ""
+        m = _SLOT_BUILDING_RE.search(t)
+        if m:
+            slots["building"] = m.group(0)
+        m = _SLOT_DATE_RE.search(t)
+        if m:
+            date = m.group(0)
+            slots["date"] = "today" if date.lower() == "tonight" else date
+        m = _SLOT_TIME_RANGE_RE.search(t)
+        if m:
+            start, start_mer, end, end_mer = m.groups()
+            slots["start_time"] = f"{start}{(start_mer or end_mer).lower()}"
+            slots["end_time"] = f"{end}{end_mer.lower()}"
+        m = _SLOT_EMAIL_RE.search(t)
+        if m:
+            slots["email"] = m.group(0)
+        m = _SLOT_CAPACITY_RE.search(t)
+        if m:
+            slots["room_capacity"] = int(m.group(1) or m.group(2))
+        m = _SLOT_NAME_RE.search(t)
+        if m:
+            slots["first_name"], slots["last_name"] = m.group(1), m.group(2)
+    return slots
+
+
+def _user_texts(history: Optional[list], current_message: str) -> list[str]:
+    """The conversation's user-message texts, oldest first, current
+    message last. Assistant messages are excluded on purpose -- our own
+    booking texts quote dates/times ('Ready to book ... 9am to 10am')
+    and must never be mistaken for user-provided slots."""
+    texts: list[str] = []
+    for entry in history or []:
+        if isinstance(entry, dict) and entry.get("role") == "user":
+            content = entry.get("content")
+            if isinstance(content, str):
+                texts.append(content)
+    texts.append(current_message or "")
+    return texts
+
+
+_BOOKING_FILL_KEYS = (
+    "building", "date", "start_time", "end_time",
+    "first_name", "last_name", "email", "room_capacity",
+)
+
+
+class _SlotFillingRegistry:
+    """ToolRegistry proxy for room_booking turns: fills book_room args
+    the LLM dropped with slots extracted from the user's own messages
+    (see the section comment above). Duck-types the two methods the
+    agent loop uses; every other tool passes through untouched."""
+
+    def __init__(self, inner: ToolRegistry, slots: dict) -> None:
+        self._inner = inner
+        self._slots = {
+            k: v for k, v in slots.items()
+            if k in _BOOKING_FILL_KEYS and v
+        }
+
+    def as_responses_tools(self) -> list[dict]:
+        return self._inner.as_responses_tools()
+
+    def get(self, name: str):
+        return self._inner.get(name)
+
+    def dispatch(self, call):
+        if call.name == "book_room" and self._slots:
+            from src.agent.tool_registry import ToolCall
+            merged = dict(call.arguments or {})
+            for key, value in self._slots.items():
+                if not merged.get(key):
+                    merged[key] = value
+            call = ToolCall(id=call.id, name=call.name, arguments=merged)
+        return self._inner.dispatch(call)
 
 
 def _renumber_citations_for_display(

--- a/ai-core/src/graph/test_new_orchestrator.py
+++ b/ai-core/src/graph/test_new_orchestrator.py
@@ -37,6 +37,10 @@ Tests:
  12. log_turn called with full telemetry payload.
  13. cited_chunk_ids surfaces from citations[] for librarian review join.
  14. Session origin URL resolves to campus default.
+ 15. Booking regressions (P3 live check 2026-07-14): dated availability
+     QUESTIONS answer via get_room_availability (never book_room slot
+     collection), and book_room args are back-filled with slots the
+     user gave in earlier turns (LLM args win; confirm never filled).
 """
 
 from __future__ import annotations
@@ -856,6 +860,333 @@ def test_rule_a_bare_question_defaults_king_no_clarify() -> None:
     assert resp.scope.get("library") in (None, "")
 
 
+# --- Booking flow: availability questions + slot accumulation -------------
+# Regressions for the P3 live check 2026-07-14:
+#   1. An availability QUESTION ("What study rooms are available at King
+#      tomorrow from 9am to 10am?") entered book_room's slot-collection
+#      flow instead of listing open rooms.
+#   2. Slot accumulation was leaky: turn 1's date/times were dropped
+#      when turn 2 supplied name/email, and the flow re-asked for them.
+
+
+_BOOKING_HISTORY = [
+    {"role": "user",
+     "content": "Book a study room at King tomorrow from 9am to 10am."},
+    {"role": "assistant",
+     "content": ("To complete your room reservation, I still need: your "
+                 "first name, last name, and @miamioh.edu email.")},
+]
+
+
+def _stub_agent_llm_book_room(book_args: dict):
+    """Stub agent LLM that calls book_room once with `book_args` (the
+    args the LIVE model was observed passing -- current-turn details
+    only), then terminates."""
+    state = {"calls": 0}
+
+    def call(*, prefix_id, messages, tools, model):
+        state["calls"] += 1
+        if state["calls"] == 1:
+            return (
+                {"role": "assistant", "content": None},
+                [ToolCall(id="bk1", name="book_room",
+                          arguments=dict(book_args))],
+                {"input_tokens": 100, "cached_input_tokens": 0,
+                 "output_tokens": 10},
+            )
+        return (
+            {"role": "assistant", "content": "done"},
+            [],
+            {"input_tokens": 10, "cached_input_tokens": 0,
+             "output_tokens": 5},
+        )
+
+    return call
+
+
+def _no_llm(*, prefix_id, dynamic_suffix=None, messages=None, tools=None,
+            model=None):
+    raise AssertionError("LLM must not be called on this path")
+
+
+def _booking_registry(
+    book_calls: list,
+    avail_calls: Optional[list] = None,
+    avail_raises: bool = False,
+) -> ToolRegistry:
+    """Registry with book_room + get_room_availability stubs that mimic
+    real_backends' return shapes and capture their args."""
+    from src.agent.tool_registry import ToolError
+
+    registry = ToolRegistry()
+
+    def book_handler(args: dict) -> dict:
+        book_calls.append(dict(args))
+        required = ("date", "start_time", "end_time",
+                    "first_name", "last_name", "email")
+        missing = [k for k in required if not args.get(k)]
+        if missing:
+            return {"success": False, "stage": "missing_slots",
+                    "text": ("To complete your room reservation, I still "
+                             "need: " + ", ".join(missing))}
+        if not args.get("confirm"):
+            return {"success": False, "stage": "needs_confirmation",
+                    "text": (f"Ready to book: a study room at King Library "
+                             f"on {args['date']}, {args['start_time']} to "
+                             f"{args['end_time']}, for {args['first_name']} "
+                             f"{args['last_name']} ({args['email']}). Reply "
+                             f"'confirm' to book it. Nothing is booked yet.")}
+        return {"success": True, "stage": "booked",
+                "text": "Booked! Confirmation: abc123"}
+
+    def avail_handler(args: dict) -> dict:
+        if avail_calls is not None:
+            avail_calls.append(dict(args))
+        if avail_raises:
+            raise ToolError("LibCal down")
+        return {"slots": [{"success": True,
+                           "text": ("Available rooms at King Library:\n\n"
+                                    "• Room 205 (capacity: 4)")}],
+                "count": 1}
+
+    registry.register(Tool(
+        name="book_room", description="stub booking",
+        parameters={"type": "object"}, handler=book_handler,
+        is_read_only=False,
+    ))
+    registry.register(Tool(
+        name="get_room_availability", description="stub availability",
+        parameters={"type": "object"}, handler=avail_handler,
+    ))
+    registry.register(_stub_search_kb_tool([]))
+    return registry
+
+
+def _booking_deps(registry: ToolRegistry, agent_llm,
+                  intent: str = "room_booking") -> OrchestratorDeps:
+    return OrchestratorDeps(
+        classifier=StubClassifier(_classification(intent)),
+        tool_registry=registry,
+        agent_llm=agent_llm,
+        synthesizer_llm=_stub_synth_llm(),
+        load_corrections=lambda: [],
+        load_url_allowlist=lambda: set(),
+        lookup_service_availability=lambda intent, campus: None,
+    )
+
+
+def test_availability_question_answers_with_availability_tool() -> None:
+    """P3 defect #1: a dated availability QUESTION must list open rooms
+    via get_room_availability -- never enter book_room slot collection."""
+    book_calls: list = []
+    avail_calls: list = []
+    deps = _booking_deps(
+        _booking_registry(book_calls, avail_calls),
+        agent_llm=_no_llm,  # deterministic path -- no LLM at all
+    )
+    resp = run_turn(
+        TurnRequest(
+            user_message=("What study rooms are available at King tomorrow "
+                          "from 9am to 10am?"),
+            conversation_id="c1",
+        ),
+        deps,
+    )
+    assert resp.agent_stopped_reason == "room_availability_short_circuit"
+    assert not resp.is_refusal
+    assert "Room 205" in resp.answer
+    assert "I still need" not in resp.answer      # no slot collection
+    assert book_calls == []                       # book_room never ran
+    assert resp.tokens == {"input": 0, "cached_input": 0, "output": 0}
+    # The live lookup got the question's window, verbatim slots.
+    assert len(avail_calls) == 1
+    call = avail_calls[0]
+    assert call["library"] == "king"
+    assert call["date"] == "tomorrow"
+    assert call["start_time"] == "9am"
+    assert call["end_time"] == "10am"
+    # Citation: the reservation page (allspaces for King).
+    assert resp.citations[0]["url"] == "https://muohio.libcal.com/allspaces"
+
+
+def test_availability_question_without_window_points_to_page() -> None:
+    """Dated availability question WITHOUT a start/end window: the live
+    grid can't be queried, so point at the reservation page -- still no
+    booking flow."""
+    book_calls: list = []
+    deps = _booking_deps(_booking_registry(book_calls), agent_llm=_no_llm)
+    resp = run_turn(
+        TurnRequest(
+            user_message="Are there any study rooms available tomorrow?",
+            conversation_id="c1",
+        ),
+        deps,
+    )
+    assert resp.agent_stopped_reason == "room_availability_short_circuit"
+    assert "reservation page" in resp.answer
+    assert book_calls == []
+    assert resp.citations[0]["url"] == "https://muohio.libcal.com/allspaces"
+
+
+def test_availability_libcal_down_degrades_to_pointer() -> None:
+    """LibCal error on the availability lookup degrades to the
+    reservation-page pointer, not a crash and not the booking flow."""
+    book_calls: list = []
+    deps = _booking_deps(
+        _booking_registry(book_calls, avail_raises=True), agent_llm=_no_llm,
+    )
+    resp = run_turn(
+        TurnRequest(
+            user_message=("What rooms are available at King tomorrow from "
+                          "9am to 10am?"),
+            conversation_id="c1",
+        ),
+        deps,
+    )
+    assert resp.agent_stopped_reason == "room_availability_short_circuit"
+    assert "reservation page" in resp.answer
+    assert book_calls == []
+
+
+def test_availability_detector_boundaries() -> None:
+    """Booking requests and undated existence questions must NOT be
+    hijacked by the availability short-circuit."""
+    from src.graph.new_orchestrator import _room_availability_answer
+    from src.scope.resolver import resolve_scope
+
+    deps = _booking_deps(_booking_registry([]), agent_llm=_no_llm)
+
+    def helper(msg):
+        return _room_availability_answer(msg, resolve_scope(msg), deps)
+
+    # Booking verb -> the agent's book_room flow keeps it.
+    assert helper("Book me a study room tomorrow from 9am to 10am") is None
+    assert helper("Can I reserve a room that's available tomorrow?") is None
+    # Undated existence question -> agent / 2.14 pointer keep it.
+    assert helper("Are there study rooms available at King?") is None
+    # Cancel and other-space questions fall through too.
+    assert helper("Is my cancelled room still available tomorrow?") is None
+    assert helper(
+        "Any rooms available at Special Collections tomorrow 1pm to 2pm?"
+    ) is None
+    # Regional campus resolves the regional reservation page.
+    res = helper("What rooms are free at Rentschler tomorrow 1pm to 2pm?")
+    assert res is not None
+    _ans, _cites = res
+    assert _cites[0]["url"] == "https://muohio.libcal.com/reserve/hamilton"
+
+
+def test_booking_slots_accumulate_across_turns() -> None:
+    """P3 defect #2: turn 1 gave date + times, turn 2 gives name/email.
+    The live model passed only current-turn details to book_room; the
+    slot-filling registry must back-fill turn 1's date/start/end so the
+    flow advances to the confirmation summary instead of re-asking."""
+    book_calls: list = []
+    registry = _booking_registry(book_calls)
+    # The LIVE failure: model drops earlier-turn slots from the args.
+    agent_llm = _stub_agent_llm_book_room({
+        "building": "King", "first_name": "Meng", "last_name": "Qu",
+        "email": "qum@miamioh.edu", "room_capacity": 3,
+    })
+    # Classifier returns out_of_scope (the mid-flow message has no
+    # library vocabulary) -- the booking-flow override must force
+    # room_booking AND the merge must still apply.
+    deps = _booking_deps(registry, agent_llm, intent="out_of_scope")
+    resp = run_turn(
+        TurnRequest(
+            user_message="My name is Meng Qu, email qum@miamioh.edu, party of 3.",
+            conversation_id="c1",
+            conversation_history=list(_BOOKING_HISTORY),
+        ),
+        deps,
+    )
+    assert len(book_calls) == 1
+    merged = book_calls[0]
+    # Earlier-turn slots survived:
+    assert merged["date"] == "tomorrow"
+    assert merged["start_time"] == "9am"
+    assert merged["end_time"] == "10am"
+    # Current-turn slots kept:
+    assert merged["first_name"] == "Meng"
+    assert merged["email"] == "qum@miamioh.edu"
+    # confirm is NEVER auto-filled -- nothing books without the user.
+    assert not merged.get("confirm")
+    # And the reply is the confirmation summary, not a re-ask.
+    assert "Ready to book" in resp.answer
+    assert "I still need" not in resp.answer
+    assert resp.intent == "room_booking"   # override held
+
+
+def test_booking_slot_merge_never_overrides_llm_args() -> None:
+    """An in-flow correction ('actually 2pm to 3pm') that the LLM passes
+    must win over the extracted history slots."""
+    book_calls: list = []
+    registry = _booking_registry(book_calls)
+    agent_llm = _stub_agent_llm_book_room({
+        "building": "King", "first_name": "Meng", "last_name": "Qu",
+        "email": "qum@miamioh.edu",
+        "start_time": "2pm", "end_time": "3pm",   # the LLM's own args
+    })
+    deps = _booking_deps(registry, agent_llm, intent="out_of_scope")
+    run_turn(
+        TurnRequest(
+            user_message=("Actually make it 2pm to 3pm. My name is Meng Qu, "
+                          "email qum@miamioh.edu."),
+            conversation_id="c1",
+            conversation_history=list(_BOOKING_HISTORY),
+        ),
+        deps,
+    )
+    merged = book_calls[0]
+    assert merged["start_time"] == "2pm"    # LLM/current turn wins
+    assert merged["end_time"] == "3pm"
+    assert merged["date"] == "tomorrow"     # still back-filled
+
+
+def test_availability_short_circuit_skipped_mid_booking_flow() -> None:
+    """Mid-booking-flow, '9am to 10am, any room available?' is a
+    slot-fill -- it must reach the agent, not the availability
+    short-circuit."""
+    book_calls: list = []
+    registry = _booking_registry(book_calls)
+    agent_llm = _stub_agent_llm_book_room({"building": "King"})
+    deps = _booking_deps(registry, agent_llm, intent="out_of_scope")
+    resp = run_turn(
+        TurnRequest(
+            user_message="9am to 10am tomorrow -- any room available?",
+            conversation_id="c1",
+            conversation_history=list(_BOOKING_HISTORY),
+        ),
+        deps,
+    )
+    assert resp.agent_stopped_reason != "room_availability_short_circuit"
+    assert len(book_calls) == 1              # the agent's flow ran
+
+
+def test_extract_booking_slots_patterns() -> None:
+    from src.graph.new_orchestrator import _extract_booking_slots
+
+    slots = _extract_booking_slots([
+        "Book a study room at King tomorrow from 9am to 10am",
+        "My name is Meng Qu, email qum@miamioh.edu, party of 3",
+    ])
+    assert slots == {
+        "building": "King", "date": "tomorrow",
+        "start_time": "9am", "end_time": "10am",
+        "email": "qum@miamioh.edu", "room_capacity": 3,
+        "first_name": "Meng", "last_name": "Qu",
+    }
+    # Later mentions override earlier ones.
+    assert _extract_booking_slots(
+        ["tomorrow 9am to 10am", "actually Friday 2pm to 3pm"]
+    ) == {"date": "Friday", "start_time": "2pm", "end_time": "3pm"}
+    # Meridiem-less start inherits the end's; bare "9 to 10" never matches.
+    assert _extract_booking_slots(["9 to 10am works"])["start_time"] == "9am"
+    assert "start_time" not in _extract_booking_slots(["rooms for 9 to 10"])
+    # "I'm looking for a room" is NOT a name.
+    assert _extract_booking_slots(["I'm looking for a room"]) == {}
+
+
 def main() -> int:
     tests = [
         test_rule_a_bare_question_defaults_king_no_clarify,
@@ -885,6 +1216,14 @@ def main() -> int:
         test_log_turn_called_with_full_payload,
         test_cited_chunk_ids_surfaces_for_librarian_review,
         test_session_origin_url_resolves_campus_default,
+        test_availability_question_answers_with_availability_tool,
+        test_availability_question_without_window_points_to_page,
+        test_availability_libcal_down_degrades_to_pointer,
+        test_availability_detector_boundaries,
+        test_booking_slots_accumulate_across_turns,
+        test_booking_slot_merge_never_overrides_llm_args,
+        test_availability_short_circuit_skipped_mid_booking_flow,
+        test_extract_booking_slots_patterns,
     ]
     failed = 0
     for t in tests:

--- a/ai-core/src/tools_v2/registry.py
+++ b/ai-core/src/tools_v2/registry.py
@@ -90,7 +90,7 @@ class ToolBackends:
     get_hours: Callable[[str], dict] = None  # type: ignore
     """get_hours(library_id) -> {today: {open, close}, week: [...], source_url}."""
     get_room_availability: Callable[[dict], list[dict]] = None  # type: ignore
-    """get_room_availability({library, date, capacity?, equipment?}) -> list of slots."""
+    """get_room_availability({library, date, start_time?, end_time?, capacity?, equipment?}) -> list of slots."""
 
     # actions (write)
     book_room: Callable[[dict], dict] = None  # type: ignore
@@ -249,6 +249,15 @@ def _make_get_room_availability(backends: ToolBackends) -> Callable[[dict], Any]
             {
                 "library": args["library"],
                 "date": args["date"],
+                # Time window forwarded since the P3 live check
+                # 2026-07-14: the backend (LibCalEnhancedAvailabilityTool)
+                # REQUIRES start/end to answer "what rooms are free from
+                # 9am to 10am?" -- dropping them here made every
+                # availability call fail with "Missing required
+                # parameters", which pushed the agent into book_room's
+                # slot-collection flow for plain availability QUESTIONS.
+                "start_time": args.get("start_time"),
+                "end_time": args.get("end_time"),
                 "capacity": args.get("capacity"),
                 "equipment": args.get("equipment"),
             }
@@ -458,7 +467,24 @@ _GET_ROOM_AVAILABILITY_SCHEMA = {
         },
         "date": {
             "type": "string",
-            "description": "ISO date YYYY-MM-DD (in the library's local timezone).",
+            "description": (
+                "Date to check, as the user said it ('tomorrow', "
+                "'next Monday') or ISO YYYY-MM-DD."
+            ),
+        },
+        "start_time": {
+            "type": "string",
+            "description": (
+                "Start of the window to check, as the user said it "
+                "('9am', '14:00'). Required by the live lookup."
+            ),
+        },
+        "end_time": {
+            "type": "string",
+            "description": (
+                "End of the window to check ('10am'). Required by the "
+                "live lookup."
+            ),
         },
         "capacity": {
             "type": "integer",
@@ -638,17 +664,23 @@ _DESCRIPTIONS = {
         "-- do NOT use search_kb for hours."
     ),
     "get_room_availability": (
-        "Fetch live room booking availability for a library on a date. "
-        "Optional capacity / equipment filters."
+        "List which rooms are free -- THE tool for availability "
+        "QUESTIONS ('what rooms are available tomorrow from 9am to "
+        "10am?'). Needs date + start_time + end_time (natural formats "
+        "OK); optional capacity/equipment. Do NOT call book_room for a "
+        "question -- only when the user asks to book."
     ),
     "book_room": (
         "Book a study room via LibCal -- THE tool for 'book/reserve a "
         "room for me'. Call it with whatever the user has provided so "
-        "far (building is required -- pass the user's exact words); it "
-        "responds with what's still missing, then a confirmation "
-        "summary. Relay its text to the user verbatim. Set confirm=true "
-        "ONLY after the user explicitly says to book. Never invent "
-        "names, emails, dates, or times the user didn't give."
+        "far -- across ALL turns of the conversation, not just the "
+        "latest message (building is required -- pass the user's exact "
+        "words); it responds with what's still missing, then a "
+        "confirmation summary. Relay its text to the user verbatim. Set "
+        "confirm=true ONLY after the user explicitly says to book. "
+        "Never invent names, emails, dates, or times the user didn't "
+        "give. If the user is only ASKING what's available, use "
+        "get_room_availability instead."
     ),
     "create_ticket": (
         "Open a LibAnswers ticket for the user's question. ACTION TOOL: "


### PR DESCRIPTION
## Summary

Fixes the two v2 room-booking defects found in the 2026-07-14 live P3 check:

**1. Availability questions entered the booking flow.** "What study rooms are available at King tomorrow from 9am to 10am?" got "To complete your room reservation, I still need: first name, last name, email..." — the user never asked to book.
- Root cause A: the question classifies as `room_booking`, where the agent prompt biases hard toward `book_room`.
- Root cause B: the `get_room_availability` handler in `tools_v2/registry.py` silently dropped `start_time`/`end_time`; the LibCal backend requires them, so every availability call failed with "Missing required parameters", pushing the agent into `book_room`.
- Fix: forward the time window through the handler + schema; add a deterministic short-circuit (2.145, `_room_availability_answer`) in `new_orchestrator.py` that answers dated availability questions via `get_room_availability` directly — verbatim live room list + reservation-page citation, zero LLM. Degrades to the reservation-page pointer when LibCal is down or no time window was given. Booking requests, undated existence questions, cancels, other-space questions, and mid-booking-flow slot-fills all keep their existing paths.

**2. Slot accumulation was leaky across turns.** Turn 1 gave date + times (acknowledged — flow asked only for name/email); after turn 2 supplied name/email, the flow re-asked for date/start/end. The LLM only reliably passes current-turn details into `book_room` args.
- Fix: `_extract_booking_slots` conservatively parses date / time range / email / party size / building / name from the user's own messages (assistant messages excluded so our "Ready to book ... 9am" texts can't be misread), and `_SlotFillingRegistry` back-fills only the args the LLM omitted at dispatch time. LLM args always win (in-flow corrections preserved); `confirm` is never auto-filled — the write gate stays with the user's explicit confirmation.

The cached `agent_v1` prompt prefix is untouched (byte-stability rule).

## Test plan

- [x] 8 new regression tests in `test_new_orchestrator.py` mirroring the live transcript (including the exact two-turn repro, which now reaches "Ready to book" instead of re-asking)
- [x] Verified the key tests FAIL against pre-fix behavior (defects genuinely pinned)
- [x] All suites green: 35/35 orchestrator, 54 short-circuits, 14 agent, 21 tool-registry
- [ ] Live P3 re-check after deploy (LibCal/prisma not available in this dev environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)